### PR TITLE
feat: configurable edge tap area + iOS developer config key separation

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.3.3
+
+### New Features
+
+- **iOS**: Add `edgeTapAreaPoints` preference to `EPUBPreferences` and `PDFPreferences` — configures edge tap zone width in absolute points (44–120pt). Replaces the previous percentage-based approach with a fixed-size zone that behaves consistently in split-screen and on all device sizes. Defaults to 44pt (iOS HIG minimum tap target) when null.
+  - Requires `flureadium_platform_interface` ^0.3.1.
+
+### Bug Fixes
+
+- **iOS**: Fix spurious `"EPUBPreferences WARN: Cannot map property"` log warnings on every `setPreferences` call and at view init. Developer config keys (`enableEdgeTapNavigation`, `enableSwipeNavigation`, `edgeTapAreaPoints`) are now filtered out before passing the preference map to Readium's `EPUBPreferences.init(fromMap:)` and `PDFPreferences.init(fromMap:)`, which only understand Readium preference keys.
+- **iOS**: Fix potential nil crash in `getCurrentLocator` when `currentLocation` returns nil inside the async task.
+
 ## 0.3.2
 
 ### Bug Fixes

--- a/flureadium/docs/api-reference/preferences.md
+++ b/flureadium/docs/api-reference/preferences.md
@@ -112,33 +112,39 @@ pageMargins: 0.1   // 10% margins
 pageMargins: 0.15  // 15% margins
 ```
 
-#### enableEdgeTapNavigation (iOS only)
+#### enableEdgeTapNavigation (iOS only — developer config)
 
 **Type:** `bool?`
 
 Whether edge tap navigation is enabled. When true, tapping on the left/right edges of the screen navigates pages. Defaults to true when null.
+
+This is a **developer config key**: it controls navigation UX behaviour set by the app developer, not a user-facing Readium reading preference. On the native side, the reader view handler extracts and consumes this key before passing the remaining map to Readium's preference mapper.
 
 ```dart
 enableEdgeTapNavigation: true   // Edge taps navigate pages (default)
 enableEdgeTapNavigation: false  // Edge taps disabled
 ```
 
-#### enableSwipeNavigation (iOS only)
+#### enableSwipeNavigation (iOS only — developer config)
 
 **Type:** `bool?`
 
 Whether swipe gesture navigation is enabled. When true, swiping left/right navigates pages. Defaults to true when null.
+
+This is a **developer config key** (see `enableEdgeTapNavigation` above).
 
 ```dart
 enableSwipeNavigation: true   // Swipe navigates pages (default)
 enableSwipeNavigation: false  // Swipe navigation disabled
 ```
 
-#### edgeTapAreaPoints (iOS only)
+#### edgeTapAreaPoints (iOS only — developer config)
 
 **Type:** `double?`
 
 Edge tap area in absolute points (44–120). Controls how wide the left/right tap zones are for page navigation. Defaults to 44pt (iOS HIG minimum tap target) when null. Values are clamped to the 44–120 range on the native side.
+
+This is a **developer config key** (see `enableEdgeTapNavigation` above).
 
 ```dart
 edgeTapAreaPoints: 44   // Default tap zones (iOS HIG minimum)
@@ -527,33 +533,39 @@ disableTextSelectionMenu: false  // Selection menu enabled (default)
 disableTextSelectionMenu: true   // Selection menu disabled
 ```
 
-#### enableEdgeTapNavigation (iOS only)
+#### enableEdgeTapNavigation (iOS only — developer config)
 
 **Type:** `bool?`
 
 Whether edge tap navigation is enabled. When true, tapping on the left/right edges of the screen navigates pages. Defaults to true when null.
+
+This is a **developer config key**: it controls navigation UX behaviour set by the app developer, not a user-facing Readium reading preference. On the native side, the reader view handler extracts and consumes this key before passing the remaining map to Readium's preference mapper.
 
 ```dart
 enableEdgeTapNavigation: true   // Edge taps navigate pages (default)
 enableEdgeTapNavigation: false  // Edge taps disabled
 ```
 
-#### enableSwipeNavigation (iOS only)
+#### enableSwipeNavigation (iOS only — developer config)
 
 **Type:** `bool?`
 
 Whether swipe gesture navigation is enabled. When true, swiping left/right navigates pages. Defaults to true when null.
+
+This is a **developer config key** (see `enableEdgeTapNavigation` above).
 
 ```dart
 enableSwipeNavigation: true   // Swipe navigates pages (default)
 enableSwipeNavigation: false  // Swipe navigation disabled
 ```
 
-#### edgeTapAreaPoints (iOS only)
+#### edgeTapAreaPoints (iOS only — developer config)
 
 **Type:** `double?`
 
 Edge tap area in absolute points (44–120). Controls how wide the left/right tap zones are for page navigation. Defaults to 44pt (iOS HIG minimum tap target) when null. Values are clamped to the 44–120 range on the native side.
+
+This is a **developer config key** (see `enableEdgeTapNavigation` above).
 
 ```dart
 edgeTapAreaPoints: 44   // Default tap zones (iOS HIG minimum)

--- a/flureadium/docs/api-reference/preferences.md
+++ b/flureadium/docs/api-reference/preferences.md
@@ -138,7 +138,7 @@ enableSwipeNavigation: false  // Swipe navigation disabled
 
 **Type:** `double?`
 
-Edge tap area as a percentage of screen width (10–30). Controls how wide the left/right tap zones are for page navigation. Defaults to 12 when null. Values are clamped to the 10–30 range on the native side.
+Edge tap area as a percentage of screen width (5–30). Controls how wide the left/right tap zones are for page navigation. Defaults to 12 when null. Values are clamped to the 5–30 range on the native side.
 
 ```dart
 edgeTapAreaPercent: 10   // Narrow tap zones (10% each side)
@@ -553,7 +553,7 @@ enableSwipeNavigation: false  // Swipe navigation disabled
 
 **Type:** `double?`
 
-Edge tap area as a percentage of screen width (10–30). Controls how wide the left/right tap zones are for page navigation. Defaults to 12 when null. Values are clamped to the 10–30 range on the native side.
+Edge tap area as a percentage of screen width (5–30). Controls how wide the left/right tap zones are for page navigation. Defaults to 12 when null. Values are clamped to the 5–30 range on the native side.
 
 ```dart
 edgeTapAreaPercent: 10   // Narrow tap zones (10% each side)

--- a/flureadium/docs/api-reference/preferences.md
+++ b/flureadium/docs/api-reference/preferences.md
@@ -19,6 +19,9 @@ EPUBPreferences({
   required Color? backgroundColor,
   required Color? textColor,
   double? pageMargins,
+  bool? enableEdgeTapNavigation,    // iOS only
+  bool? enableSwipeNavigation,      // iOS only
+  double? edgeTapAreaPercent,       // iOS only
 })
 ```
 
@@ -129,6 +132,19 @@ Whether swipe gesture navigation is enabled. When true, swiping left/right navig
 ```dart
 enableSwipeNavigation: true   // Swipe navigates pages (default)
 enableSwipeNavigation: false  // Swipe navigation disabled
+```
+
+#### edgeTapAreaPercent (iOS only)
+
+**Type:** `double?`
+
+Edge tap area as a percentage of screen width (10–30). Controls how wide the left/right tap zones are for page navigation. Defaults to 12 when null. Values are clamped to the 10–30 range on the native side.
+
+```dart
+edgeTapAreaPercent: 10   // Narrow tap zones (10% each side)
+edgeTapAreaPercent: 12   // Default tap zones
+edgeTapAreaPercent: 20   // Wider tap zones
+edgeTapAreaPercent: 30   // Maximum tap zones (30% each side)
 ```
 
 ### Methods
@@ -416,6 +432,7 @@ PDFPreferences({
   bool? disableTextSelectionMenu,  // iOS only
   bool? enableEdgeTapNavigation,   // iOS only
   bool? enableSwipeNavigation,     // iOS only
+  double? edgeTapAreaPercent,      // iOS only
 })
 ```
 
@@ -532,6 +549,19 @@ enableSwipeNavigation: true   // Swipe navigates pages (default)
 enableSwipeNavigation: false  // Swipe navigation disabled
 ```
 
+#### edgeTapAreaPercent (iOS only)
+
+**Type:** `double?`
+
+Edge tap area as a percentage of screen width (10–30). Controls how wide the left/right tap zones are for page navigation. Defaults to 12 when null. Values are clamped to the 10–30 range on the native side.
+
+```dart
+edgeTapAreaPercent: 10   // Narrow tap zones (10% each side)
+edgeTapAreaPercent: 12   // Default tap zones
+edgeTapAreaPercent: 20   // Wider tap zones
+edgeTapAreaPercent: 30   // Maximum tap zones (30% each side)
+```
+
 ### Methods
 
 #### toJson
@@ -566,6 +596,7 @@ PDFPreferences copyWith({
   bool? disableTextSelectionMenu,
   bool? enableEdgeTapNavigation,
   bool? enableSwipeNavigation,
+  double? edgeTapAreaPercent,
 })
 ```
 

--- a/flureadium/docs/api-reference/preferences.md
+++ b/flureadium/docs/api-reference/preferences.md
@@ -21,7 +21,7 @@ EPUBPreferences({
   double? pageMargins,
   bool? enableEdgeTapNavigation,    // iOS only
   bool? enableSwipeNavigation,      // iOS only
-  double? edgeTapAreaPercent,       // iOS only
+  double? edgeTapAreaPoints,        // iOS only
 })
 ```
 
@@ -134,17 +134,17 @@ enableSwipeNavigation: true   // Swipe navigates pages (default)
 enableSwipeNavigation: false  // Swipe navigation disabled
 ```
 
-#### edgeTapAreaPercent (iOS only)
+#### edgeTapAreaPoints (iOS only)
 
 **Type:** `double?`
 
-Edge tap area as a percentage of screen width (5–30). Controls how wide the left/right tap zones are for page navigation. Defaults to 12 when null. Values are clamped to the 5–30 range on the native side.
+Edge tap area in absolute points (44–120). Controls how wide the left/right tap zones are for page navigation. Defaults to 44pt (iOS HIG minimum tap target) when null. Values are clamped to the 44–120 range on the native side.
 
 ```dart
-edgeTapAreaPercent: 10   // Narrow tap zones (10% each side)
-edgeTapAreaPercent: 12   // Default tap zones
-edgeTapAreaPercent: 20   // Wider tap zones
-edgeTapAreaPercent: 30   // Maximum tap zones (30% each side)
+edgeTapAreaPoints: 44   // Default tap zones (iOS HIG minimum)
+edgeTapAreaPoints: 60   // Wider tap zones
+edgeTapAreaPoints: 80   // Even wider tap zones
+edgeTapAreaPoints: 120  // Maximum tap zones
 ```
 
 ### Methods
@@ -432,7 +432,7 @@ PDFPreferences({
   bool? disableTextSelectionMenu,  // iOS only
   bool? enableEdgeTapNavigation,   // iOS only
   bool? enableSwipeNavigation,     // iOS only
-  double? edgeTapAreaPercent,      // iOS only
+  double? edgeTapAreaPoints,       // iOS only
 })
 ```
 
@@ -549,17 +549,17 @@ enableSwipeNavigation: true   // Swipe navigates pages (default)
 enableSwipeNavigation: false  // Swipe navigation disabled
 ```
 
-#### edgeTapAreaPercent (iOS only)
+#### edgeTapAreaPoints (iOS only)
 
 **Type:** `double?`
 
-Edge tap area as a percentage of screen width (5–30). Controls how wide the left/right tap zones are for page navigation. Defaults to 12 when null. Values are clamped to the 5–30 range on the native side.
+Edge tap area in absolute points (44–120). Controls how wide the left/right tap zones are for page navigation. Defaults to 44pt (iOS HIG minimum tap target) when null. Values are clamped to the 44–120 range on the native side.
 
 ```dart
-edgeTapAreaPercent: 10   // Narrow tap zones (10% each side)
-edgeTapAreaPercent: 12   // Default tap zones
-edgeTapAreaPercent: 20   // Wider tap zones
-edgeTapAreaPercent: 30   // Maximum tap zones (30% each side)
+edgeTapAreaPoints: 44   // Default tap zones (iOS HIG minimum)
+edgeTapAreaPoints: 60   // Wider tap zones
+edgeTapAreaPoints: 80   // Even wider tap zones
+edgeTapAreaPoints: 120  // Maximum tap zones
 ```
 
 ### Methods
@@ -596,7 +596,7 @@ PDFPreferences copyWith({
   bool? disableTextSelectionMenu,
   bool? enableEdgeTapNavigation,
   bool? enableSwipeNavigation,
-  double? edgeTapAreaPercent,
+  double? edgeTapAreaPoints,
 })
 ```
 

--- a/flureadium/docs/guides/preferences.md
+++ b/flureadium/docs/guides/preferences.md
@@ -615,6 +615,32 @@ PDFPreferences(
 
 **Note:** When `null` (default), both gestures are enabled. In EPUB scroll mode, both are automatically disabled regardless of these settings.
 
+### Edge Tap Area Size (iOS)
+
+You can configure how wide the edge tap zones are using `edgeTapAreaPercent`. The value is a percentage of screen width (10–30), and defaults to 12 when null. The default of 12% ensures at least 44pt tap targets on the smallest iOS device (iPhone SE, 375pt width).
+
+```dart
+// EPUB: smaller edge tap zones
+EPUBPreferences(
+  fontFamily: 'Georgia',
+  fontSize: 100,
+  fontWeight: 400,
+  verticalScroll: false,
+  backgroundColor: null,
+  textColor: null,
+  edgeTapAreaPercent: 10,  // 10% of screen width per side
+)
+
+// PDF: larger edge tap zones
+PDFPreferences(
+  fit: PDFFit.width,
+  scrollMode: PDFScrollMode.horizontal,
+  edgeTapAreaPercent: 25,  // 25% of screen width per side
+)
+```
+
+Values outside the 10–30 range are clamped automatically. This preference only affects iOS; on Android, edge taps are handled internally by the Readium Kotlin Toolkit.
+
 ## See Also
 
 - [EPUBPreferences Reference](../api-reference/preferences.md#epubpreferences)

--- a/flureadium/docs/guides/preferences.md
+++ b/flureadium/docs/guides/preferences.md
@@ -617,10 +617,10 @@ PDFPreferences(
 
 ### Edge Tap Area Size (iOS)
 
-You can configure how wide the edge tap zones are using `edgeTapAreaPercent`. The value is a percentage of screen width (5–30), and defaults to 12 when null. The default of 12% ensures at least 44pt tap targets on the smallest iOS device (iPhone SE, 375pt width).
+You can configure how wide the edge tap zones are using `edgeTapAreaPoints`. The value is in absolute iOS points (44–120), and defaults to 44pt (iOS HIG minimum tap target) when null. Using absolute points ensures consistent tap zones across all devices and multitasking modes, including iPad split-screen.
 
 ```dart
-// EPUB: smaller edge tap zones
+// EPUB: default tap zones (iOS HIG minimum)
 EPUBPreferences(
   fontFamily: 'Georgia',
   fontSize: 100,
@@ -628,18 +628,18 @@ EPUBPreferences(
   verticalScroll: false,
   backgroundColor: null,
   textColor: null,
-  edgeTapAreaPercent: 10,  // 10% of screen width per side
+  edgeTapAreaPoints: 44,  // 44pt per side (iOS HIG minimum, default)
 )
 
-// PDF: larger edge tap zones
+// PDF: wider tap zones for accessibility
 PDFPreferences(
   fit: PDFFit.width,
   scrollMode: PDFScrollMode.horizontal,
-  edgeTapAreaPercent: 25,  // 25% of screen width per side
+  edgeTapAreaPoints: 80,  // 80pt per side
 )
 ```
 
-Values outside the 5–30 range are clamped automatically. This preference only affects iOS; on Android, edge taps are handled internally by the Readium Kotlin Toolkit.
+Values outside the 44–120 range are clamped automatically. This preference only affects iOS; on Android, edge taps are handled internally by the Readium Kotlin Toolkit.
 
 ## See Also
 

--- a/flureadium/docs/guides/preferences.md
+++ b/flureadium/docs/guides/preferences.md
@@ -617,7 +617,7 @@ PDFPreferences(
 
 ### Edge Tap Area Size (iOS)
 
-You can configure how wide the edge tap zones are using `edgeTapAreaPercent`. The value is a percentage of screen width (10–30), and defaults to 12 when null. The default of 12% ensures at least 44pt tap targets on the smallest iOS device (iPhone SE, 375pt width).
+You can configure how wide the edge tap zones are using `edgeTapAreaPercent`. The value is a percentage of screen width (5–30), and defaults to 12 when null. The default of 12% ensures at least 44pt tap targets on the smallest iOS device (iPhone SE, 375pt width).
 
 ```dart
 // EPUB: smaller edge tap zones
@@ -639,7 +639,7 @@ PDFPreferences(
 )
 ```
 
-Values outside the 10–30 range are clamped automatically. This preference only affects iOS; on Android, edge taps are handled internally by the Readium Kotlin Toolkit.
+Values outside the 5–30 range are clamped automatically. This preference only affects iOS; on Android, edge taps are handled internally by the Readium Kotlin Toolkit.
 
 ## See Also
 

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -157,6 +157,10 @@ EPUBPreferences(
 
 **Note:** In EPUB scroll mode, both gestures are automatically disabled regardless of preference values.
 
+**Developer Config vs Readium Preferences:**
+
+`enableEdgeTapNavigation`, `enableSwipeNavigation`, and `edgeTapAreaPoints` are **developer config keys** — they control navigation UX behaviour defined by the app developer, not user-facing reading appearance. They are serialized alongside Readium preferences in the same `setPreferences` call for convenience, but the native `ReadiumReaderView` and `PdfReaderView` handlers extract and consume these keys before forwarding the remaining map to `EPUBPreferences.init(fromMap:)` / `PDFPreferences.init(fromMap:)`. This keeps Readium's preference mapping clean and prevents spurious "Cannot map property" warnings.
+
 **Edge Threshold:**
 
 The edge threshold defaults to 44pt (iOS HIG minimum tap target) and is controlled via the `edgeTapAreaPoints` preference (44–120pt range, clamped automatically). The raw property on `EdgeTapInterceptView` can also be set directly in Swift:

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -159,10 +159,10 @@ EPUBPreferences(
 
 **Edge Threshold:**
 
-The edge threshold (30% by default) can be customized in Swift:
+The edge threshold defaults to 44pt (iOS HIG minimum tap target) and is controlled via the `edgeTapAreaPoints` preference (44–120pt range, clamped automatically). The raw property on `EdgeTapInterceptView` can also be set directly in Swift:
 
 ```swift
-edgeTapView.edgeThresholdPercent = 0.25 // 25% of screen width
+edgeTapView.edgeThresholdPoints = 80.0 // 80pt per side
 ```
 
 **Files:**

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -207,14 +207,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.3.2"
   flureadium_platform_interface:
     dependency: transitive
     description:
-      path: "../../flureadium_platform_interface"
-      relative: true
-    source: path
-    version: "0.0.1"
+      name: flureadium_platform_interface
+      sha256: c94da9aca6e56ef9be4d4c6a980851c9ca6c1d9c570a9d7561722bda9157c99b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/flureadium/ios/flureadium/Sources/flureadium/EdgeTapInterceptView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/EdgeTapInterceptView.swift
@@ -20,8 +20,8 @@ class EdgeTapInterceptView: UIView {
     var onSwipeLeft: (() -> Void)?
     /// Callback for swipe right gesture (in edge zones)
     var onSwipeRight: (() -> Void)?
-    /// Edge threshold as percentage of width (default 12%)
-    var edgeThresholdPercent: CGFloat = 0.12
+    /// Edge threshold in absolute points (default 44pt, iOS HIG minimum tap target)
+    var edgeThresholdPoints: CGFloat = 44.0
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -68,7 +68,7 @@ class EdgeTapInterceptView: UIView {
 
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
         let location = gesture.location(in: self)
-        let edgeSize = bounds.width * edgeThresholdPercent
+        let edgeSize = edgeThresholdPoints
 
         if location.x < edgeSize {
             onLeftEdgeTap?()
@@ -80,7 +80,7 @@ class EdgeTapInterceptView: UIView {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let result = super.hitTest(point, with: event)
 
-        let edgeSize = bounds.width * edgeThresholdPercent
+        let edgeSize = edgeThresholdPoints
         let isLeftEdge = point.x < edgeSize
         let isRightEdge = point.x > bounds.width - edgeSize
 

--- a/flureadium/ios/flureadium/Sources/flureadium/EdgeTapInterceptView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/EdgeTapInterceptView.swift
@@ -20,8 +20,8 @@ class EdgeTapInterceptView: UIView {
     var onSwipeLeft: (() -> Void)?
     /// Callback for swipe right gesture (in edge zones)
     var onSwipeRight: (() -> Void)?
-    /// Edge threshold as percentage of width (default 30%)
-    var edgeThresholdPercent: CGFloat = 0.3
+    /// Edge threshold as percentage of width (default 12%)
+    var edgeThresholdPercent: CGFloat = 0.12
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -34,7 +34,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
   private let disableTextSelectionMenu: Bool
   private let enableEdgeTapNavigation: Bool
   private let enableSwipeNavigation: Bool
-  private let edgeTapAreaPercent: CGFloat?
+  private var edgeTapAreaPoints: CGFloat?
 
   var publicationIdentifier: String?
 
@@ -79,10 +79,10 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     disableTextSelectionMenu = flutterPrefs.disableTextSelectionMenu ?? false
     enableEdgeTapNavigation = flutterPrefs.enableEdgeTapNavigation ?? true
     enableSwipeNavigation = flutterPrefs.enableSwipeNavigation ?? true
-    if let rawPercent = flutterPrefs.edgeTapAreaPercent {
-      edgeTapAreaPercent = CGFloat(min(max(rawPercent / 100.0, 0.05), 0.30))
+    if let rawPoints = flutterPrefs.edgeTapAreaPoints {
+      edgeTapAreaPoints = CGFloat(min(max(rawPoints, 44.0), 120.0))
     } else {
-      edgeTapAreaPercent = nil
+      edgeTapAreaPoints = nil
     }
     print(TAG, "PDF Preferences - disableDoubleTapZoom: \(disableDoubleTapZoom), disableTextSelection: \(disableTextSelection), disableDragGestures: \(disableDragGestures), disableTextSelectionMenu: \(disableTextSelectionMenu), enableEdgeTapNavigation: \(enableEdgeTapNavigation), enableSwipeNavigation: \(enableSwipeNavigation)")
 
@@ -222,19 +222,19 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
 
   private func setUserPreferences(preferences: PDFPreferences) {
     self.pdfViewController.submitPreferences(preferences)
+    configureEdgeTapHandlers()
   }
 
   /// Configure edge tap handlers for page navigation.
-  /// Tapping on the left 30% of the screen triggers goLeft (previous page).
-  /// Tapping on the right 30% of the screen triggers goRight (next page).
+  /// Tapping on the left edge triggers goLeft (previous page).
+  /// Tapping on the right edge triggers goRight (next page).
   private func configureEdgeTapHandlers() {
     guard let edgeTapView = _view as? EdgeTapInterceptView else { return }
 
-    if let percent = edgeTapAreaPercent {
-      edgeTapView.edgeThresholdPercent = percent
-    }
-
     if enableEdgeTapNavigation {
+      if let points = edgeTapAreaPoints {
+        edgeTapView.edgeThresholdPoints = points
+      }
       edgeTapView.onLeftEdgeTap = { [weak self] in
         guard let self = self else { return }
         print(TAG, "[FALLBACK] Triggering goLeft via edge tap")
@@ -439,6 +439,9 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     case "setPreferences":
       let args = call.arguments as! [String: Any]
       print(TAG, "onMethodCall[setPreferences] args = \(args)")
+      if let rawPoints = args["edgeTapAreaPoints"] as? Double {
+        edgeTapAreaPoints = CGFloat(min(max(rawPoints, 44.0), 120.0))
+      }
       let preferences = PDFPreferences(fromMap: args)
       setUserPreferences(preferences: preferences)
       result(nil)

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -34,6 +34,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
   private let disableTextSelectionMenu: Bool
   private let enableEdgeTapNavigation: Bool
   private let enableSwipeNavigation: Bool
+  private let edgeTapAreaPercent: CGFloat?
 
   var publicationIdentifier: String?
 
@@ -78,6 +79,11 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     disableTextSelectionMenu = flutterPrefs.disableTextSelectionMenu ?? false
     enableEdgeTapNavigation = flutterPrefs.enableEdgeTapNavigation ?? true
     enableSwipeNavigation = flutterPrefs.enableSwipeNavigation ?? true
+    if let rawPercent = flutterPrefs.edgeTapAreaPercent {
+      edgeTapAreaPercent = CGFloat(min(max(rawPercent / 100.0, 0.10), 0.30))
+    } else {
+      edgeTapAreaPercent = nil
+    }
     print(TAG, "PDF Preferences - disableDoubleTapZoom: \(disableDoubleTapZoom), disableTextSelection: \(disableTextSelection), disableDragGestures: \(disableDragGestures), disableTextSelectionMenu: \(disableTextSelectionMenu), enableEdgeTapNavigation: \(enableEdgeTapNavigation), enableSwipeNavigation: \(enableSwipeNavigation)")
 
     let locatorStr = creationParams["initialLocator"] as? String
@@ -223,6 +229,10 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
   /// Tapping on the right 30% of the screen triggers goRight (next page).
   private func configureEdgeTapHandlers() {
     guard let edgeTapView = _view as? EdgeTapInterceptView else { return }
+
+    if let percent = edgeTapAreaPercent {
+      edgeTapView.edgeThresholdPercent = percent
+    }
 
     if enableEdgeTapNavigation {
       edgeTapView.onLeftEdgeTap = { [weak self] in

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -28,13 +28,26 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
   private let _view: UIView
   private let pdfViewController: PDFNavigatorViewController
   private var hasSentReady = false
-  private let disableDoubleTapZoom: Bool
-  private let disableTextSelection: Bool
-  private let disableDragGestures: Bool
-  private let disableTextSelectionMenu: Bool
-  private let enableEdgeTapNavigation: Bool
-  private let enableSwipeNavigation: Bool
+  private var disableDoubleTapZoom: Bool
+  private var disableTextSelection: Bool
+  private var disableDragGestures: Bool
+  private var disableTextSelectionMenu: Bool
+  private var enableEdgeTapNavigation: Bool
+  private var enableSwipeNavigation: Bool
   private var edgeTapAreaPoints: CGFloat?
+
+  /// Keys owned by the app developer (navigation UX config). Extracted via
+  /// FlutterPdfPreferences in the setPreferences handler and must NOT be forwarded
+  /// to PDFPreferences.init(fromMap:), which only understands Readium preference keys.
+  private static let developerConfigKeys: Set<String> = [
+    "enableEdgeTapNavigation",
+    "enableSwipeNavigation",
+    "edgeTapAreaPoints",
+    "disableDoubleTapZoom",
+    "disableTextSelection",
+    "disableDragGestures",
+    "disableTextSelectionMenu",
+  ]
 
   var publicationIdentifier: String?
 
@@ -439,10 +452,21 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     case "setPreferences":
       let args = call.arguments as! [String: Any]
       print(TAG, "onMethodCall[setPreferences] args = \(args)")
-      if let rawPoints = args["edgeTapAreaPoints"] as? Double {
-        edgeTapAreaPoints = CGFloat(min(max(rawPoints, 44.0), 120.0))
+      // Extract developer config keys via FlutterPdfPreferences — these control
+      // navigation UX and are not Readium reader settings. They must not be
+      // forwarded to PDFPreferences.init(fromMap:).
+      let flutterPrefs = FlutterPdfPreferences(fromMap: args)
+      enableEdgeTapNavigation = flutterPrefs.enableEdgeTapNavigation ?? enableEdgeTapNavigation
+      enableSwipeNavigation = flutterPrefs.enableSwipeNavigation ?? enableSwipeNavigation
+      disableDoubleTapZoom = flutterPrefs.disableDoubleTapZoom ?? disableDoubleTapZoom
+      disableTextSelection = flutterPrefs.disableTextSelection ?? disableTextSelection
+      disableDragGestures = flutterPrefs.disableDragGestures ?? disableDragGestures
+      disableTextSelectionMenu = flutterPrefs.disableTextSelectionMenu ?? disableTextSelectionMenu
+      if let pts = flutterPrefs.edgeTapAreaPoints {
+        edgeTapAreaPoints = CGFloat(min(max(pts, 44.0), 120.0))
       }
-      let preferences = PDFPreferences(fromMap: args)
+      let readerArgs = args.filter { !PdfReaderView.developerConfigKeys.contains($0.key) }
+      let preferences = PDFPreferences(fromMap: readerArgs)
       setUserPreferences(preferences: preferences)
       result(nil)
     case "dispose":

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -80,7 +80,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     enableEdgeTapNavigation = flutterPrefs.enableEdgeTapNavigation ?? true
     enableSwipeNavigation = flutterPrefs.enableSwipeNavigation ?? true
     if let rawPercent = flutterPrefs.edgeTapAreaPercent {
-      edgeTapAreaPercent = CGFloat(min(max(rawPercent / 100.0, 0.10), 0.30))
+      edgeTapAreaPercent = CGFloat(min(max(rawPercent / 100.0, 0.05), 0.30))
     } else {
       edgeTapAreaPercent = nil
     }

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -34,7 +34,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   private var hasSentReady = false
   private let enableEdgeTapNavigation: Bool
   private let enableSwipeNavigation: Bool
-  private var edgeTapAreaPercent: CGFloat?
+  private var edgeTapAreaPoints: CGFloat?
 
   // Retain the navigation adapter to prevent ARC deallocation
   private var directionalNavigationAdapter: DirectionalNavigationAdapter?
@@ -77,10 +77,10 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     let swipeStr = preferencesMap??["enableSwipeNavigation"]
     enableSwipeNavigation = swipeStr != "false"  // default true
 
-    // Read edge tap area percentage (serialized as string from Dart)
-    if let edgeTapAreaStr = preferencesMap??["edgeTapAreaPercent"],
+    // Read edge tap area in points (serialized as string from Dart)
+    if let edgeTapAreaStr = preferencesMap??["edgeTapAreaPoints"],
        let edgeTapArea = Double(edgeTapAreaStr) {
-      edgeTapAreaPercent = CGFloat(min(max(edgeTapArea / 100.0, 0.05), 0.30))
+      edgeTapAreaPoints = CGFloat(min(max(edgeTapArea, 44.0), 120.0))
     }
 
     let locatorStr = creationParams["initialLocator"] as? String
@@ -285,10 +285,6 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   private func configureEdgeTapHandlers(isScrollMode: Bool) {
     guard let edgeTapView = _view as? EdgeTapInterceptView else { return }
 
-    if let percent = edgeTapAreaPercent {
-      edgeTapView.edgeThresholdPercent = percent
-    }
-
     if isScrollMode {
       // Disable edge tap and swipe navigation in scroll mode
       edgeTapView.onLeftEdgeTap = nil
@@ -298,6 +294,9 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     } else {
       // Enable edge tap navigation in paginated mode (if preference allows)
       if enableEdgeTapNavigation {
+        if let points = edgeTapAreaPoints {
+          edgeTapView.edgeThresholdPoints = points
+        }
         edgeTapView.onLeftEdgeTap = { [weak self] in
           guard let self = self else { return }
           print(TAG, "[FALLBACK] Triggering goLeft via fallback tap handler")
@@ -530,6 +529,10 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     case "setPreferences":
       let args = call.arguments as! [String: String]
       print(TAG, "onMethodCall[setPreferences] args = \(args)")
+      if let edgeTapAreaStr = args["edgeTapAreaPoints"],
+         let edgeTapArea = Double(edgeTapAreaStr) {
+        edgeTapAreaPoints = CGFloat(min(max(edgeTapArea, 44.0), 120.0))
+      }
       let preferences = EPUBPreferences.init(fromMap: args)
       setUserPreferences(preferences: preferences)
       break

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -493,15 +493,13 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
       let args = call.arguments as? String ?? "null"
       print(TAG, "onMethodCall[currentLocator] args = \(args)")
       Task.detached(priority: .high) { [isVerticalScroll] in
-        let json = await self.readiumViewController.currentLocation?.jsonString ?? nil
-        if (json == nil) {
-          await MainActor.run() {
-            return result(nil)
-          }
+        guard let json = await self.readiumViewController.currentLocation?.jsonString else {
+          await MainActor.run { result(nil) }
+          return
         }
-        let data = await self.getLocatorFragments(json!, isVerticalScroll)
-        await MainActor.run() {
-          return result(data?.jsonString)
+        let data = await self.getLocatorFragments(json, isVerticalScroll)
+        await MainActor.run {
+          result(data?.jsonString)
         }
       }
       break

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -34,6 +34,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   private var hasSentReady = false
   private let enableEdgeTapNavigation: Bool
   private let enableSwipeNavigation: Bool
+  private var edgeTapAreaPercent: CGFloat?
 
   // Retain the navigation adapter to prevent ARC deallocation
   private var directionalNavigationAdapter: DirectionalNavigationAdapter?
@@ -75,6 +76,12 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     enableEdgeTapNavigation = edgeTapStr != "false"  // default true
     let swipeStr = preferencesMap??["enableSwipeNavigation"]
     enableSwipeNavigation = swipeStr != "false"  // default true
+
+    // Read edge tap area percentage (serialized as string from Dart)
+    if let edgeTapAreaStr = preferencesMap??["edgeTapAreaPercent"],
+       let edgeTapArea = Double(edgeTapAreaStr) {
+      edgeTapAreaPercent = CGFloat(min(max(edgeTapArea / 100.0, 0.10), 0.30))
+    }
 
     let locatorStr = creationParams["initialLocator"] as? String
     let locator = locatorStr == nil ? nil : try! Locator.init(jsonString: locatorStr!)
@@ -277,6 +284,10 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   /// In paginated mode, edge taps trigger goLeft/goRight for page navigation.
   private func configureEdgeTapHandlers(isScrollMode: Bool) {
     guard let edgeTapView = _view as? EdgeTapInterceptView else { return }
+
+    if let percent = edgeTapAreaPercent {
+      edgeTapView.edgeThresholdPercent = percent
+    }
 
     if isScrollMode {
       // Disable edge tap and swipe navigation in scroll mode

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -80,7 +80,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     // Read edge tap area percentage (serialized as string from Dart)
     if let edgeTapAreaStr = preferencesMap??["edgeTapAreaPercent"],
        let edgeTapArea = Double(edgeTapAreaStr) {
-      edgeTapAreaPercent = CGFloat(min(max(edgeTapArea / 100.0, 0.10), 0.30))
+      edgeTapAreaPercent = CGFloat(min(max(edgeTapArea / 100.0, 0.05), 0.30))
     }
 
     let locatorStr = creationParams["initialLocator"] as? String

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -32,9 +32,18 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   private let readiumViewController: EPUBNavigatorViewController
   private var isVerticalScroll = false
   private var hasSentReady = false
-  private let enableEdgeTapNavigation: Bool
-  private let enableSwipeNavigation: Bool
+  private var enableEdgeTapNavigation: Bool
+  private var enableSwipeNavigation: Bool
   private var edgeTapAreaPoints: CGFloat?
+
+  /// Keys owned by the app developer (navigation UX config). Extracted separately
+  /// in the setPreferences handler and must NOT be forwarded to
+  /// EPUBPreferences.init(fromMap:), which only understands Readium preference keys.
+  private static let developerConfigKeys: Set<String> = [
+    "enableEdgeTapNavigation",
+    "enableSwipeNavigation",
+    "edgeTapAreaPoints",
+  ]
 
   // Retain the navigation adapter to prevent ARC deallocation
   private var directionalNavigationAdapter: DirectionalNavigationAdapter?
@@ -69,7 +78,8 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     let publication = getCurrentPublication()!
 
     let preferencesMap = creationParams["preferences"] as? Dictionary<String, String>?
-    let defaultPreferences = preferencesMap == nil ? nil : EPUBPreferences.init(fromMap: preferencesMap!!)
+    let filteredPrefsMap = preferencesMap == nil ? nil : preferencesMap!!.filter { !ReadiumReaderView.developerConfigKeys.contains($0.key) }
+    let defaultPreferences = filteredPrefsMap == nil ? nil : EPUBPreferences.init(fromMap: filteredPrefsMap!)
 
     // Read navigation gesture preferences (serialized as strings from Dart)
     let edgeTapStr = preferencesMap??["enableEdgeTapNavigation"]
@@ -527,11 +537,15 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     case "setPreferences":
       let args = call.arguments as! [String: String]
       print(TAG, "onMethodCall[setPreferences] args = \(args)")
-      if let edgeTapAreaStr = args["edgeTapAreaPoints"],
-         let edgeTapArea = Double(edgeTapAreaStr) {
-        edgeTapAreaPoints = CGFloat(min(max(edgeTapArea, 44.0), 120.0))
+      // Extract developer config keys first — these control navigation UX and are
+      // not Readium reader settings. They must not be forwarded to EPUBPreferences.
+      if let v = args["enableEdgeTapNavigation"] { enableEdgeTapNavigation = v != "false" }
+      if let v = args["enableSwipeNavigation"] { enableSwipeNavigation = v != "false" }
+      if let pts = args["edgeTapAreaPoints"].flatMap(Double.init) {
+        edgeTapAreaPoints = CGFloat(min(max(pts, 44.0), 120.0))
       }
-      let preferences = EPUBPreferences.init(fromMap: args)
+      let readerPrefs = args.filter { !ReadiumReaderView.developerConfigKeys.contains($0.key) }
+      let preferences = EPUBPreferences.init(fromMap: readerPrefs)
       setUserPreferences(preferences: preferences)
       break
     case "applyDecorations":

--- a/flureadium/ios/flureadium/Sources/flureadium/model/FlutterPdfPreferences.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/model/FlutterPdfPreferences.swift
@@ -126,9 +126,9 @@ public struct FlutterPdfPreferences {
     /// Defaults to true (enabled) when nil.
     var enableSwipeNavigation: Bool?
 
-    /// Edge tap area as a percentage of screen width (10–30). iOS only.
-    /// Defaults to 12 when nil.
-    var edgeTapAreaPercent: Double?
+    /// Edge tap area in absolute points (44–120). iOS only.
+    /// Defaults to 44pt (iOS HIG minimum tap target) when nil.
+    var edgeTapAreaPoints: Double?
 
     /// Creates FlutterPdfPreferences with default values.
     init(
@@ -142,7 +142,7 @@ public struct FlutterPdfPreferences {
         disableTextSelectionMenu: Bool? = nil,
         enableEdgeTapNavigation: Bool? = nil,
         enableSwipeNavigation: Bool? = nil,
-        edgeTapAreaPercent: Double? = nil
+        edgeTapAreaPoints: Double? = nil
     ) {
         self.fit = fit
         self.scrollMode = scrollMode
@@ -154,7 +154,7 @@ public struct FlutterPdfPreferences {
         self.disableTextSelectionMenu = disableTextSelectionMenu
         self.enableEdgeTapNavigation = enableEdgeTapNavigation
         self.enableSwipeNavigation = enableSwipeNavigation
-        self.edgeTapAreaPercent = edgeTapAreaPercent
+        self.edgeTapAreaPoints = edgeTapAreaPoints
     }
 
     /// Creates FlutterPdfPreferences from a Flutter dictionary.
@@ -175,7 +175,7 @@ public struct FlutterPdfPreferences {
             disableTextSelectionMenu: map["disableTextSelectionMenu"] as? Bool,
             enableEdgeTapNavigation: map["enableEdgeTapNavigation"] as? Bool,
             enableSwipeNavigation: map["enableSwipeNavigation"] as? Bool,
-            edgeTapAreaPercent: map["edgeTapAreaPercent"] as? Double
+            edgeTapAreaPoints: map["edgeTapAreaPoints"] as? Double
         )
     }
 
@@ -231,8 +231,8 @@ public struct FlutterPdfPreferences {
         if let enableSwipeNavigation = enableSwipeNavigation {
             map["enableSwipeNavigation"] = enableSwipeNavigation
         }
-        if let edgeTapAreaPercent = edgeTapAreaPercent {
-            map["edgeTapAreaPercent"] = edgeTapAreaPercent
+        if let edgeTapAreaPoints = edgeTapAreaPoints {
+            map["edgeTapAreaPoints"] = edgeTapAreaPoints
         }
         return map
     }

--- a/flureadium/ios/flureadium/Sources/flureadium/model/FlutterPdfPreferences.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/model/FlutterPdfPreferences.swift
@@ -126,6 +126,10 @@ public struct FlutterPdfPreferences {
     /// Defaults to true (enabled) when nil.
     var enableSwipeNavigation: Bool?
 
+    /// Edge tap area as a percentage of screen width (10–30). iOS only.
+    /// Defaults to 12 when nil.
+    var edgeTapAreaPercent: Double?
+
     /// Creates FlutterPdfPreferences with default values.
     init(
         fit: FlutterPdfFit? = nil,
@@ -137,7 +141,8 @@ public struct FlutterPdfPreferences {
         disableDragGestures: Bool? = nil,
         disableTextSelectionMenu: Bool? = nil,
         enableEdgeTapNavigation: Bool? = nil,
-        enableSwipeNavigation: Bool? = nil
+        enableSwipeNavigation: Bool? = nil,
+        edgeTapAreaPercent: Double? = nil
     ) {
         self.fit = fit
         self.scrollMode = scrollMode
@@ -149,6 +154,7 @@ public struct FlutterPdfPreferences {
         self.disableTextSelectionMenu = disableTextSelectionMenu
         self.enableEdgeTapNavigation = enableEdgeTapNavigation
         self.enableSwipeNavigation = enableSwipeNavigation
+        self.edgeTapAreaPercent = edgeTapAreaPercent
     }
 
     /// Creates FlutterPdfPreferences from a Flutter dictionary.
@@ -168,7 +174,8 @@ public struct FlutterPdfPreferences {
             disableDragGestures: map["disableDragGestures"] as? Bool,
             disableTextSelectionMenu: map["disableTextSelectionMenu"] as? Bool,
             enableEdgeTapNavigation: map["enableEdgeTapNavigation"] as? Bool,
-            enableSwipeNavigation: map["enableSwipeNavigation"] as? Bool
+            enableSwipeNavigation: map["enableSwipeNavigation"] as? Bool,
+            edgeTapAreaPercent: map["edgeTapAreaPercent"] as? Double
         )
     }
 
@@ -223,6 +230,9 @@ public struct FlutterPdfPreferences {
         }
         if let enableSwipeNavigation = enableSwipeNavigation {
             map["enableSwipeNavigation"] = enableSwipeNavigation
+        }
+        if let edgeTapAreaPercent = edgeTapAreaPercent {
+            map["edgeTapAreaPercent"] = edgeTapAreaPercent
         }
         return map
     }

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/EdgeTapInterceptViewTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/EdgeTapInterceptViewTests.swift
@@ -205,7 +205,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         // The view is a dumb component - clamping happens in reader views, not here
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.edgeThresholdPercent = 0.05
-        XCTAssertEqual(view.edgeThresholdPercent, 0.05, "View should accept values below 10% range")
+        XCTAssertEqual(view.edgeThresholdPercent, 0.05, "View should accept values below 5% range")
 
         view.edgeThresholdPercent = 0.50
         XCTAssertEqual(view.edgeThresholdPercent, 0.50, "View should accept values above 30% range")

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/EdgeTapInterceptViewTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/EdgeTapInterceptViewTests.swift
@@ -14,7 +14,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testDefaultEdgeThreshold() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        XCTAssertEqual(view.edgeThresholdPercent, 0.3)
+        XCTAssertEqual(view.edgeThresholdPercent, 0.12)
     }
 
     func testCallbacksDefaultToNil() {
@@ -33,28 +33,28 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testLeftEdgeDetection() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        // With 30% threshold, left edge is 0-30 pixels
+        // With 12% threshold, left edge is 0-12 pixels
 
-        // Point at x=15 should be in left edge (15 < 30)
-        let leftEdgePoint = CGPoint(x: 15, y: 50)
+        // Point at x=5 should be in left edge (5 < 12)
+        let leftEdgePoint = CGPoint(x: 5, y: 50)
         let edgeSize = view.bounds.width * view.edgeThresholdPercent
-        XCTAssertTrue(leftEdgePoint.x < edgeSize, "Point at x=15 should be in left edge zone")
+        XCTAssertTrue(leftEdgePoint.x < edgeSize, "Point at x=5 should be in left edge zone")
 
-        // Point at x=50 should NOT be in left edge (50 > 30)
+        // Point at x=50 should NOT be in left edge (50 > 12)
         let centerPoint = CGPoint(x: 50, y: 50)
         XCTAssertFalse(centerPoint.x < edgeSize, "Point at x=50 should not be in left edge zone")
     }
 
     func testRightEdgeDetection() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        // With 30% threshold, right edge is 70-100 pixels
+        // With 12% threshold, right edge is 88-100 pixels
 
-        // Point at x=85 should be in right edge (85 > 70)
-        let rightEdgePoint = CGPoint(x: 85, y: 50)
+        // Point at x=95 should be in right edge (95 > 88)
+        let rightEdgePoint = CGPoint(x: 95, y: 50)
         let edgeSize = view.bounds.width * view.edgeThresholdPercent
-        XCTAssertTrue(rightEdgePoint.x > view.bounds.width - edgeSize, "Point at x=85 should be in right edge zone")
+        XCTAssertTrue(rightEdgePoint.x > view.bounds.width - edgeSize, "Point at x=95 should be in right edge zone")
 
-        // Point at x=50 should NOT be in right edge (50 < 70)
+        // Point at x=50 should NOT be in right edge (50 < 88)
         let centerPoint = CGPoint(x: 50, y: 50)
         XCTAssertFalse(centerPoint.x > view.bounds.width - edgeSize, "Point at x=50 should not be in right edge zone")
     }
@@ -78,8 +78,8 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         // No callbacks set
 
-        let leftEdgePoint = CGPoint(x: 15, y: 50)
-        let rightEdgePoint = CGPoint(x: 85, y: 50)
+        let leftEdgePoint = CGPoint(x: 5, y: 50)
+        let rightEdgePoint = CGPoint(x: 95, y: 50)
 
         XCTAssertNil(view.hitTest(leftEdgePoint, with: nil), "Hit test should return nil for left edge when no callback")
         XCTAssertNil(view.hitTest(rightEdgePoint, with: nil), "Hit test should return nil for right edge when no callback")
@@ -89,7 +89,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.onLeftEdgeTap = { }
 
-        let leftEdgePoint = CGPoint(x: 15, y: 50)
+        let leftEdgePoint = CGPoint(x: 5, y: 50)
         XCTAssertEqual(view.hitTest(leftEdgePoint, with: nil), view, "Hit test should return self for left edge with callback")
     }
 
@@ -97,7 +97,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.onRightEdgeTap = { }
 
-        let rightEdgePoint = CGPoint(x: 85, y: 50)
+        let rightEdgePoint = CGPoint(x: 95, y: 50)
         XCTAssertEqual(view.hitTest(rightEdgePoint, with: nil), view, "Hit test should return self for right edge with callback")
     }
 
@@ -149,9 +149,9 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testExactlyOnLeftEdgeBoundary() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.onLeftEdgeTap = { }
-        let edgeSize = view.bounds.width * view.edgeThresholdPercent // 30
+        let edgeSize = view.bounds.width * view.edgeThresholdPercent // 12
 
-        // Point exactly at boundary (x=30) should NOT be in left edge (30 < 30 is false)
+        // Point exactly at boundary (x=12) should NOT be in left edge (12 < 12 is false)
         let boundaryPoint = CGPoint(x: edgeSize, y: 50)
         XCTAssertNil(view.hitTest(boundaryPoint, with: nil), "Point exactly at left boundary should not trigger")
     }
@@ -159,10 +159,10 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testExactlyOnRightEdgeBoundary() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.onRightEdgeTap = { }
-        let edgeSize = view.bounds.width * view.edgeThresholdPercent // 30
-        let rightBoundary = view.bounds.width - edgeSize // 70
+        let edgeSize = view.bounds.width * view.edgeThresholdPercent // 12
+        let rightBoundary = view.bounds.width - edgeSize // 88
 
-        // Point exactly at boundary (x=70) should NOT be in right edge (70 > 70 is false)
+        // Point exactly at boundary (x=88) should NOT be in right edge (88 > 88 is false)
         let boundaryPoint = CGPoint(x: rightBoundary, y: 50)
         XCTAssertNil(view.hitTest(boundaryPoint, with: nil), "Point exactly at right boundary should not trigger")
     }
@@ -174,9 +174,9 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
-        // With 30% threshold on 1000px width, left edge is 0-300, right edge is 700-1000
-        let leftEdgePoint = CGPoint(x: 150, y: 400)
-        let rightEdgePoint = CGPoint(x: 850, y: 400)
+        // With 12% threshold on 1000px width, left edge is 0-120, right edge is 880-1000
+        let leftEdgePoint = CGPoint(x: 60, y: 400)
+        let rightEdgePoint = CGPoint(x: 950, y: 400)
         let centerPoint = CGPoint(x: 500, y: 400)
 
         XCTAssertEqual(view.hitTest(leftEdgePoint, with: nil), view, "Left edge detection should work on large view")
@@ -189,9 +189,9 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
-        // With 30% threshold on 50px width, left edge is 0-15, right edge is 35-50
-        let leftEdgePoint = CGPoint(x: 7, y: 25)
-        let rightEdgePoint = CGPoint(x: 43, y: 25)
+        // With 12% threshold on 50px width, left edge is 0-6, right edge is 44-50
+        let leftEdgePoint = CGPoint(x: 3, y: 25)
+        let rightEdgePoint = CGPoint(x: 47, y: 25)
         let centerPoint = CGPoint(x: 25, y: 25)
 
         XCTAssertEqual(view.hitTest(leftEdgePoint, with: nil), view, "Left edge detection should work on small view")
@@ -200,6 +200,23 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     }
 
     // MARK: - Custom Threshold Tests
+
+    func testEdgeThresholdAcceptsAnyValue() {
+        // The view is a dumb component - clamping happens in reader views, not here
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.edgeThresholdPercent = 0.05
+        XCTAssertEqual(view.edgeThresholdPercent, 0.05, "View should accept values below 10% range")
+
+        view.edgeThresholdPercent = 0.50
+        XCTAssertEqual(view.edgeThresholdPercent, 0.50, "View should accept values above 30% range")
+    }
+
+    func testDefaultThresholdGivesMinimum44ptOnSmallestDevice() {
+        // iPhone SE has 375pt width. 12% of 375 = 45pt, which is >= 44pt minimum tap target
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        let edgeSize = view.bounds.width * view.edgeThresholdPercent
+        XCTAssertGreaterThanOrEqual(edgeSize, 44.0, "Default 12% threshold should give >= 44pt on iPhone SE (375pt width)")
+    }
 
     func testCustomThresholdChangesEdgeZones() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/EdgeTapInterceptViewTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/EdgeTapInterceptViewTests.swift
@@ -14,7 +14,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testDefaultEdgeThreshold() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        XCTAssertEqual(view.edgeThresholdPercent, 0.12)
+        XCTAssertEqual(view.edgeThresholdPoints, 44.0)
     }
 
     func testCallbacksDefaultToNil() {
@@ -25,45 +25,46 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testCustomEdgeThreshold() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        view.edgeThresholdPercent = 0.2
-        XCTAssertEqual(view.edgeThresholdPercent, 0.2)
+        view.edgeThresholdPoints = 60.0
+        XCTAssertEqual(view.edgeThresholdPoints, 60.0)
     }
 
     // MARK: - Edge Detection Calculation Tests
 
     func testLeftEdgeDetection() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        // With 12% threshold, left edge is 0-12 pixels
+        // With 44pt threshold, left edge is x < 44
 
-        // Point at x=5 should be in left edge (5 < 12)
-        let leftEdgePoint = CGPoint(x: 5, y: 50)
-        let edgeSize = view.bounds.width * view.edgeThresholdPercent
-        XCTAssertTrue(leftEdgePoint.x < edgeSize, "Point at x=5 should be in left edge zone")
+        // Point at x=20 should be in left edge (20 < 44)
+        let leftEdgePoint = CGPoint(x: 20, y: 50)
+        let edgeSize = view.edgeThresholdPoints
+        XCTAssertTrue(leftEdgePoint.x < edgeSize, "Point at x=20 should be in left edge zone")
 
-        // Point at x=50 should NOT be in left edge (50 > 12)
-        let centerPoint = CGPoint(x: 50, y: 50)
-        XCTAssertFalse(centerPoint.x < edgeSize, "Point at x=50 should not be in left edge zone")
+        // Point at x=60 should NOT be in left edge (60 < 44 is false)
+        let outerPoint = CGPoint(x: 60, y: 50)
+        XCTAssertFalse(outerPoint.x < edgeSize, "Point at x=60 should not be in left edge zone")
     }
 
     func testRightEdgeDetection() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        // With 12% threshold, right edge is 88-100 pixels
+        // With 44pt threshold, right edge is x > 56 (100 - 44 = 56)
 
-        // Point at x=95 should be in right edge (95 > 88)
-        let rightEdgePoint = CGPoint(x: 95, y: 50)
-        let edgeSize = view.bounds.width * view.edgeThresholdPercent
-        XCTAssertTrue(rightEdgePoint.x > view.bounds.width - edgeSize, "Point at x=95 should be in right edge zone")
+        // Point at x=75 should be in right edge (75 > 56)
+        let rightEdgePoint = CGPoint(x: 75, y: 50)
+        let edgeSize = view.edgeThresholdPoints
+        XCTAssertTrue(rightEdgePoint.x > view.bounds.width - edgeSize, "Point at x=75 should be in right edge zone")
 
-        // Point at x=50 should NOT be in right edge (50 < 88)
-        let centerPoint = CGPoint(x: 50, y: 50)
-        XCTAssertFalse(centerPoint.x > view.bounds.width - edgeSize, "Point at x=50 should not be in right edge zone")
+        // Point at x=40 should NOT be in right edge (40 > 56 is false)
+        let outerPoint = CGPoint(x: 40, y: 50)
+        XCTAssertFalse(outerPoint.x > view.bounds.width - edgeSize, "Point at x=40 should not be in right edge zone")
     }
 
     func testCenterZoneNotInEdge() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        let edgeSize = view.bounds.width * view.edgeThresholdPercent
+        let edgeSize = view.edgeThresholdPoints
 
         // Point at x=50 (center) should not be in any edge
+        // Left edge: x < 44. Right edge: x > 56. x=50 is in neither.
         let centerPoint = CGPoint(x: 50, y: 50)
         let isInLeftEdge = centerPoint.x < edgeSize
         let isInRightEdge = centerPoint.x > view.bounds.width - edgeSize
@@ -89,7 +90,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.onLeftEdgeTap = { }
 
-        let leftEdgePoint = CGPoint(x: 5, y: 50)
+        let leftEdgePoint = CGPoint(x: 20, y: 50)
         XCTAssertEqual(view.hitTest(leftEdgePoint, with: nil), view, "Hit test should return self for left edge with callback")
     }
 
@@ -97,7 +98,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.onRightEdgeTap = { }
 
-        let rightEdgePoint = CGPoint(x: 95, y: 50)
+        let rightEdgePoint = CGPoint(x: 75, y: 50)
         XCTAssertEqual(view.hitTest(rightEdgePoint, with: nil), view, "Hit test should return self for right edge with callback")
     }
 
@@ -149,9 +150,9 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testExactlyOnLeftEdgeBoundary() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.onLeftEdgeTap = { }
-        let edgeSize = view.bounds.width * view.edgeThresholdPercent // 12
+        let edgeSize = view.edgeThresholdPoints // 44
 
-        // Point exactly at boundary (x=12) should NOT be in left edge (12 < 12 is false)
+        // Point exactly at boundary (x=44) should NOT be in left edge (44 < 44 is false)
         let boundaryPoint = CGPoint(x: edgeSize, y: 50)
         XCTAssertNil(view.hitTest(boundaryPoint, with: nil), "Point exactly at left boundary should not trigger")
     }
@@ -159,10 +160,10 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testExactlyOnRightEdgeBoundary() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.onRightEdgeTap = { }
-        let edgeSize = view.bounds.width * view.edgeThresholdPercent // 12
-        let rightBoundary = view.bounds.width - edgeSize // 88
+        let edgeSize = view.edgeThresholdPoints // 44
+        let rightBoundary = view.bounds.width - edgeSize // 56
 
-        // Point exactly at boundary (x=88) should NOT be in right edge (88 > 88 is false)
+        // Point exactly at boundary (x=56) should NOT be in right edge (56 > 56 is false)
         let boundaryPoint = CGPoint(x: rightBoundary, y: 50)
         XCTAssertNil(view.hitTest(boundaryPoint, with: nil), "Point exactly at right boundary should not trigger")
     }
@@ -174,9 +175,9 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
-        // With 12% threshold on 1000px width, left edge is 0-120, right edge is 880-1000
-        let leftEdgePoint = CGPoint(x: 60, y: 400)
-        let rightEdgePoint = CGPoint(x: 950, y: 400)
+        // With 44pt threshold on 1000px width, left edge is 0-44, right edge is 956-1000
+        let leftEdgePoint = CGPoint(x: 20, y: 400)
+        let rightEdgePoint = CGPoint(x: 975, y: 400)
         let centerPoint = CGPoint(x: 500, y: 400)
 
         XCTAssertEqual(view.hitTest(leftEdgePoint, with: nil), view, "Left edge detection should work on large view")
@@ -186,12 +187,13 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testEdgeDetectionWithSmallView() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        view.edgeThresholdPoints = 10.0  // Use a small threshold for this small view test
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
-        // With 12% threshold on 50px width, left edge is 0-6, right edge is 44-50
-        let leftEdgePoint = CGPoint(x: 3, y: 25)
-        let rightEdgePoint = CGPoint(x: 47, y: 25)
+        // With 10pt threshold on 50px width, left edge is 0-10, right edge is 40-50
+        let leftEdgePoint = CGPoint(x: 5, y: 25)
+        let rightEdgePoint = CGPoint(x: 45, y: 25)
         let centerPoint = CGPoint(x: 25, y: 25)
 
         XCTAssertEqual(view.hitTest(leftEdgePoint, with: nil), view, "Left edge detection should work on small view")
@@ -204,35 +206,105 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testEdgeThresholdAcceptsAnyValue() {
         // The view is a dumb component - clamping happens in reader views, not here
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        view.edgeThresholdPercent = 0.05
-        XCTAssertEqual(view.edgeThresholdPercent, 0.05, "View should accept values below 5% range")
+        view.edgeThresholdPoints = 20.0
+        XCTAssertEqual(view.edgeThresholdPoints, 20.0, "View should accept values below 44pt range")
 
-        view.edgeThresholdPercent = 0.50
-        XCTAssertEqual(view.edgeThresholdPercent, 0.50, "View should accept values above 30% range")
+        view.edgeThresholdPoints = 200.0
+        XCTAssertEqual(view.edgeThresholdPoints, 200.0, "View should accept values above 120pt range")
     }
 
-    func testDefaultThresholdGivesMinimum44ptOnSmallestDevice() {
-        // iPhone SE has 375pt width. 12% of 375 = 45pt, which is >= 44pt minimum tap target
+    func testDefaultThresholdIsExactly44Points() {
+        // Default is 44pt — the iOS HIG minimum tap target size
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
-        let edgeSize = view.bounds.width * view.edgeThresholdPercent
-        XCTAssertGreaterThanOrEqual(edgeSize, 44.0, "Default 12% threshold should give >= 44pt on iPhone SE (375pt width)")
+        XCTAssertEqual(view.edgeThresholdPoints, 44.0, "Default threshold should be exactly 44pt (iOS HIG minimum)")
     }
 
     func testCustomThresholdChangesEdgeZones() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        view.edgeThresholdPercent = 0.1 // 10% threshold
+        view.edgeThresholdPoints = 30.0  // 30pt threshold
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
-        // With 10% threshold, left edge is 0-10, right edge is 90-100
-        let leftEdgePoint = CGPoint(x: 5, y: 50)
-        let rightEdgePoint = CGPoint(x: 95, y: 50)
-        let outsideLeftEdge = CGPoint(x: 15, y: 50) // Would be in edge with 30%, but not with 10%
-        let outsideRightEdge = CGPoint(x: 85, y: 50) // Would be in edge with 30%, but not with 10%
+        // With 30pt threshold on 100px width, left edge is 0-30, right edge is 70-100
+        let leftEdgePoint = CGPoint(x: 15, y: 50)
+        let rightEdgePoint = CGPoint(x: 85, y: 50)
+        let outsideLeftEdge = CGPoint(x: 40, y: 50)   // Not in 30pt left edge
+        let outsideRightEdge = CGPoint(x: 60, y: 50)  // Not in 30pt right edge
 
-        XCTAssertEqual(view.hitTest(leftEdgePoint, with: nil), view, "Point in 10% left edge should trigger")
-        XCTAssertEqual(view.hitTest(rightEdgePoint, with: nil), view, "Point in 10% right edge should trigger")
-        XCTAssertNil(view.hitTest(outsideLeftEdge, with: nil), "Point outside 10% left edge should not trigger")
-        XCTAssertNil(view.hitTest(outsideRightEdge, with: nil), "Point outside 10% right edge should not trigger")
+        XCTAssertEqual(view.hitTest(leftEdgePoint, with: nil), view, "Point in 30pt left edge should trigger")
+        XCTAssertEqual(view.hitTest(rightEdgePoint, with: nil), view, "Point in 30pt right edge should trigger")
+        XCTAssertNil(view.hitTest(outsideLeftEdge, with: nil), "Point outside 30pt left edge should not trigger")
+        XCTAssertNil(view.hitTest(outsideRightEdge, with: nil), "Point outside 30pt right edge should not trigger")
+    }
+
+    // MARK: - Dynamic Threshold Update Tests
+
+    func testThresholdUpdateExpandsEdgeZone() {
+        // Simulates configureEdgeTapHandlers() updating edgeThresholdPoints at runtime
+        // (the behavior relied on by ReadiumReaderView and PdfReaderView after setPreferences)
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.onLeftEdgeTap = { }
+
+        // Default 44pt threshold: x=50 is outside left edge (50 >= 44)
+        XCTAssertNil(view.hitTest(CGPoint(x: 50, y: 50), with: nil), "x=50 should not be in left edge with 44pt threshold")
+
+        // Update threshold to 80pt
+        view.edgeThresholdPoints = 80.0
+
+        // Now x=50 IS inside left edge (50 < 80)
+        XCTAssertEqual(view.hitTest(CGPoint(x: 50, y: 50), with: nil), view, "x=50 should be in left edge after updating threshold to 80pt")
+    }
+
+    func testThresholdUpdateShrinksEdgeZone() {
+        // Verify that shrinking the threshold takes effect immediately
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.onLeftEdgeTap = { }
+        view.edgeThresholdPoints = 80.0
+
+        // With 80pt threshold: x=50 is in left edge (50 < 80)
+        XCTAssertEqual(view.hitTest(CGPoint(x: 50, y: 50), with: nil), view, "x=50 should be in left edge with 80pt threshold")
+
+        // Reduce threshold to 44pt
+        view.edgeThresholdPoints = 44.0
+
+        // Now x=50 is no longer in left edge (50 >= 44)
+        XCTAssertNil(view.hitTest(CGPoint(x: 50, y: 50), with: nil), "x=50 should not be in left edge after reducing threshold to 44pt")
+    }
+
+    func testThresholdUpdateAffectsBothEdgesSynchronously() {
+        // Verify both left and right edge zones update when threshold changes
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.onLeftEdgeTap = { }
+        view.onRightEdgeTap = { }
+
+        // Default 44pt: on 200px view, left=0-44, right=156-200. x=50 and x=150 are center.
+        XCTAssertNil(view.hitTest(CGPoint(x: 50, y: 50), with: nil), "x=50 should not trigger with 44pt threshold")
+        XCTAssertNil(view.hitTest(CGPoint(x: 150, y: 50), with: nil), "x=150 should not trigger with 44pt threshold")
+
+        // Update to 80pt: left=0-80, right=120-200
+        view.edgeThresholdPoints = 80.0
+
+        XCTAssertEqual(view.hitTest(CGPoint(x: 50, y: 50), with: nil), view, "x=50 should be in left edge after updating to 80pt")
+        XCTAssertEqual(view.hitTest(CGPoint(x: 150, y: 50), with: nil), view, "x=150 should be in right edge after updating to 80pt")
+    }
+
+    func testThresholdCanBeUpdatedMultipleTimes() {
+        // Verify multiple sequential updates all take effect (regression check for var mutation)
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.onLeftEdgeTap = { }
+
+        let testPoint = CGPoint(x: 60, y: 50)
+
+        view.edgeThresholdPoints = 44.0  // 60 >= 44 → not in edge
+        XCTAssertNil(view.hitTest(testPoint, with: nil), "x=60 not in left edge at 44pt")
+
+        view.edgeThresholdPoints = 80.0  // 60 < 80 → in edge
+        XCTAssertEqual(view.hitTest(testPoint, with: nil), view, "x=60 in left edge at 80pt")
+
+        view.edgeThresholdPoints = 50.0  // 60 >= 50 → not in edge
+        XCTAssertNil(view.hitTest(testPoint, with: nil), "x=60 not in left edge at 50pt")
+
+        view.edgeThresholdPoints = 70.0  // 60 < 70 → in edge
+        XCTAssertEqual(view.hitTest(testPoint, with: nil), view, "x=60 in left edge at 70pt")
     }
 }

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/ReadiumExtensionsMappingTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/ReadiumExtensionsMappingTests.swift
@@ -1,0 +1,201 @@
+//
+//  ReadiumExtensionsMappingTests.swift
+//  flureadiumTests
+//
+//  Tests that EPUBPreferences and PDFPreferences extensions only receive
+//  Readium-specific keys — never developer config keys.
+//  The filtering contract: ReadiumReaderView and PdfReaderView extract
+//  developer config keys before passing the remaining map to these inits.
+//
+
+import XCTest
+@testable import flureadium
+import ReadiumNavigator
+
+final class ReadiumExtensionsMappingTests: XCTestCase {
+
+    // MARK: - EPUBPreferences.init(fromMap:) — Readium key mapping
+
+    func testEPUBPreferencesFromMapMapsBackgroundColor() {
+        let map: [String: String] = ["backgroundColor": "#000000"]
+        let prefs = EPUBPreferences(fromMap: map)
+        XCTAssertNotNil(prefs.backgroundColor)
+    }
+
+    func testEPUBPreferencesFromMapMapsTextColor() {
+        let map: [String: String] = ["textColor": "#ffffff"]
+        let prefs = EPUBPreferences(fromMap: map)
+        XCTAssertNotNil(prefs.textColor)
+    }
+
+    func testEPUBPreferencesFromMapMapsFontSize() {
+        let map: [String: String] = ["fontSize": "1.5"]
+        let prefs = EPUBPreferences(fromMap: map)
+        XCTAssertEqual(prefs.fontSize, 1.5)
+    }
+
+    func testEPUBPreferencesFromMapMapsVerticalScroll() {
+        let map: [String: String] = ["verticalScroll": "true"]
+        let prefs = EPUBPreferences(fromMap: map)
+        XCTAssertEqual(prefs.scroll, true)
+    }
+
+    func testEPUBPreferencesFromMapMapsMultipleReadiumKeys() {
+        let map: [String: String] = [
+            "backgroundColor": "#1a1a1a",
+            "textColor": "#eeeeee",
+            "fontSize": "1.2",
+            "fontWeight": "0.8",
+            "verticalScroll": "false",
+        ]
+        let prefs = EPUBPreferences(fromMap: map)
+        XCTAssertNotNil(prefs.backgroundColor)
+        XCTAssertNotNil(prefs.textColor)
+        XCTAssertEqual(prefs.fontSize, 1.2)
+        XCTAssertEqual(prefs.fontWeight, 0.8)
+        XCTAssertEqual(prefs.scroll, false)
+    }
+
+    func testEPUBPreferencesFromMapEmptyMapProducesDefaultPrefs() {
+        let map: [String: String] = [:]
+        let prefs = EPUBPreferences(fromMap: map)
+        // All optional fields should remain nil when map is empty
+        XCTAssertNil(prefs.backgroundColor)
+        XCTAssertNil(prefs.textColor)
+        XCTAssertNil(prefs.fontSize)
+        XCTAssertNil(prefs.scroll)
+    }
+
+    // MARK: - EPUBPreferences developer config key separation
+
+    /// Verifies the contract: developer config keys must be filtered BEFORE calling
+    /// EPUBPreferences.init(fromMap:). A clean (filtered) map only contains Readium keys.
+    func testEPUBPreferencesFilteredMapContainsOnlyReadiumKeys() {
+        let developerConfigKeys: Set<String> = [
+            "enableEdgeTapNavigation",
+            "enableSwipeNavigation",
+            "edgeTapAreaPoints",
+        ]
+        let fullMap: [String: String] = [
+            "backgroundColor": "#000000",
+            "textColor": "#ffffff",
+            "fontSize": "1.0",
+            "enableEdgeTapNavigation": "true",
+            "enableSwipeNavigation": "true",
+            "edgeTapAreaPoints": "44.0",
+        ]
+
+        let filteredMap = fullMap.filter { !developerConfigKeys.contains($0.key) }
+
+        XCTAssertFalse(filteredMap.keys.contains("enableEdgeTapNavigation"))
+        XCTAssertFalse(filteredMap.keys.contains("enableSwipeNavigation"))
+        XCTAssertFalse(filteredMap.keys.contains("edgeTapAreaPoints"))
+        XCTAssertTrue(filteredMap.keys.contains("backgroundColor"))
+        XCTAssertTrue(filteredMap.keys.contains("textColor"))
+        XCTAssertTrue(filteredMap.keys.contains("fontSize"))
+    }
+
+    func testEPUBPreferencesFilteredMapMapsCorrectly() {
+        let developerConfigKeys: Set<String> = [
+            "enableEdgeTapNavigation",
+            "enableSwipeNavigation",
+            "edgeTapAreaPoints",
+        ]
+        let fullMap: [String: String] = [
+            "backgroundColor": "#000000",
+            "textColor": "#ffffff",
+            "fontSize": "1.0",
+            "enableEdgeTapNavigation": "true",
+            "enableSwipeNavigation": "false",
+            "edgeTapAreaPoints": "60.0",
+        ]
+
+        let filteredMap = fullMap.filter { !developerConfigKeys.contains($0.key) }
+        let prefs = EPUBPreferences(fromMap: filteredMap)
+
+        XCTAssertNotNil(prefs.backgroundColor)
+        XCTAssertNotNil(prefs.textColor)
+        XCTAssertEqual(prefs.fontSize, 1.0)
+    }
+
+    // MARK: - PDFPreferences developer config key separation
+
+    func testPDFPreferencesFilteredMapContainsOnlyReadiumKeys() {
+        let developerConfigKeys: Set<String> = [
+            "enableEdgeTapNavigation",
+            "enableSwipeNavigation",
+            "edgeTapAreaPoints",
+            "disableDoubleTapZoom",
+            "disableTextSelection",
+            "disableDragGestures",
+            "disableTextSelectionMenu",
+        ]
+        let fullMap: [String: Any] = [
+            "fit": "contain",
+            "scrollMode": "horizontal",
+            "backgroundColor": "#000000",
+            "enableEdgeTapNavigation": true,
+            "enableSwipeNavigation": true,
+            "edgeTapAreaPoints": 44.0,
+            "disableDoubleTapZoom": true,
+            "disableTextSelection": false,
+            "disableDragGestures": false,
+            "disableTextSelectionMenu": true,
+        ]
+
+        let filteredMap = fullMap.filter { !developerConfigKeys.contains($0.key) }
+
+        XCTAssertFalse(filteredMap.keys.contains("enableEdgeTapNavigation"))
+        XCTAssertFalse(filteredMap.keys.contains("enableSwipeNavigation"))
+        XCTAssertFalse(filteredMap.keys.contains("edgeTapAreaPoints"))
+        XCTAssertFalse(filteredMap.keys.contains("disableDoubleTapZoom"))
+        XCTAssertFalse(filteredMap.keys.contains("disableTextSelection"))
+        XCTAssertFalse(filteredMap.keys.contains("disableDragGestures"))
+        XCTAssertFalse(filteredMap.keys.contains("disableTextSelectionMenu"))
+        XCTAssertTrue(filteredMap.keys.contains("fit"))
+        XCTAssertTrue(filteredMap.keys.contains("scrollMode"))
+        XCTAssertTrue(filteredMap.keys.contains("backgroundColor"))
+    }
+
+    func testPDFPreferencesFilteredMapMapsCorrectly() {
+        let developerConfigKeys: Set<String> = [
+            "enableEdgeTapNavigation",
+            "enableSwipeNavigation",
+            "edgeTapAreaPoints",
+            "disableDoubleTapZoom",
+            "disableTextSelection",
+            "disableDragGestures",
+            "disableTextSelectionMenu",
+        ]
+        let fullMap: [String: Any] = [
+            "fit": "width",
+            "scrollMode": "vertical",
+            "enableEdgeTapNavigation": true,
+            "disableDoubleTapZoom": true,
+        ]
+
+        let filteredMap = fullMap.filter { !developerConfigKeys.contains($0.key) }
+        let prefs = PDFPreferences(fromMap: filteredMap)
+
+        XCTAssertEqual(prefs.scroll, true)
+        XCTAssertEqual(prefs.scrollAxis, .vertical)
+    }
+
+    // MARK: - Developer config key extraction
+
+    func testEnableEdgeTapNavigationExtractedFromFullMap() {
+        let fullMap: [String: String] = [
+            "backgroundColor": "#000000",
+            "enableEdgeTapNavigation": "false",
+        ]
+        let edgeTapEnabled = fullMap["enableEdgeTapNavigation"] != "false" ? true :
+            (fullMap["enableEdgeTapNavigation"] == nil ? true : false)
+        XCTAssertFalse(edgeTapEnabled)
+    }
+
+    func testEnableEdgeTapNavigationDefaultsTrueWhenAbsent() {
+        let fullMap: [String: String] = ["backgroundColor": "#000000"]
+        let edgeTapEnabled = fullMap["enableEdgeTapNavigation"].map { $0 != "false" } ?? true
+        XCTAssertTrue(edgeTapEnabled)
+    }
+}

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flureadium_platform_interface: ^0.3.0
+  flureadium_platform_interface: ^0.3.1
   rxdart: ^0.28.0
   wakelock_plus: ^1.2.8
   web: ^1.1.1

--- a/flureadium_platform_interface/CHANGELOG.md
+++ b/flureadium_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+- Add `edgeTapAreaPoints` to `EPUBPreferences` — configures the edge tap zone width in absolute points (44–120pt). iOS only. Defaults to 44pt (iOS HIG minimum tap target) when null.
+- Add `edgeTapAreaPoints` to `PDFPreferences` — same control for the PDF reader.
+
 ## 0.3.0
 
 - Add `renderFirstPage` method to `FlureadiumPlatform` and `MethodChannelFlureadium` — renders the first page of a PDF as a JPEG image for cover generation.

--- a/flureadium_platform_interface/lib/src/reader/reader_epub_preferences.dart
+++ b/flureadium_platform_interface/lib/src/reader/reader_epub_preferences.dart
@@ -14,6 +14,7 @@ class EPUBPreferences {
     this.pageMargins,
     this.enableEdgeTapNavigation,
     this.enableSwipeNavigation,
+    this.edgeTapAreaPercent,
   });
 
   factory EPUBPreferences.fromJsonMap(final Map<String, dynamic> map) =>
@@ -44,6 +45,10 @@ class EPUBPreferences {
   /// Defaults to true (enabled) when null.
   bool? enableSwipeNavigation;
 
+  /// Edge tap area as a percentage of screen width (10–30). iOS only.
+  /// Defaults to 12 when null.
+  double? edgeTapAreaPercent;
+
   // TODO: Add more preferences,
   //see https://github.com/readium/swift-toolkit/blob/develop/Sources/Navigator/EPUB/Preferences/EPUBPreferences.swift
 
@@ -64,6 +69,9 @@ class EPUBPreferences {
     }
     if (enableSwipeNavigation != null) {
       map['enableSwipeNavigation'] = enableSwipeNavigation.toString();
+    }
+    if (edgeTapAreaPercent != null) {
+      map['edgeTapAreaPercent'] = edgeTapAreaPercent.toString();
     }
     return map;
   }

--- a/flureadium_platform_interface/lib/src/reader/reader_epub_preferences.dart
+++ b/flureadium_platform_interface/lib/src/reader/reader_epub_preferences.dart
@@ -14,7 +14,7 @@ class EPUBPreferences {
     this.pageMargins,
     this.enableEdgeTapNavigation,
     this.enableSwipeNavigation,
-    this.edgeTapAreaPercent,
+    this.edgeTapAreaPoints,
   });
 
   factory EPUBPreferences.fromJsonMap(final Map<String, dynamic> map) =>
@@ -45,9 +45,9 @@ class EPUBPreferences {
   /// Defaults to true (enabled) when null.
   bool? enableSwipeNavigation;
 
-  /// Edge tap area as a percentage of screen width (5–30). iOS only.
-  /// Defaults to 12 when null.
-  double? edgeTapAreaPercent;
+  /// Edge tap area in absolute points (44–120). iOS only.
+  /// Defaults to 44pt (iOS HIG minimum tap target) when null.
+  double? edgeTapAreaPoints;
 
   // TODO: Add more preferences,
   //see https://github.com/readium/swift-toolkit/blob/develop/Sources/Navigator/EPUB/Preferences/EPUBPreferences.swift
@@ -70,8 +70,8 @@ class EPUBPreferences {
     if (enableSwipeNavigation != null) {
       map['enableSwipeNavigation'] = enableSwipeNavigation.toString();
     }
-    if (edgeTapAreaPercent != null) {
-      map['edgeTapAreaPercent'] = edgeTapAreaPercent.toString();
+    if (edgeTapAreaPoints != null) {
+      map['edgeTapAreaPoints'] = edgeTapAreaPoints.toString();
     }
     return map;
   }

--- a/flureadium_platform_interface/lib/src/reader/reader_epub_preferences.dart
+++ b/flureadium_platform_interface/lib/src/reader/reader_epub_preferences.dart
@@ -45,7 +45,7 @@ class EPUBPreferences {
   /// Defaults to true (enabled) when null.
   bool? enableSwipeNavigation;
 
-  /// Edge tap area as a percentage of screen width (10–30). iOS only.
+  /// Edge tap area as a percentage of screen width (5–30). iOS only.
   /// Defaults to 12 when null.
   double? edgeTapAreaPercent;
 

--- a/flureadium_platform_interface/lib/src/reader/reader_pdf_preferences.dart
+++ b/flureadium_platform_interface/lib/src/reader/reader_pdf_preferences.dart
@@ -19,6 +19,7 @@ class PDFPreferences {
     this.disableTextSelectionMenu,
     this.enableEdgeTapNavigation,
     this.enableSwipeNavigation,
+    this.edgeTapAreaPercent,
   });
 
   factory PDFPreferences.fromJsonMap(Map<String, dynamic> map) =>
@@ -39,6 +40,7 @@ class PDFPreferences {
         disableTextSelectionMenu: map['disableTextSelectionMenu'] as bool?,
         enableEdgeTapNavigation: map['enableEdgeTapNavigation'] as bool?,
         enableSwipeNavigation: map['enableSwipeNavigation'] as bool?,
+        edgeTapAreaPercent: (map['edgeTapAreaPercent'] as num?)?.toDouble(),
       );
 
   /// How the page fits in the viewport.
@@ -83,6 +85,10 @@ class PDFPreferences {
   /// Defaults to true (enabled) when null.
   bool? enableSwipeNavigation;
 
+  /// Edge tap area as a percentage of screen width (10–30). iOS only.
+  /// Defaults to 12 when null.
+  double? edgeTapAreaPercent;
+
   Map<String, dynamic> toJson() {
     final map = <String, dynamic>{};
     if (fit != null) map['fit'] = fit!.name;
@@ -107,6 +113,9 @@ class PDFPreferences {
     if (enableSwipeNavigation != null) {
       map['enableSwipeNavigation'] = enableSwipeNavigation;
     }
+    if (edgeTapAreaPercent != null) {
+      map['edgeTapAreaPercent'] = edgeTapAreaPercent;
+    }
     return map;
   }
 
@@ -121,6 +130,7 @@ class PDFPreferences {
     bool? disableTextSelectionMenu,
     bool? enableEdgeTapNavigation,
     bool? enableSwipeNavigation,
+    double? edgeTapAreaPercent,
   }) => PDFPreferences(
     fit: fit ?? this.fit,
     scrollMode: scrollMode ?? this.scrollMode,
@@ -134,6 +144,7 @@ class PDFPreferences {
     enableEdgeTapNavigation:
         enableEdgeTapNavigation ?? this.enableEdgeTapNavigation,
     enableSwipeNavigation: enableSwipeNavigation ?? this.enableSwipeNavigation,
+    edgeTapAreaPercent: edgeTapAreaPercent ?? this.edgeTapAreaPercent,
   );
 }
 

--- a/flureadium_platform_interface/lib/src/reader/reader_pdf_preferences.dart
+++ b/flureadium_platform_interface/lib/src/reader/reader_pdf_preferences.dart
@@ -85,7 +85,7 @@ class PDFPreferences {
   /// Defaults to true (enabled) when null.
   bool? enableSwipeNavigation;
 
-  /// Edge tap area as a percentage of screen width (10–30). iOS only.
+  /// Edge tap area as a percentage of screen width (5–30). iOS only.
   /// Defaults to 12 when null.
   double? edgeTapAreaPercent;
 

--- a/flureadium_platform_interface/lib/src/reader/reader_pdf_preferences.dart
+++ b/flureadium_platform_interface/lib/src/reader/reader_pdf_preferences.dart
@@ -19,7 +19,7 @@ class PDFPreferences {
     this.disableTextSelectionMenu,
     this.enableEdgeTapNavigation,
     this.enableSwipeNavigation,
-    this.edgeTapAreaPercent,
+    this.edgeTapAreaPoints,
   });
 
   factory PDFPreferences.fromJsonMap(Map<String, dynamic> map) =>
@@ -40,7 +40,7 @@ class PDFPreferences {
         disableTextSelectionMenu: map['disableTextSelectionMenu'] as bool?,
         enableEdgeTapNavigation: map['enableEdgeTapNavigation'] as bool?,
         enableSwipeNavigation: map['enableSwipeNavigation'] as bool?,
-        edgeTapAreaPercent: (map['edgeTapAreaPercent'] as num?)?.toDouble(),
+        edgeTapAreaPoints: (map['edgeTapAreaPoints'] as num?)?.toDouble(),
       );
 
   /// How the page fits in the viewport.
@@ -85,9 +85,9 @@ class PDFPreferences {
   /// Defaults to true (enabled) when null.
   bool? enableSwipeNavigation;
 
-  /// Edge tap area as a percentage of screen width (5–30). iOS only.
-  /// Defaults to 12 when null.
-  double? edgeTapAreaPercent;
+  /// Edge tap area in absolute points (44–120). iOS only.
+  /// Defaults to 44pt (iOS HIG minimum tap target) when null.
+  double? edgeTapAreaPoints;
 
   Map<String, dynamic> toJson() {
     final map = <String, dynamic>{};
@@ -113,8 +113,8 @@ class PDFPreferences {
     if (enableSwipeNavigation != null) {
       map['enableSwipeNavigation'] = enableSwipeNavigation;
     }
-    if (edgeTapAreaPercent != null) {
-      map['edgeTapAreaPercent'] = edgeTapAreaPercent;
+    if (edgeTapAreaPoints != null) {
+      map['edgeTapAreaPoints'] = edgeTapAreaPoints;
     }
     return map;
   }
@@ -130,7 +130,7 @@ class PDFPreferences {
     bool? disableTextSelectionMenu,
     bool? enableEdgeTapNavigation,
     bool? enableSwipeNavigation,
-    double? edgeTapAreaPercent,
+    double? edgeTapAreaPoints,
   }) => PDFPreferences(
     fit: fit ?? this.fit,
     scrollMode: scrollMode ?? this.scrollMode,
@@ -144,7 +144,7 @@ class PDFPreferences {
     enableEdgeTapNavigation:
         enableEdgeTapNavigation ?? this.enableEdgeTapNavigation,
     enableSwipeNavigation: enableSwipeNavigation ?? this.enableSwipeNavigation,
-    edgeTapAreaPercent: edgeTapAreaPercent ?? this.edgeTapAreaPercent,
+    edgeTapAreaPoints: edgeTapAreaPoints ?? this.edgeTapAreaPoints,
   );
 }
 

--- a/flureadium_platform_interface/pubspec.yaml
+++ b/flureadium_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium_platform_interface
 description: "Platform interface for Flureadium, providing shared models, exceptions, and the abstract FlureadiumPlatform class for EPUB, PDF, and audiobook reading."
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium_platform_interface/test/models/preferences_test.dart
+++ b/flureadium_platform_interface/test/models/preferences_test.dart
@@ -186,7 +186,7 @@ void main() {
       });
     });
 
-    group('edgeTapAreaPercent', () {
+    group('edgeTapAreaPoints', () {
       test('defaults to null', () {
         final prefs = EPUBPreferences(
           fontFamily: 'Arial',
@@ -196,7 +196,7 @@ void main() {
           backgroundColor: null,
           textColor: null,
         );
-        expect(prefs.edgeTapAreaPercent, isNull);
+        expect(prefs.edgeTapAreaPoints, isNull);
       });
 
       test('can be set via constructor', () {
@@ -207,9 +207,9 @@ void main() {
           verticalScroll: false,
           backgroundColor: null,
           textColor: null,
-          edgeTapAreaPercent: 15.0,
+          edgeTapAreaPoints: 60.0,
         );
-        expect(prefs.edgeTapAreaPercent, equals(15.0));
+        expect(prefs.edgeTapAreaPoints, equals(60.0));
       });
 
       test('serializes to JSON when set', () {
@@ -220,10 +220,10 @@ void main() {
           verticalScroll: false,
           backgroundColor: null,
           textColor: null,
-          edgeTapAreaPercent: 20.0,
+          edgeTapAreaPoints: 80.0,
         );
         final json = prefs.toJson();
-        expect(json['edgeTapAreaPercent'], equals('20.0'));
+        expect(json['edgeTapAreaPoints'], equals('80.0'));
       });
 
       test('not included in JSON when null', () {
@@ -236,7 +236,7 @@ void main() {
           textColor: null,
         );
         final json = prefs.toJson();
-        expect(json.containsKey('edgeTapAreaPercent'), isFalse);
+        expect(json.containsKey('edgeTapAreaPoints'), isFalse);
       });
 
       test('can be modified', () {
@@ -247,9 +247,9 @@ void main() {
           verticalScroll: false,
           backgroundColor: null,
           textColor: null,
-        )..edgeTapAreaPercent = 25.0;
+        )..edgeTapAreaPoints = 100.0;
 
-        expect(prefs.edgeTapAreaPercent, equals(25.0));
+        expect(prefs.edgeTapAreaPoints, equals(100.0));
       });
     });
 
@@ -628,7 +628,7 @@ void main() {
         expect(json.containsKey('disableTextSelection'), isFalse);
         expect(json.containsKey('enableEdgeTapNavigation'), isFalse);
         expect(json.containsKey('enableSwipeNavigation'), isFalse);
-        expect(json.containsKey('edgeTapAreaPercent'), isFalse);
+        expect(json.containsKey('edgeTapAreaPoints'), isFalse);
       });
 
       test('serializes disableDoubleTapZoom when set', () {

--- a/flureadium_platform_interface/test/models/preferences_test.dart
+++ b/flureadium_platform_interface/test/models/preferences_test.dart
@@ -186,6 +186,73 @@ void main() {
       });
     });
 
+    group('edgeTapAreaPercent', () {
+      test('defaults to null', () {
+        final prefs = EPUBPreferences(
+          fontFamily: 'Arial',
+          fontSize: 100,
+          fontWeight: 400.0,
+          verticalScroll: false,
+          backgroundColor: null,
+          textColor: null,
+        );
+        expect(prefs.edgeTapAreaPercent, isNull);
+      });
+
+      test('can be set via constructor', () {
+        final prefs = EPUBPreferences(
+          fontFamily: 'Arial',
+          fontSize: 100,
+          fontWeight: 400.0,
+          verticalScroll: false,
+          backgroundColor: null,
+          textColor: null,
+          edgeTapAreaPercent: 15.0,
+        );
+        expect(prefs.edgeTapAreaPercent, equals(15.0));
+      });
+
+      test('serializes to JSON when set', () {
+        final prefs = EPUBPreferences(
+          fontFamily: 'Arial',
+          fontSize: 100,
+          fontWeight: 400.0,
+          verticalScroll: false,
+          backgroundColor: null,
+          textColor: null,
+          edgeTapAreaPercent: 20.0,
+        );
+        final json = prefs.toJson();
+        expect(json['edgeTapAreaPercent'], equals('20.0'));
+      });
+
+      test('not included in JSON when null', () {
+        final prefs = EPUBPreferences(
+          fontFamily: 'Arial',
+          fontSize: 100,
+          fontWeight: 400.0,
+          verticalScroll: false,
+          backgroundColor: null,
+          textColor: null,
+        );
+        final json = prefs.toJson();
+        expect(json.containsKey('edgeTapAreaPercent'), isFalse);
+      });
+
+      test('can be modified', () {
+        final prefs = EPUBPreferences(
+          fontFamily: 'Arial',
+          fontSize: 100,
+          fontWeight: 400.0,
+          verticalScroll: false,
+          backgroundColor: null,
+          textColor: null,
+        )..edgeTapAreaPercent = 25.0;
+
+        expect(prefs.edgeTapAreaPercent, equals(25.0));
+      });
+    });
+
     group('enableSwipeNavigation', () {
       test('defaults to null', () {
         final prefs = EPUBPreferences(
@@ -561,6 +628,7 @@ void main() {
         expect(json.containsKey('disableTextSelection'), isFalse);
         expect(json.containsKey('enableEdgeTapNavigation'), isFalse);
         expect(json.containsKey('enableSwipeNavigation'), isFalse);
+        expect(json.containsKey('edgeTapAreaPercent'), isFalse);
       });
 
       test('serializes disableDoubleTapZoom when set', () {

--- a/flureadium_platform_interface/test/reader/reader_pdf_preferences_test.dart
+++ b/flureadium_platform_interface/test/reader/reader_pdf_preferences_test.dart
@@ -82,6 +82,54 @@ void main() {
       });
     });
 
+    group('edgeTapAreaPercent', () {
+      test('defaults to null', () {
+        final prefs = PDFPreferences();
+        expect(prefs.edgeTapAreaPercent, isNull);
+      });
+
+      test('can be set via constructor', () {
+        final prefs = PDFPreferences(edgeTapAreaPercent: 15.0);
+        expect(prefs.edgeTapAreaPercent, equals(15.0));
+      });
+
+      test('serializes correctly', () {
+        final prefs = PDFPreferences(edgeTapAreaPercent: 20.0);
+        final json = prefs.toJson();
+        expect(json['edgeTapAreaPercent'], equals(20.0));
+      });
+
+      test('not included when null', () {
+        final prefs = PDFPreferences();
+        final json = prefs.toJson();
+        expect(json.containsKey('edgeTapAreaPercent'), false);
+      });
+
+      test('fromJsonMap parses edgeTapAreaPercent', () {
+        final json = {'edgeTapAreaPercent': 18.0};
+        final prefs = PDFPreferences.fromJsonMap(json);
+        expect(prefs.edgeTapAreaPercent, equals(18.0));
+      });
+
+      test('fromJsonMap parses edgeTapAreaPercent from int', () {
+        final json = {'edgeTapAreaPercent': 15};
+        final prefs = PDFPreferences.fromJsonMap(json);
+        expect(prefs.edgeTapAreaPercent, equals(15.0));
+      });
+
+      test('copyWith preserves edgeTapAreaPercent', () {
+        final prefs1 = PDFPreferences(edgeTapAreaPercent: 20.0);
+        final prefs2 = prefs1.copyWith();
+        expect(prefs2.edgeTapAreaPercent, equals(20.0));
+      });
+
+      test('copyWith can override edgeTapAreaPercent', () {
+        final prefs1 = PDFPreferences(edgeTapAreaPercent: 20.0);
+        final prefs2 = prefs1.copyWith(edgeTapAreaPercent: 10.0);
+        expect(prefs2.edgeTapAreaPercent, equals(10.0));
+      });
+    });
+
     group('enableSwipeNavigation', () {
       test('defaults to null', () {
         final prefs = PDFPreferences();

--- a/flureadium_platform_interface/test/reader/reader_pdf_preferences_test.dart
+++ b/flureadium_platform_interface/test/reader/reader_pdf_preferences_test.dart
@@ -82,51 +82,51 @@ void main() {
       });
     });
 
-    group('edgeTapAreaPercent', () {
+    group('edgeTapAreaPoints', () {
       test('defaults to null', () {
         final prefs = PDFPreferences();
-        expect(prefs.edgeTapAreaPercent, isNull);
+        expect(prefs.edgeTapAreaPoints, isNull);
       });
 
       test('can be set via constructor', () {
-        final prefs = PDFPreferences(edgeTapAreaPercent: 15.0);
-        expect(prefs.edgeTapAreaPercent, equals(15.0));
+        final prefs = PDFPreferences(edgeTapAreaPoints: 60.0);
+        expect(prefs.edgeTapAreaPoints, equals(60.0));
       });
 
       test('serializes correctly', () {
-        final prefs = PDFPreferences(edgeTapAreaPercent: 20.0);
+        final prefs = PDFPreferences(edgeTapAreaPoints: 80.0);
         final json = prefs.toJson();
-        expect(json['edgeTapAreaPercent'], equals(20.0));
+        expect(json['edgeTapAreaPoints'], equals(80.0));
       });
 
       test('not included when null', () {
         final prefs = PDFPreferences();
         final json = prefs.toJson();
-        expect(json.containsKey('edgeTapAreaPercent'), false);
+        expect(json.containsKey('edgeTapAreaPoints'), false);
       });
 
-      test('fromJsonMap parses edgeTapAreaPercent', () {
-        final json = {'edgeTapAreaPercent': 18.0};
+      test('fromJsonMap parses edgeTapAreaPoints', () {
+        final json = {'edgeTapAreaPoints': 72.0};
         final prefs = PDFPreferences.fromJsonMap(json);
-        expect(prefs.edgeTapAreaPercent, equals(18.0));
+        expect(prefs.edgeTapAreaPoints, equals(72.0));
       });
 
-      test('fromJsonMap parses edgeTapAreaPercent from int', () {
-        final json = {'edgeTapAreaPercent': 15};
+      test('fromJsonMap parses edgeTapAreaPoints from int', () {
+        final json = {'edgeTapAreaPoints': 60};
         final prefs = PDFPreferences.fromJsonMap(json);
-        expect(prefs.edgeTapAreaPercent, equals(15.0));
+        expect(prefs.edgeTapAreaPoints, equals(60.0));
       });
 
-      test('copyWith preserves edgeTapAreaPercent', () {
-        final prefs1 = PDFPreferences(edgeTapAreaPercent: 20.0);
+      test('copyWith preserves edgeTapAreaPoints', () {
+        final prefs1 = PDFPreferences(edgeTapAreaPoints: 80.0);
         final prefs2 = prefs1.copyWith();
-        expect(prefs2.edgeTapAreaPercent, equals(20.0));
+        expect(prefs2.edgeTapAreaPoints, equals(80.0));
       });
 
-      test('copyWith can override edgeTapAreaPercent', () {
-        final prefs1 = PDFPreferences(edgeTapAreaPercent: 20.0);
-        final prefs2 = prefs1.copyWith(edgeTapAreaPercent: 10.0);
-        expect(prefs2.edgeTapAreaPercent, equals(10.0));
+      test('copyWith can override edgeTapAreaPoints', () {
+        final prefs1 = PDFPreferences(edgeTapAreaPoints: 80.0);
+        final prefs2 = prefs1.copyWith(edgeTapAreaPoints: 44.0);
+        expect(prefs2.edgeTapAreaPoints, equals(44.0));
       });
     });
 


### PR DESCRIPTION
## Summary

- Add `edgeTapAreaPoints` to `EPUBPreferences` and `PDFPreferences` — configures the iOS edge tap zone width in absolute points (44–120pt), replacing the previous percentage-based approach. Behaves consistently across all device sizes and split-screen modes.
- Fix spurious `"EPUBPreferences WARN: Cannot map property"` warnings by filtering developer config keys (`enableEdgeTapNavigation`, `enableSwipeNavigation`, `edgeTapAreaPoints`) out of the preference map before forwarding to Readium's `EPUBPreferences.init(fromMap:)` and `PDFPreferences.init(fromMap:)`. Filtering applied at both the `init` (creationParams) and `setPreferences` call sites.
- Fix potential nil crash in `getCurrentLocator` async task when `currentLocation` returns nil.

## Version bumps

- `flureadium_platform_interface`: `0.3.0` → `0.3.1`
- `flureadium`: `0.3.2` → `0.3.3` (requires `flureadium_platform_interface ^0.3.1`)

## Test plan

- [ ] Open an EPUB in dark mode — verify no theme flash on first open
- [ ] Verify no `"Cannot map property"` warnings in the console
- [ ] Verify edge tap navigation works with the default 44pt zone
- [ ] Set `edgeTapAreaPoints: 80` and verify wider tap zones
- [ ] Open a PDF — verify same developer config key filtering (no warnings)
- [ ] Run `flutter test` in `flureadium/` — all tests pass
- [ ] Run `dart pub publish --dry-run` in both packages — no errors