### PR TITLE
fix(ios): crash on app close due to stream disposal in deinit

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.3.2
+
+### Bug Fixes
+
+- **iOS**: Fix crash on app close caused by stream handlers sending `FlutterEndOfEventStream` during `deinit`, after the Flutter engine has already torn down its channels.
+  - Move all `EventStreamHandler.dispose()` calls from `deinit` to the Dart `"dispose"` method call handler, which runs while the engine is still alive.
+  - `deinit` now only nils out references as a safety net without sending any messages.
+
+### Testing
+
+- Add `EventStreamHandlerTests` covering dispose lifecycle, double-dispose safety, send-after-dispose no-op, and listener registration/cancellation.
+
 ## 0.3.1
 
 ### Bug Fixes

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -170,6 +170,19 @@ edgeTapView.edgeThresholdPercent = 0.25 // 25% of screen width
 - `ReadiumReaderView.swift` - EPUB reader using EdgeTapInterceptView
 - `PdfReaderView.swift` - PDF reader using EdgeTapInterceptView
 
+### Stream and View Lifecycle
+
+Flureadium iOS uses `EventStreamHandler` to manage Flutter EventChannel streams (text locator, reader status, errors). Proper lifecycle management is critical:
+
+- **Stream disposal** (sending `FlutterEndOfEventStream` and clearing handlers) must happen in the `"dispose"` method call from Dart, while the Flutter engine is still alive
+- **`deinit`** only nils out references as a safety net — it must NOT send messages on Flutter channels, as `deinit` may be triggered during engine teardown when channels are no longer valid
+
+This separation prevents crashes during app termination, where `FlutterEngine.destroyContext` triggers deallocation of native views after the message channels are already torn down.
+
+**Files:**
+- `EventStreamHandler.swift` - Stream handler with `dispose()` that sends `FlutterEndOfEventStream`
+- `ReadiumReaderView.swift` - Calls stream `dispose()` in method call handler, not in `deinit`
+
 ## Troubleshooting
 
 ### Pod Install Fails

--- a/flureadium/docs/troubleshooting.md
+++ b/flureadium/docs/troubleshooting.md
@@ -223,6 +223,14 @@ await flureadium.goRight();
    );
    ```
 
+### iOS: Crash on App Close
+
+**Symptom:** App crashes when closing/terminating, with a stack trace through `EventStreamHandler.dispose()` → `FlutterBinaryMessengerRelay sendOnChannel` → `FlutterEngine destroyContext`.
+
+**Cause:** Native stream handlers are trying to send `FlutterEndOfEventStream` during `deinit`, but `deinit` is triggered by the Flutter engine teardown — the channel is already dead.
+
+**Fix:** Ensure all stream handler `.dispose()` calls happen in the platform view's `"dispose"` method call handler (called from Dart while the engine is alive), not in `deinit`. The `deinit` should only nil out references without sending any messages. See [iOS Platform - Stream and View Lifecycle](platform-specific/ios.md#stream-and-view-lifecycle).
+
 ## Platform-Specific Issues
 
 ### iOS: Localhost Connection Failed

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -46,14 +46,11 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   }
 
   deinit {
-    print(TAG, "::dispose")
+    print(TAG, "::deinit")
     readiumViewController.view.removeFromSuperview()
     readiumViewController.delegate = nil
-    textLocatorStreamHandler?.dispose()
     textLocatorStreamHandler = nil
-    readerStatusStreamHandler?.dispose()
     readerStatusStreamHandler = nil
-    errorStreamHandler?.dispose()
     errorStreamHandler = nil
     channel.setMethodCallHandler(nil)
     setCurrentReadiumReaderView(nil)
@@ -545,6 +542,12 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
       readiumViewController.view.removeFromSuperview()
       readiumViewController.delegate = nil
       self.readerStatusStreamHandler?.sendEvent(ReadiumReaderStatusClosed)
+      textLocatorStreamHandler?.dispose()
+      textLocatorStreamHandler = nil
+      readerStatusStreamHandler?.dispose()
+      readerStatusStreamHandler = nil
+      errorStreamHandler?.dispose()
+      errorStreamHandler = nil
       result(nil)
       break
     default:

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/EventStreamHandlerTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/EventStreamHandlerTests.swift
@@ -1,0 +1,126 @@
+//
+//  EventStreamHandlerTests.swift
+//  flureadiumTests
+//
+//  Unit tests for EventStreamHandler lifecycle behavior.
+//  NOTE: Requires Flutter framework (runs through Xcode/Flutter build, not pure SPM).
+//
+
+import XCTest
+import Flutter
+@testable import flureadium
+
+/// Minimal mock of FlutterBinaryMessenger for testing EventStreamHandler
+/// without a running Flutter engine.
+private class MockBinaryMessenger: NSObject, FlutterBinaryMessenger {
+
+    var sentMessages: [(channel: String, message: Data?)] = []
+
+    func send(onChannel channel: String, message: Data?) {
+        sentMessages.append((channel: channel, message: message))
+    }
+
+    func send(onChannel channel: String, message: Data?, binaryReply callback: FlutterBinaryReply?) {
+        sentMessages.append((channel: channel, message: message))
+        callback?(nil)
+    }
+
+    func setMessageHandlerOnChannel(_ channel: String, binaryMessageHandler handler: FlutterBinaryMessageHandler?) -> FlutterBinaryMessengerConnection {
+        return FlutterBinaryMessengerConnection(0)
+    }
+
+    func cleanUpConnection(_ connection: FlutterBinaryMessengerConnection) {}
+}
+
+final class EventStreamHandlerTests: XCTestCase {
+
+    private var messenger: MockBinaryMessenger!
+
+    override func setUp() {
+        super.setUp()
+        messenger = MockBinaryMessenger()
+    }
+
+    override func tearDown() {
+        messenger = nil
+        super.tearDown()
+    }
+
+    // MARK: - Dispose Tests
+
+    func testDisposeDoesNotCrash() {
+        let handler = EventStreamHandler(withName: "test-stream", messenger: messenger)
+        // Should not crash even without an active listener
+        handler.dispose()
+    }
+
+    func testDisposeCalledTwiceDoesNotCrash() {
+        let handler = EventStreamHandler(withName: "test-stream", messenger: messenger)
+        handler.dispose()
+        handler.dispose()
+    }
+
+    func testSendEventAfterDisposeIsNoOp() {
+        let handler = EventStreamHandler(withName: "test-stream", messenger: messenger)
+        handler.dispose()
+        // Should not crash — eventSink is nil after dispose
+        handler.sendEvent("some event")
+    }
+
+    // MARK: - Listener Lifecycle Tests
+
+    func testSendEventWithoutListenerIsNoOp() {
+        let handler = EventStreamHandler(withName: "test-stream", messenger: messenger)
+        // No listener registered, should not crash
+        handler.sendEvent("some event")
+    }
+
+    func testOnListenSetsEventSink() {
+        let handler = EventStreamHandler(withName: "test-stream", messenger: messenger)
+        var receivedEvents: [Any?] = []
+
+        let error = handler.onListen(withArguments: nil) { event in
+            receivedEvents.append(event)
+        }
+
+        XCTAssertNil(error, "onListen should not return an error")
+
+        handler.sendEvent("test-event")
+        XCTAssertEqual(receivedEvents.count, 1, "Event should be received after onListen")
+        XCTAssertEqual(receivedEvents.first as? String, "test-event")
+    }
+
+    func testOnCancelClearsEventSink() {
+        let handler = EventStreamHandler(withName: "test-stream", messenger: messenger)
+        var receivedEvents: [Any?] = []
+
+        _ = handler.onListen(withArguments: nil) { event in
+            receivedEvents.append(event)
+        }
+
+        let error = handler.onCancel(withArguments: nil)
+        XCTAssertNil(error, "onCancel should not return an error")
+
+        handler.sendEvent("after-cancel")
+        XCTAssertEqual(receivedEvents.count, 0, "No events should be received after onCancel")
+    }
+
+    func testDisposeSendsEndOfStreamBeforeClearing() {
+        let handler = EventStreamHandler(withName: "test-stream", messenger: messenger)
+        var receivedEvents: [Any?] = []
+
+        _ = handler.onListen(withArguments: nil) { event in
+            receivedEvents.append(event)
+        }
+
+        handler.dispose()
+
+        // FlutterEndOfEventStream should have been sent
+        XCTAssertEqual(receivedEvents.count, 1, "dispose should send FlutterEndOfEventStream")
+        XCTAssertTrue(receivedEvents.first is NSObject, "End-of-stream sentinel should be sent")
+
+        // After dispose, sending should be a no-op
+        handler.sendEvent("after-dispose")
+        XCTAssertEqual(receivedEvents.count, 1, "No events should be received after dispose")
+    }
+}

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- Fix iOS crash on app close where `EventStreamHandler.dispose()` sent `FlutterEndOfEventStream` during `deinit`, after the Flutter engine had already torn down its channels.
- Move all stream handler `dispose()` calls from `deinit` to the Dart `"dispose"` method call handler, which runs while the engine is still alive. `deinit` now only nils out references.
- Bump version to 0.3.2 for pub.dev release.

## Test plan

- [x] Add `EventStreamHandlerTests` covering dispose lifecycle, double-dispose safety, send-after-dispose no-op, and listener registration/cancellation
- [x] Manual: open an EPUB, close the app — no crash in Xcode console
- [x] Manual: reopen app, reader works normally