### PR TITLE
fix(ios/pdf): disable double-tap word selection; rename preference to disableDoubleTapTextSelection

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.4.0
+
+### Breaking Changes
+
+- **iOS / PDFPreferences**: Rename `disableTextSelectionMenu` to `disableDoubleTapTextSelection`.
+  Requires `flureadium_platform_interface` ^0.4.0.
+
+### New Features
+
+- **iOS / PDF**: Fix double-tap word selection in PDF reader. Double-tapping on PDF text no longer
+  selects the word or shows the Copy/Look Up/Translate menu. Only the reader overlay controls toggle.
+  Long-press text selection with the system menu remains fully functional, matching ePub behavior.
+  - Root cause: `UITextNonEditableInteraction.doubleTapInUneditable:` on the lazily-created
+    `PDFTextInputView` was intercepting double taps. Previous attempts failed because `PDFTextInputView`
+    does not exist at `setupPDFView` time — it is added asynchronously after page rendering.
+  - Fix: Deferred traversal (0.1s / 0.5s / 1.0s after `setupPDFView` and each `locationDidChange`)
+    finds `PDFTextInputView` and removes `UITextNonEditableInteraction` from it.
+
 ## 0.3.4
 
 ### Bug Fixes

--- a/flureadium/docs/api-reference/preferences.md
+++ b/flureadium/docs/api-reference/preferences.md
@@ -435,8 +435,8 @@ PDFPreferences({
   bool? disableDoubleTapZoom,      // iOS only
   bool? disableTextSelection,      // iOS only
   bool? disableDragGestures,       // iOS only
-  bool? disableTextSelectionMenu,  // iOS only
-  bool? enableEdgeTapNavigation,   // iOS only
+  bool? disableDoubleTapTextSelection,  // iOS only
+  bool? enableEdgeTapNavigation,        // iOS only
   bool? enableSwipeNavigation,     // iOS only
   double? edgeTapAreaPoints,       // iOS only
 })
@@ -522,15 +522,15 @@ disableDragGestures: false  // Drag gestures enabled (default)
 disableDragGestures: true   // Drag gestures disabled
 ```
 
-#### disableTextSelectionMenu (iOS only)
+#### disableDoubleTapTextSelection (iOS only)
 
 **Type:** `bool?`
 
-Whether to disable the text selection menu. When true, the Copy/Look Up/Translate menu won't appear when text is selected.
+Whether to disable double-tap word selection in PDF text. When true, double-tapping on PDF text won't select a word or show the Copy/Look Up/Translate menu. Long-press text selection and the Look Up/Translate/Search Web menu remain fully functional, matching ePub behavior.
 
 ```dart
-disableTextSelectionMenu: false  // Selection menu enabled (default)
-disableTextSelectionMenu: true   // Selection menu disabled
+disableDoubleTapTextSelection: false  // Double-tap selection enabled (default)
+disableDoubleTapTextSelection: true   // Double-tap selection disabled
 ```
 
 #### enableEdgeTapNavigation (iOS only — developer config)
@@ -605,7 +605,7 @@ PDFPreferences copyWith({
   bool? disableDoubleTapZoom,
   bool? disableTextSelection,
   bool? disableDragGestures,
-  bool? disableTextSelectionMenu,
+  bool? disableDoubleTapTextSelection,
   bool? enableEdgeTapNavigation,
   bool? enableSwipeNavigation,
   double? edgeTapAreaPoints,
@@ -650,7 +650,7 @@ final readOnlyPrefs = PDFPreferences(
   disableDoubleTapZoom: true,
   disableTextSelection: true,
   disableDragGestures: true,
-  disableTextSelectionMenu: true,
+  disableDoubleTapTextSelection: true,
 );
 ```
 

--- a/flureadium/docs/guides/preferences.md
+++ b/flureadium/docs/guides/preferences.md
@@ -575,7 +575,7 @@ PDFPreferences(
   disableDoubleTapZoom: true,      // Disable double-tap to zoom
   disableTextSelection: true,       // Disable long-press text selection
   disableDragGestures: true,        // Disable drag gestures
-  disableTextSelectionMenu: true,   // Disable Copy/Translate menu
+  disableDoubleTapTextSelection: true,  // Disable double-tap word selection
 )
 ```
 

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -31,7 +31,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
   private var disableDoubleTapZoom: Bool
   private var disableTextSelection: Bool
   private var disableDragGestures: Bool
-  private var disableTextSelectionMenu: Bool
+  private var disableDoubleTapTextSelection: Bool
   private var enableEdgeTapNavigation: Bool
   private var enableSwipeNavigation: Bool
   private var edgeTapAreaPoints: CGFloat?
@@ -46,7 +46,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     "disableDoubleTapZoom",
     "disableTextSelection",
     "disableDragGestures",
-    "disableTextSelectionMenu",
+    "disableDoubleTapTextSelection",
   ]
 
   var publicationIdentifier: String?
@@ -89,7 +89,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     disableDoubleTapZoom = flutterPrefs.disableDoubleTapZoom ?? false
     disableTextSelection = flutterPrefs.disableTextSelection ?? false
     disableDragGestures = flutterPrefs.disableDragGestures ?? false
-    disableTextSelectionMenu = flutterPrefs.disableTextSelectionMenu ?? false
+    disableDoubleTapTextSelection = flutterPrefs.disableDoubleTapTextSelection ?? false
     enableEdgeTapNavigation = flutterPrefs.enableEdgeTapNavigation ?? true
     enableSwipeNavigation = flutterPrefs.enableSwipeNavigation ?? true
     if let rawPoints = flutterPrefs.edgeTapAreaPoints {
@@ -97,7 +97,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     } else {
       edgeTapAreaPoints = nil
     }
-    print(TAG, "PDF Preferences - disableDoubleTapZoom: \(disableDoubleTapZoom), disableTextSelection: \(disableTextSelection), disableDragGestures: \(disableDragGestures), disableTextSelectionMenu: \(disableTextSelectionMenu), enableEdgeTapNavigation: \(enableEdgeTapNavigation), enableSwipeNavigation: \(enableSwipeNavigation)")
+    print(TAG, "PDF Preferences - disableDoubleTapZoom: \(disableDoubleTapZoom), disableTextSelection: \(disableTextSelection), disableDragGestures: \(disableDragGestures), disableDoubleTapTextSelection: \(disableDoubleTapTextSelection), enableEdgeTapNavigation: \(enableEdgeTapNavigation), enableSwipeNavigation: \(enableSwipeNavigation)")
 
     let locatorStr = creationParams["initialLocator"] as? String
     let locator = locatorStr == nil ? nil : try! Locator.init(jsonString: locatorStr!)
@@ -182,6 +182,9 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
       self.readerStatusStreamHandler?.sendEvent(PdfReaderStatusReady)
       hasSentReady = true
     }
+    if disableDoubleTapTextSelection {
+      scheduleDisableDoubleTapWordSelection()
+    }
     emitOnPageChanged(locator: locator)
   }
 
@@ -196,7 +199,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
   // MARK: - PDFNavigatorDelegate
 
   func navigator(_ navigator: PDFNavigatorViewController, setupPDFView view: PDFDocumentView) {
-    print(TAG, "setupPDFView called - disableDoubleTapZoom: \(disableDoubleTapZoom), disableTextSelection: \(disableTextSelection), disableDragGestures: \(disableDragGestures), disableTextSelectionMenu: \(disableTextSelectionMenu)")
+    print(TAG, "setupPDFView called - disableDoubleTapZoom: \(disableDoubleTapZoom), disableTextSelection: \(disableTextSelection), disableDragGestures: \(disableDragGestures), disableDoubleTapTextSelection: \(disableDoubleTapTextSelection)")
 
     if disableDoubleTapZoom {
       print(TAG, "Calling disableDoubleTapZoomGesture...")
@@ -208,9 +211,10 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
       disableTextSelectionGesture(in: view)
     }
 
-    if disableTextSelectionMenu {
-      print(TAG, "Calling disableTextSelectionMenu...")
-      disableTextSelectionMenu(in: view)
+    if disableDoubleTapTextSelection {
+      print(TAG, "Calling removeEditMenuInteractions...")
+      removeEditMenuInteractions(in: view)
+      scheduleDisableDoubleTapWordSelection()
     }
 
     if disableDragGestures {
@@ -359,8 +363,8 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     }
   }
 
-  private func disableTextSelectionMenu(in view: UIView) {
-    print(TAG, "disableTextSelectionMenu: Checking interactions on \(type(of: view))")
+  private func removeEditMenuInteractions(in view: UIView) {
+    print(TAG, "removeEditMenuInteractions: Checking interactions on \(type(of: view))")
 
     // Remove text selection and editing menu interactions (iOS 13+)
     if #available(iOS 13.0, *) {
@@ -383,7 +387,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
 
     // Recursively disable on all subviews
     for subview in view.subviews {
-      disableTextSelectionMenu(in: subview)
+      removeEditMenuInteractions(in: subview)
     }
   }
 
@@ -408,6 +412,44 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
       await MainActor.run() {
         self.channel.onExternalLinkActivated(url: url)
       }
+    }
+  }
+
+  // MARK: - Double-Tap Word Selection
+
+  /// Schedules repeated attempts to find PDFTextInputView and remove UITextNonEditableInteraction.
+  /// PDFTextInputView is added asynchronously after page rendering, so a single deferred attempt
+  /// is not sufficient — we retry at 0.1s, 0.5s, and 1.0s after the call.
+  private func scheduleDisableDoubleTapWordSelection() {
+    for delay in [0.1, 0.5, 1.0] {
+      DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        guard let self = self else { return }
+        self.disableDoubleTapWordSelection(in: self.pdfViewController.view)
+      }
+    }
+  }
+
+  /// Recursively searches the view tree for PDFTextInputView and removes
+  /// UITextNonEditableInteraction — the interaction responsible for double-tap
+  /// word selection. Long-press selection lives in UITextRefinementInteraction
+  /// and is unaffected.
+  private func disableDoubleTapWordSelection(in view: UIView) {
+    let className = String(describing: type(of: view))
+    if className == "PDFTextInputView" {
+      var removed = 0
+      for interaction in view.interactions {
+        if String(describing: type(of: interaction)) == "UITextNonEditableInteraction" {
+          view.removeInteraction(interaction)
+          removed += 1
+        }
+      }
+      if removed > 0 {
+        print(TAG, "disableDoubleTapWordSelection: removed \(removed) UITextNonEditableInteraction(s) from PDFTextInputView")
+      }
+      return
+    }
+    for subview in view.subviews {
+      disableDoubleTapWordSelection(in: subview)
     }
   }
 
@@ -461,7 +503,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
       disableDoubleTapZoom = flutterPrefs.disableDoubleTapZoom ?? disableDoubleTapZoom
       disableTextSelection = flutterPrefs.disableTextSelection ?? disableTextSelection
       disableDragGestures = flutterPrefs.disableDragGestures ?? disableDragGestures
-      disableTextSelectionMenu = flutterPrefs.disableTextSelectionMenu ?? disableTextSelectionMenu
+      disableDoubleTapTextSelection = flutterPrefs.disableDoubleTapTextSelection ?? disableDoubleTapTextSelection
       if let pts = flutterPrefs.edgeTapAreaPoints {
         edgeTapAreaPoints = CGFloat(min(max(pts, 44.0), 120.0))
       }

--- a/flureadium/ios/flureadium/Sources/flureadium/model/FlutterPdfPreferences.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/model/FlutterPdfPreferences.swift
@@ -111,10 +111,11 @@ public struct FlutterPdfPreferences {
     /// Defaults to false (drag gestures enabled).
     var disableDragGestures: Bool?
 
-    /// Whether to disable the text selection menu (iOS only).
-    /// When true, the Copy/Look Up/Translate menu won't appear when text is selected.
-    /// Defaults to false (selection menu enabled).
-    var disableTextSelectionMenu: Bool?
+    /// Whether to disable double-tap word selection in PDF text (iOS only).
+    /// When true, double-tapping on PDF text won't select a word or show the
+    /// Copy/Look Up/Translate menu. Long-press text selection remains functional.
+    /// Defaults to false (double-tap selection enabled).
+    var disableDoubleTapTextSelection: Bool?
 
     /// Whether edge tap navigation is enabled (iOS only).
     /// When true, tapping on the left/right edges of the screen navigates pages.
@@ -139,7 +140,7 @@ public struct FlutterPdfPreferences {
         disableDoubleTapZoom: Bool? = nil,
         disableTextSelection: Bool? = nil,
         disableDragGestures: Bool? = nil,
-        disableTextSelectionMenu: Bool? = nil,
+        disableDoubleTapTextSelection: Bool? = nil,
         enableEdgeTapNavigation: Bool? = nil,
         enableSwipeNavigation: Bool? = nil,
         edgeTapAreaPoints: Double? = nil
@@ -151,7 +152,7 @@ public struct FlutterPdfPreferences {
         self.disableDoubleTapZoom = disableDoubleTapZoom
         self.disableTextSelection = disableTextSelection
         self.disableDragGestures = disableDragGestures
-        self.disableTextSelectionMenu = disableTextSelectionMenu
+        self.disableDoubleTapTextSelection = disableDoubleTapTextSelection
         self.enableEdgeTapNavigation = enableEdgeTapNavigation
         self.enableSwipeNavigation = enableSwipeNavigation
         self.edgeTapAreaPoints = edgeTapAreaPoints
@@ -172,7 +173,7 @@ public struct FlutterPdfPreferences {
             disableDoubleTapZoom: map["disableDoubleTapZoom"] as? Bool,
             disableTextSelection: map["disableTextSelection"] as? Bool,
             disableDragGestures: map["disableDragGestures"] as? Bool,
-            disableTextSelectionMenu: map["disableTextSelectionMenu"] as? Bool,
+            disableDoubleTapTextSelection: map["disableDoubleTapTextSelection"] as? Bool,
             enableEdgeTapNavigation: map["enableEdgeTapNavigation"] as? Bool,
             enableSwipeNavigation: map["enableSwipeNavigation"] as? Bool,
             edgeTapAreaPoints: map["edgeTapAreaPoints"] as? Double
@@ -222,8 +223,8 @@ public struct FlutterPdfPreferences {
         if let disableDragGestures = disableDragGestures {
             map["disableDragGestures"] = disableDragGestures
         }
-        if let disableTextSelectionMenu = disableTextSelectionMenu {
-            map["disableTextSelectionMenu"] = disableTextSelectionMenu
+        if let disableDoubleTapTextSelection = disableDoubleTapTextSelection {
+            map["disableDoubleTapTextSelection"] = disableDoubleTapTextSelection
         }
         if let enableEdgeTapNavigation = enableEdgeTapNavigation {
             map["enableEdgeTapNavigation"] = enableEdgeTapNavigation

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/FlutterPdfPreferencesTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/FlutterPdfPreferencesTests.swift
@@ -201,33 +201,33 @@ final class FlutterPdfPreferencesTests: XCTestCase {
         XCTAssertTrue(map.isEmpty)
     }
 
-    // MARK: - disableTextSelectionMenu Tests
+    // MARK: - disableDoubleTapTextSelection Tests
 
-    func testDisableTextSelectionMenu() {
-        let preferences = FlutterPdfPreferences(disableTextSelectionMenu: true)
-        XCTAssertEqual(preferences.disableTextSelectionMenu, true)
+    func testDisableDoubleTapTextSelection() {
+        let preferences = FlutterPdfPreferences(disableDoubleTapTextSelection: true)
+        XCTAssertEqual(preferences.disableDoubleTapTextSelection, true)
     }
 
-    func testDisableTextSelectionMenuFromMap() {
-        let map: [String: Any] = ["disableTextSelectionMenu": true]
+    func testDisableDoubleTapTextSelectionFromMap() {
+        let map: [String: Any] = ["disableDoubleTapTextSelection": true]
         let preferences = FlutterPdfPreferences(fromMap: map)
-        XCTAssertEqual(preferences.disableTextSelectionMenu, true)
+        XCTAssertEqual(preferences.disableDoubleTapTextSelection, true)
     }
 
-    func testDisableTextSelectionMenuToMap() {
-        let preferences = FlutterPdfPreferences(disableTextSelectionMenu: true)
+    func testDisableDoubleTapTextSelectionToMap() {
+        let preferences = FlutterPdfPreferences(disableDoubleTapTextSelection: true)
         let map = preferences.toMap()
-        XCTAssertEqual(map["disableTextSelectionMenu"] as? Bool, true)
+        XCTAssertEqual(map["disableDoubleTapTextSelection"] as? Bool, true)
     }
 
-    func testDisableTextSelectionMenuDefaultsToNil() {
+    func testDisableDoubleTapTextSelectionDefaultsToNil() {
         let preferences = FlutterPdfPreferences()
-        XCTAssertNil(preferences.disableTextSelectionMenu)
+        XCTAssertNil(preferences.disableDoubleTapTextSelection)
     }
 
-    func testDisableTextSelectionMenuNotInMapWhenNil() {
+    func testDisableDoubleTapTextSelectionNotInMapWhenNil() {
         let preferences = FlutterPdfPreferences()
         let map = preferences.toMap()
-        XCTAssertNil(map["disableTextSelectionMenu"])
+        XCTAssertNil(map["disableDoubleTapTextSelection"])
     }
 }

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/ReadiumExtensionsMappingTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/ReadiumExtensionsMappingTests.swift
@@ -128,7 +128,7 @@ final class ReadiumExtensionsMappingTests: XCTestCase {
             "disableDoubleTapZoom",
             "disableTextSelection",
             "disableDragGestures",
-            "disableTextSelectionMenu",
+            "disableDoubleTapTextSelection",
         ]
         let fullMap: [String: Any] = [
             "fit": "contain",
@@ -140,7 +140,7 @@ final class ReadiumExtensionsMappingTests: XCTestCase {
             "disableDoubleTapZoom": true,
             "disableTextSelection": false,
             "disableDragGestures": false,
-            "disableTextSelectionMenu": true,
+            "disableDoubleTapTextSelection": true,
         ]
 
         let filteredMap = fullMap.filter { !developerConfigKeys.contains($0.key) }
@@ -151,7 +151,7 @@ final class ReadiumExtensionsMappingTests: XCTestCase {
         XCTAssertFalse(filteredMap.keys.contains("disableDoubleTapZoom"))
         XCTAssertFalse(filteredMap.keys.contains("disableTextSelection"))
         XCTAssertFalse(filteredMap.keys.contains("disableDragGestures"))
-        XCTAssertFalse(filteredMap.keys.contains("disableTextSelectionMenu"))
+        XCTAssertFalse(filteredMap.keys.contains("disableDoubleTapTextSelection"))
         XCTAssertTrue(filteredMap.keys.contains("fit"))
         XCTAssertTrue(filteredMap.keys.contains("scrollMode"))
         XCTAssertTrue(filteredMap.keys.contains("backgroundColor"))
@@ -165,7 +165,7 @@ final class ReadiumExtensionsMappingTests: XCTestCase {
             "disableDoubleTapZoom",
             "disableTextSelection",
             "disableDragGestures",
-            "disableTextSelectionMenu",
+            "disableDoubleTapTextSelection",
         ]
         let fullMap: [String: Any] = [
             "fit": "width",

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.3.4
+version: 0.4.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flureadium_platform_interface: ^0.3.1
+  flureadium_platform_interface: ^0.4.0
   rxdart: ^0.28.0
   wakelock_plus: ^1.2.8
   web: ^1.1.1

--- a/flureadium_platform_interface/CHANGELOG.md
+++ b/flureadium_platform_interface/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.4.0
+
+### Breaking Changes
+
+- **PDFPreferences**: Rename `disableTextSelectionMenu` to `disableDoubleTapTextSelection`. The old name
+  was misleading — this preference removes `UITextNonEditableInteraction` from `PDFTextInputView`,
+  preventing double-tap word selection entirely. Long-press text selection and the Look Up/Translate/
+  Search Web menu remain fully functional.
+
 ## 0.3.1
 
 - Add `edgeTapAreaPoints` to `EPUBPreferences` — configures the edge tap zone width in absolute points (44–120pt). iOS only. Defaults to 44pt (iOS HIG minimum tap target) when null.

--- a/flureadium_platform_interface/lib/src/reader/reader_pdf_preferences.dart
+++ b/flureadium_platform_interface/lib/src/reader/reader_pdf_preferences.dart
@@ -16,7 +16,7 @@ class PDFPreferences {
     this.disableDoubleTapZoom,
     this.disableTextSelection,
     this.disableDragGestures,
-    this.disableTextSelectionMenu,
+    this.disableDoubleTapTextSelection,
     this.enableEdgeTapNavigation,
     this.enableSwipeNavigation,
     this.edgeTapAreaPoints,
@@ -37,7 +37,8 @@ class PDFPreferences {
         disableDoubleTapZoom: map['disableDoubleTapZoom'] as bool?,
         disableTextSelection: map['disableTextSelection'] as bool?,
         disableDragGestures: map['disableDragGestures'] as bool?,
-        disableTextSelectionMenu: map['disableTextSelectionMenu'] as bool?,
+        disableDoubleTapTextSelection:
+            map['disableDoubleTapTextSelection'] as bool?,
         enableEdgeTapNavigation: map['enableEdgeTapNavigation'] as bool?,
         enableSwipeNavigation: map['enableSwipeNavigation'] as bool?,
         edgeTapAreaPoints: (map['edgeTapAreaPoints'] as num?)?.toDouble(),
@@ -70,10 +71,11 @@ class PDFPreferences {
   /// Defaults to false (drag gestures enabled).
   bool? disableDragGestures;
 
-  /// Whether to disable the text selection menu (iOS only).
-  /// When true, the Copy/Look Up/Translate menu won't appear when text is selected.
-  /// Defaults to false (selection menu enabled).
-  bool? disableTextSelectionMenu;
+  /// Whether to disable double-tap word selection in PDF text (iOS only).
+  /// When true, double-tapping on PDF text won't select a word or show the
+  /// Copy/Look Up/Translate menu. Long-press text selection remains functional.
+  /// Defaults to false (double-tap selection enabled).
+  bool? disableDoubleTapTextSelection;
 
   /// Whether edge tap navigation is enabled (iOS only).
   /// When true, tapping on the left/right edges of the screen navigates pages.
@@ -104,8 +106,8 @@ class PDFPreferences {
     if (disableDragGestures != null) {
       map['disableDragGestures'] = disableDragGestures;
     }
-    if (disableTextSelectionMenu != null) {
-      map['disableTextSelectionMenu'] = disableTextSelectionMenu;
+    if (disableDoubleTapTextSelection != null) {
+      map['disableDoubleTapTextSelection'] = disableDoubleTapTextSelection;
     }
     if (enableEdgeTapNavigation != null) {
       map['enableEdgeTapNavigation'] = enableEdgeTapNavigation;
@@ -127,7 +129,7 @@ class PDFPreferences {
     bool? disableDoubleTapZoom,
     bool? disableTextSelection,
     bool? disableDragGestures,
-    bool? disableTextSelectionMenu,
+    bool? disableDoubleTapTextSelection,
     bool? enableEdgeTapNavigation,
     bool? enableSwipeNavigation,
     double? edgeTapAreaPoints,
@@ -139,8 +141,8 @@ class PDFPreferences {
     disableDoubleTapZoom: disableDoubleTapZoom ?? this.disableDoubleTapZoom,
     disableTextSelection: disableTextSelection ?? this.disableTextSelection,
     disableDragGestures: disableDragGestures ?? this.disableDragGestures,
-    disableTextSelectionMenu:
-        disableTextSelectionMenu ?? this.disableTextSelectionMenu,
+    disableDoubleTapTextSelection:
+        disableDoubleTapTextSelection ?? this.disableDoubleTapTextSelection,
     enableEdgeTapNavigation:
         enableEdgeTapNavigation ?? this.enableEdgeTapNavigation,
     enableSwipeNavigation: enableSwipeNavigation ?? this.enableSwipeNavigation,

--- a/flureadium_platform_interface/pubspec.yaml
+++ b/flureadium_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium_platform_interface
 description: "Platform interface for Flureadium, providing shared models, exceptions, and the abstract FlureadiumPlatform class for EPUB, PDF, and audiobook reading."
-version: 0.3.1
+version: 0.4.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium_platform_interface/test/reader/reader_pdf_preferences_test.dart
+++ b/flureadium_platform_interface/test/reader/reader_pdf_preferences_test.dart
@@ -5,39 +5,39 @@ import 'package:flureadium_platform_interface/flureadium_platform_interface.dart
 
 void main() {
   group('PDFPreferences', () {
-    group('disableTextSelectionMenu', () {
+    group('disableDoubleTapTextSelection', () {
       test('defaults to null', () {
         final prefs = PDFPreferences();
-        expect(prefs.disableTextSelectionMenu, isNull);
+        expect(prefs.disableDoubleTapTextSelection, isNull);
       });
 
       test('can be set to true', () {
-        final prefs = PDFPreferences(disableTextSelectionMenu: true);
-        expect(prefs.disableTextSelectionMenu, true);
+        final prefs = PDFPreferences(disableDoubleTapTextSelection: true);
+        expect(prefs.disableDoubleTapTextSelection, true);
       });
 
       test('serializes correctly', () {
-        final prefs = PDFPreferences(disableTextSelectionMenu: true);
+        final prefs = PDFPreferences(disableDoubleTapTextSelection: true);
         final json = prefs.toJson();
-        expect(json['disableTextSelectionMenu'], true);
+        expect(json['disableDoubleTapTextSelection'], true);
       });
 
       test('not included when null', () {
         final prefs = PDFPreferences();
         final json = prefs.toJson();
-        expect(json.containsKey('disableTextSelectionMenu'), false);
+        expect(json.containsKey('disableDoubleTapTextSelection'), false);
       });
 
-      test('copyWith preserves disableTextSelectionMenu', () {
-        final prefs1 = PDFPreferences(disableTextSelectionMenu: true);
+      test('copyWith preserves disableDoubleTapTextSelection', () {
+        final prefs1 = PDFPreferences(disableDoubleTapTextSelection: true);
         final prefs2 = prefs1.copyWith();
-        expect(prefs2.disableTextSelectionMenu, true);
+        expect(prefs2.disableDoubleTapTextSelection, true);
       });
 
-      test('copyWith can override disableTextSelectionMenu', () {
-        final prefs1 = PDFPreferences(disableTextSelectionMenu: true);
-        final prefs2 = prefs1.copyWith(disableTextSelectionMenu: false);
-        expect(prefs2.disableTextSelectionMenu, false);
+      test('copyWith can override disableDoubleTapTextSelection', () {
+        final prefs1 = PDFPreferences(disableDoubleTapTextSelection: true);
+        final prefs2 = prefs1.copyWith(disableDoubleTapTextSelection: false);
+        expect(prefs2.disableDoubleTapTextSelection, false);
       });
     });
 


### PR DESCRIPTION
## Summary

- **Root cause found and fixed**: `UITextNonEditableInteraction.doubleTapInUneditable:` on the lazily-created `PDFTextInputView` was intercepting double taps and selecting words. Previous attempts failed because `PDFTextInputView` does not exist at `setupPDFView` time — it is added asynchronously after page rendering. Fix uses deferred traversal (0.1s / 0.5s / 1.0s after `setupPDFView` and each `locationDidChange`) to find `PDFTextInputView` and remove `UITextNonEditableInteraction` from it.
- **Breaking rename**: `disableTextSelectionMenu` → `disableDoubleTapTextSelection` in `PDFPreferences` (Dart) and `FlutterPdfPreferences` (Swift). The old name was misleading — this preference prevents double-tap word selection, not a menu. Long-press text selection and the Look Up/Translate/Search Web menu remain fully functional (matching ePub behavior).
- **Cleanup**: Removed temporary debug investigation code from `PdfReaderView.swift` (`debugDumpViewHierarchy`, `debugSetupSelectionObserver`, `debugScheduleDelayedDumps`, `import PDFKit`).
- **Version bump**: Both packages → `0.4.0` (breaking API change).

## Test plan

- [ ] Build epist on iOS — no compilation errors
- [ ] Double-tap PDF text → no word selection, no menu appears
- [ ] Long-press PDF text → text selected + Look Up/Translate/Search Web menu appears
- [ ] Single-tap to dismiss selection
- [ ] Navigate to next page → double-tap → still no selection
- [ ] No debug logs in console (`VIEW HIERARCHY DUMP`, `PDFViewSelectionChanged fired`)
- [ ] Dart tests: 28/28 passed (`flureadium_platform_interface`)