### PR TITLE
fix(ios): prevent MissingPluginException on event channel cancel after dispose

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.4
+
+### Bug Fixes
+
+- **iOS**: Fix `MissingPluginException` on channel `dev.mulev.flureadium/text-locator` (and sibling event channels) when closing a publication.
+  - Root cause: `EventStreamHandler.dispose()` was calling `channel.setStreamHandler(nil)` synchronously after sending `FlutterEndOfEventStream`. Flutter's answering "cancel" message arrived after the handler was already gone, producing the exception.
+  - Fix: Remove the premature `setStreamHandler(nil)` call. The handler remains registered until the "cancel" round-trip completes; `onCancel` then clears the event sink. The handler is released naturally when the view is deallocated.
+
 ## 0.3.3
 
 ### New Features

--- a/flureadium/ios/flureadium/Sources/flureadium/utils/EventStreamHandler.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/utils/EventStreamHandler.swift
@@ -26,10 +26,14 @@ class EventStreamHandler: NSObject, FlutterStreamHandler {
 
   func dispose() {
     print(TAG, "dispose")
-    // End stream and clear the event-sink to prevent memory leaks.
+    // Send end-of-stream so Flutter closes its subscription, then clear the
+    // local sink so further sendEvent calls are no-ops.
+    // Do NOT call channel.setStreamHandler(nil) here: that unregisters the
+    // handler synchronously, but Flutter still needs to complete the "cancel"
+    // round-trip. Removing the handler before that arrives causes a
+    // MissingPluginException on the Dart side.
     eventSink?(FlutterEndOfEventStream)
     eventSink = nil
-    channel.setStreamHandler(nil)
   }
 
   init(withName streamName: String, messenger: FlutterBinaryMessenger) {

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.3.3
+version: 0.3.4
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- `EventStreamHandler.dispose()` was calling `channel.setStreamHandler(nil)` synchronously right after sending `FlutterEndOfEventStream`
- Flutter's answering `"cancel"` message arrived after the handler was already gone, producing `MissingPluginException(No implementation found for method cancel on channel dev.mulev.flureadium/text-locator)`
- Fix: remove the premature `setStreamHandler(nil)` call — the handler stays registered until Flutter completes the cancel round-trip, then `onCancel` clears the event sink, and the handler is released naturally when the view is deallocated
- Affects all three event channels: `text-locator`, `reader-status`, `error`
- Bumps to `0.3.4`

## Test plan

- [x] Open a book and read for a few pages
- [x] Close the reader — no `MissingPluginException` in the console
- [x] Reopen the book — reader initialises and text-locator stream works normally
- [x] Repeat on a fresh cold start
- [x] Existing `EventStreamHandlerTests` pass (dispose lifecycle, double-dispose safety, send-after-dispose no-op)