### PR TITLE
feat(api): add renderFirstPage method for PDF cover generation

### DIFF
--- a/flureadium_platform_interface/CHANGELOG.md
+++ b/flureadium_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Add `renderFirstPage` method to `FlureadiumPlatform` and `MethodChannelFlureadium` — renders the first page of a PDF as a JPEG image for cover generation.
+
 ## 0.2.0
 
 - Add `enableEdgeTapNavigation` and `enableSwipeNavigation` to `PDFPreferences` — allows independently controlling edge tap and swipe page navigation on iOS.

--- a/flureadium_platform_interface/lib/flureadium_platform_interface.dart
+++ b/flureadium_platform_interface/lib/flureadium_platform_interface.dart
@@ -4,6 +4,7 @@
 // See LICENSE for details.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -174,6 +175,16 @@ abstract class FlureadiumPlatform extends PlatformInterface {
   Future<void> audioSeekBy(Duration offset) =>
       throw UnimplementedError('seekInAudio() has not been implemented');
   // AUDIOBOOK API - END
+
+  /// Renders the first page of a PDF publication as a JPEG image.
+  /// Returns the image bytes, or null if rendering fails.
+  /// [pubUrl] is the file path or URL to the PDF.
+  /// [maxWidth] and [maxHeight] constrain the output dimensions.
+  Future<Uint8List?> renderFirstPage(
+    String pubUrl, {
+    int maxWidth = 600,
+    int maxHeight = 800,
+  }) => throw UnimplementedError('renderFirstPage() has not been implemented.');
 
   // State stream for reader status changes
   Stream<ReadiumReaderStatus> get onReaderStatusChanged {

--- a/flureadium_platform_interface/lib/method_channel_flureadium.dart
+++ b/flureadium_platform_interface/lib/method_channel_flureadium.dart
@@ -239,4 +239,17 @@ class MethodChannelFlureadium extends FlureadiumPlatform {
   @override
   Future<void> audioSeekBy(Duration offset) =>
       methodChannel.invokeMethod('audioSeekBy', offset.inSeconds);
+
+  @override
+  Future<Uint8List?> renderFirstPage(
+    String pubUrl, {
+    int maxWidth = 600,
+    int maxHeight = 800,
+  }) async {
+    final result = await methodChannel.invokeMethod<Uint8List>(
+      'renderFirstPage',
+      [pubUrl, maxWidth, maxHeight],
+    );
+    return result;
+  }
 }

--- a/flureadium_platform_interface/pubspec.yaml
+++ b/flureadium_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium_platform_interface
 description: "Platform interface for Flureadium, providing shared models, exceptions, and the abstract FlureadiumPlatform class for EPUB, PDF, and audiobook reading."
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
Add renderFirstPage method to FlureadiumPlatform and MethodChannelFlureadium that renders the first page of a PDF as a JPEG image. This enables apps to generate cover images from PDFs without embedded covers.

- Platform interface method with maxWidth/maxHeight parameters
- Method channel implementation passing args as list
- Version bump to 0.3.0
- CHANGELOG entry