### PR TITLE
feat(pdf): add renderFirstPage API for PDF cover generation 

### DIFF
--- a/flureadium/.pubignore
+++ b/flureadium/.pubignore
@@ -19,6 +19,7 @@ doc/
 # Project-level files
 project/
 CONTRIBUTING.md
+pubspec_overrides.yaml
 
 # npm files
 package.json

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- Add `renderFirstPage` API — renders the first page of a PDF as a JPEG image for use as a cover. Uses `PdfRenderer` on Android and `CGPDFDocument` on iOS. No Readium dependency needed.
+- Requires `flureadium_platform_interface` ^0.3.0.
+
 ## 0.2.0
 
 - Add swipe gesture navigation for EPUB and PDF readers on iOS — swipe left/right to turn pages in edge zones.

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
@@ -234,6 +234,14 @@ internal class PublicationMethodCallHandler() :
                 return Try.success(null)
             }
 
+            "renderFirstPage" -> {
+                val args = arguments as List<Any?>
+                val pubUrlStr = args[0] as String
+                val maxWidth = args[1] as Int
+                val maxHeight = args[2] as Int
+                return renderFirstPage(pubUrlStr, maxWidth, maxHeight)
+            }
+
             else -> {
                 throw NotImplementedError()
             }
@@ -378,6 +386,65 @@ internal class PublicationMethodCallHandler() :
 
         ReadiumReader.audioEnable(locator, preferences)
         return Try.success(null)
+    }
+
+    /**
+     * Render the first page of a PDF file as a JPEG image.
+     * Uses Android's PdfRenderer (available since API 21).
+     */
+    private fun renderFirstPage(
+        pubUrlStr: String,
+        maxWidth: Int,
+        maxHeight: Int
+    ): Try<ByteArray?, PublicationError> {
+        val filePath = pubUrlStr.removePrefix("file://")
+        val file = java.io.File(filePath)
+        if (!file.exists()) {
+            return Try.failure(PublicationError.NotFound("File not found: $filePath"))
+        }
+
+        return try {
+            val fd = android.os.ParcelFileDescriptor.open(
+                file,
+                android.os.ParcelFileDescriptor.MODE_READ_ONLY
+            )
+            val renderer = android.graphics.pdf.PdfRenderer(fd)
+            val page = renderer.openPage(0)
+
+            val scale = minOf(
+                maxWidth.toFloat() / page.width,
+                maxHeight.toFloat() / page.height,
+                1f
+            )
+            val width = (page.width * scale).toInt()
+            val height = (page.height * scale).toInt()
+
+            val bitmap = android.graphics.Bitmap.createBitmap(
+                width,
+                height,
+                android.graphics.Bitmap.Config.ARGB_8888
+            )
+            bitmap.eraseColor(android.graphics.Color.WHITE)
+            page.render(
+                bitmap,
+                null,
+                null,
+                android.graphics.pdf.PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY
+            )
+
+            page.close()
+            renderer.close()
+            fd.close()
+
+            val stream = java.io.ByteArrayOutputStream()
+            bitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 85, stream)
+            bitmap.recycle()
+
+            Try.success(stream.toByteArray())
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to render first page: $e")
+            Try.success(null)
+        }
     }
 }
 

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
@@ -391,6 +391,7 @@ internal class PublicationMethodCallHandler() :
     /**
      * Render the first page of a PDF file as a JPEG image.
      * Uses Android's PdfRenderer (available since API 21).
+     * Returns null if the file doesn't exist or rendering fails.
      */
     private fun renderFirstPage(
         pubUrlStr: String,
@@ -400,7 +401,8 @@ internal class PublicationMethodCallHandler() :
         val filePath = pubUrlStr.removePrefix("file://")
         val file = java.io.File(filePath)
         if (!file.exists()) {
-            return Try.failure(PublicationError.NotFound("File not found: $filePath"))
+            Log.w(TAG, "File not found for renderFirstPage: $filePath")
+            return Try.success(null)
         }
 
         return try {

--- a/flureadium/docs/api-reference/flureadium-class.md
+++ b/flureadium/docs/api-reference/flureadium-class.md
@@ -372,6 +372,40 @@ await flureadium.setDecorationStyle(
 );
 ```
 
+## PDF Utilities
+
+### renderFirstPage
+
+Renders the first page of a PDF as a JPEG image for use as a cover.
+
+```dart
+Future<Uint8List?> renderFirstPage(
+  String pubUrl, {
+  int maxWidth = 600,
+  int maxHeight = 800,
+})
+```
+
+**Parameters:**
+- `pubUrl` - Local file path to the PDF
+- `maxWidth` - Maximum output width in pixels (default: 600)
+- `maxHeight` - Maximum output height in pixels (default: 800)
+
+**Returns:** JPEG image bytes, or `null` if rendering fails
+
+Does not require opening a publication first. Uses `PdfRenderer` on Android and `CGPDFDocument` on iOS — no Readium dependency needed.
+
+**Example:**
+```dart
+final coverBytes = await flureadium.renderFirstPage('file:///path/to/book.pdf');
+if (coverBytes != null) {
+  final file = File('/path/to/cover.jpg');
+  await file.writeAsBytes(coverBytes);
+}
+```
+
+---
+
 ## Audiobook
 
 ### audioEnable

--- a/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
@@ -409,6 +409,27 @@ public class FlureadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.WarningLog
         result(nil)
       }
 
+    case "renderFirstPage":
+      let args = call.arguments as! [Any?]
+      let pubUrlStr = args[0] as! String
+      let maxWidth = args[1] as! Int
+      let maxHeight = args[2] as! Int
+
+      Task.detached(priority: .background) {
+        let imageData = Self.renderFirstPage(
+          pubUrlStr: pubUrlStr,
+          maxWidth: maxWidth,
+          maxHeight: maxHeight
+        )
+        await MainActor.run {
+          if let data = imageData {
+            result(FlutterStandardTypedData(bytes: data))
+          } else {
+            result(nil)
+          }
+        }
+      }
+
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -525,5 +546,50 @@ extension FlureadiumPlugin {
       currentPublication = nil
       currentPublicationUrlStr = nil
     }
+  }
+
+  /// Renders the first page of a PDF file as a JPEG image using Core Graphics.
+  static func renderFirstPage(pubUrlStr: String, maxWidth: Int, maxHeight: Int) -> Data? {
+    var urlStr = pubUrlStr
+    if !urlStr.hasPrefix("file://") && !urlStr.hasPrefix("http") {
+      urlStr = "file://\(urlStr)"
+    }
+
+    guard let url = URL(string: urlStr),
+          let document = CGPDFDocument(url as CFURL),
+          let page = document.page(at: 1) else {
+      return nil
+    }
+
+    let pageRect = page.getBoxRect(.mediaBox)
+    let scale = min(
+      CGFloat(maxWidth) / pageRect.width,
+      CGFloat(maxHeight) / pageRect.height,
+      1.0
+    )
+    let width = Int(pageRect.width * scale)
+    let height = Int(pageRect.height * scale)
+
+    UIGraphicsBeginImageContextWithOptions(
+      CGSize(width: width, height: height),
+      true,
+      1.0
+    )
+    guard let context = UIGraphicsGetCurrentContext() else {
+      UIGraphicsEndImageContext()
+      return nil
+    }
+
+    context.setFillColor(UIColor.white.cgColor)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+    context.translateBy(x: 0, y: CGFloat(height))
+    context.scaleBy(x: scale, y: -scale)
+    context.drawPDFPage(page)
+
+    let image = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+
+    return image?.jpegData(compressionQuality: 0.85)
   }
 }

--- a/flureadium/lib/flureadium.dart
+++ b/flureadium/lib/flureadium.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:flureadium_platform_interface/flureadium_platform_interface.dart';
@@ -271,6 +272,32 @@ class Flureadium {
   ///
   /// Positive offset seeks forward, negative seeks backward.
   Future<void> audioSeekBy(Duration offset) => _platform.audioSeekBy(offset);
+
+  /// Renders the first page of a PDF as a JPEG image for use as a cover.
+  ///
+  /// Returns image bytes (JPEG), or null if the publication is not a PDF
+  /// or rendering fails. Does not require opening a publication first.
+  ///
+  /// [maxWidth] and [maxHeight] constrain the output image dimensions
+  /// while preserving aspect ratio.
+  ///
+  /// ```dart
+  /// final coverBytes = await flureadium.renderFirstPage('file:///path/to/book.pdf');
+  /// if (coverBytes != null) {
+  ///   // Save or display the cover image
+  /// }
+  /// ```
+  Future<Uint8List?> renderFirstPage(
+    String pubUrl, {
+    int maxWidth = 600,
+    int maxHeight = 800,
+  }) {
+    return _platform.renderFirstPage(
+      pubUrl,
+      maxWidth: maxWidth,
+      maxHeight: maxHeight,
+    );
+  }
 
   /// Navigates to a link within the publication.
   ///

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flureadium_platform_interface: ^0.2.0
+  flureadium_platform_interface: ^0.3.0
   rxdart: ^0.28.0
   wakelock_plus: ^1.2.8
   web: ^1.1.1

--- a/flureadium/pubspec_overrides.yaml
+++ b/flureadium/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  flureadium_platform_interface:
+    path: ../flureadium_platform_interface

--- a/flureadium/test/flureadium_test.dart
+++ b/flureadium/test/flureadium_test.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'dart:ui' show Color;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -359,6 +360,62 @@ void main() {
           mockPlatform.lastCallArgs('audioSeekBy')?['offset'],
           equals(const Duration(seconds: -15)),
         );
+      });
+    });
+
+    group('Render First Page', () {
+      test(
+        'renderFirstPage calls platform method with correct arguments',
+        () async {
+          mockPlatform.mockRenderFirstPageResult = Uint8List.fromList([
+            1,
+            2,
+            3,
+          ]);
+
+          final result = await flureadium.renderFirstPage(
+            'file:///test.pdf',
+            maxWidth: 300,
+            maxHeight: 400,
+          );
+
+          expect(mockPlatform.wasCalled('renderFirstPage'), isTrue);
+          expect(
+            mockPlatform.lastCallArgs('renderFirstPage')?['pubUrl'],
+            equals('file:///test.pdf'),
+          );
+          expect(
+            mockPlatform.lastCallArgs('renderFirstPage')?['maxWidth'],
+            equals(300),
+          );
+          expect(
+            mockPlatform.lastCallArgs('renderFirstPage')?['maxHeight'],
+            equals(400),
+          );
+          expect(result, isNotNull);
+          expect(result!.length, equals(3));
+        },
+      );
+
+      test('renderFirstPage uses default dimensions', () async {
+        await flureadium.renderFirstPage('file:///test.pdf');
+
+        expect(
+          mockPlatform.lastCallArgs('renderFirstPage')?['maxWidth'],
+          equals(600),
+        );
+        expect(
+          mockPlatform.lastCallArgs('renderFirstPage')?['maxHeight'],
+          equals(800),
+        );
+      });
+
+      test('renderFirstPage returns null when platform returns null', () async {
+        mockPlatform.mockRenderFirstPageResult = null;
+
+        final result = await flureadium.renderFirstPage('file:///test.pdf');
+
+        expect(result, isNull);
       });
     });
 

--- a/flureadium/test/mocks/mock_platform.dart
+++ b/flureadium/test/mocks/mock_platform.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flureadium/flureadium.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -22,6 +23,7 @@ class MockFlureadiumPlatform
   String? mockLinkContent;
   List<ReaderTTSVoice> mockVoices = [];
   bool mockGoToLocatorResult = true;
+  Uint8List? mockRenderFirstPageResult;
 
   // Stream controllers for testing
   final StreamController<ReadiumReaderStatus> _readerStatusController =
@@ -262,6 +264,22 @@ class MockFlureadiumPlatform
   @override
   Future<void> audioSeekBy(Duration offset) async {
     calls.add(MockMethodCall('audioSeekBy', {'offset': offset}));
+  }
+
+  @override
+  Future<Uint8List?> renderFirstPage(
+    String pubUrl, {
+    int maxWidth = 600,
+    int maxHeight = 800,
+  }) async {
+    calls.add(
+      MockMethodCall('renderFirstPage', {
+        'pubUrl': pubUrl,
+        'maxWidth': maxWidth,
+        'maxHeight': maxHeight,
+      }),
+    );
+    return mockRenderFirstPageResult;
   }
 
   // State Streams


### PR DESCRIPTION
Implement renderFirstPage method that renders the first page of a PDF as a
JPEG image for use as a cover. This enables apps to generate cover images
from PDFs without embedded covers.

Implementation:
- Android: PdfRenderer (API 21+, no Readium dependency)
- iOS: CGPDFDocument (Core Graphics, no Readium dependency)
- Public Flureadium API with maxWidth/maxHeight parameters (defaults: 600x800)
- Returns Uint8List (JPEG bytes) or null on failure

Testing:
- 3 new unit tests (args validation, defaults, null handling)
- All 168 tests pass

Other changes:
- Version bump to 0.3.0
- Update platform_interface dependency to ^0.3.0
- CHANGELOG entry
- API documentation
- Add pubspec_overrides.yaml to .pubignore