### PR TITLE
feat(ios): scroll-mode swipe-back position memory

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.6.0
+
+### New Features
+
+- **iOS / EPUB scroll mode**: Swipe-back now restores the last scroll position within the previous spine item.
+  Previously, swiping back always landed at the start of the item. The position is stored in memory per
+  spine item and restored automatically when a backward swipe is detected.
+  - Explicit navigation (TOC tap, `skipToPrevious`) is unaffected — it clears the stored position for the
+    target item so restoration does not override an intentional jump.
+  - History is session-only; it is not persisted across app launches.
+  - `onLocatorChanged` fires after restoration, so persistent position saving always reflects the
+    final restored position.
+
+---
+
 ## 0.5.0
 
 ### Breaking Changes

--- a/flureadium/docs/guides/epub-reading.md
+++ b/flureadium/docs/guides/epub-reading.md
@@ -256,6 +256,35 @@ void showGoToPageDialog() {
 }
 ```
 
+## Scroll Mode Swipe Navigation
+
+In scroll mode (`verticalScroll: true`), horizontal swipes between spine items are
+handled natively by WKWebView. No gesture configuration is needed.
+
+### Position Restoration on Swipe-Back
+
+When the user swipes back to a previously visited spine item, flureadium automatically
+restores the last scroll position within that item. This is in-memory only — history
+is cleared when the app is relaunched.
+
+**How it works:**
+- Each time the reader leaves a spine item, its last position is stored in memory.
+- When a swipe-back is detected (new spine index < old spine index), the stored
+  position is restored via `goToLocator`.
+- Explicit navigation (TOC tap, `skipToPrevious`) clears the stored position for the
+  target spine item so restoration does not override the intentional jump.
+- `onLocatorChanged` fires after restoration — persistent position saving always
+  reflects the final restored position.
+
+**Known behaviour:**
+- On swipe-back, there is a brief double save: the navigator first lands at position 0
+  of the previous item (~50ms) before restoration fires. The final saved position is
+  always correct.
+- History is session-only and is not persisted across app launches.
+- Forward swipes always land at the start of the next spine item (unchanged).
+
+---
+
 ## Position Tracking
 
 ### Listen for Position Changes

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -273,13 +273,14 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   }
 
   /// Configure edge tap handlers based on scroll mode.
-  /// In scroll mode, edge taps are disabled since there are no pages to turn.
+  /// In scroll mode, all callbacks are nil — WKWebView handles native swipes.
   /// In paginated mode, edge taps trigger goLeft/goRight for page navigation.
   private func configureEdgeTapHandlers(isScrollMode: Bool) {
     guard let edgeTapView = _view as? EdgeTapInterceptView else { return }
 
     if isScrollMode {
-      // Disable edge tap and swipe navigation in scroll mode
+      // Scroll mode: all callbacks nil.
+      // Swipes are handled natively by WKWebView — no interception needed.
       edgeTapView.onLeftEdgeTap = nil
       edgeTapView.onRightEdgeTap = nil
       edgeTapView.onSwipeLeft = nil
@@ -652,6 +653,35 @@ func initUserScripts(registrar: FlutterPluginRegistrar) {
   })();
   """
   userScripts.append(WKUserScript(source: clickSynthesisScript, injectionTime: .atDocumentEnd, forMainFrameOnly: false))
+}
+
+func strippedHref(_ href: String) -> String {
+  href.components(separatedBy: "#").first?
+      .components(separatedBy: "?").first ?? href
+}
+
+func chapterLink(before currentHref: String, in readingOrder: [Link]) -> Link? {
+  let clean = strippedHref(currentHref)
+  guard let idx = readingOrder.firstIndex(where: { strippedHref($0.href) == clean }),
+        idx > 0 else { return nil }
+  return readingOrder[idx - 1]
+}
+
+func chapterLink(after currentHref: String, in readingOrder: [Link]) -> Link? {
+  let clean = strippedHref(currentHref)
+  guard let idx = readingOrder.firstIndex(where: { strippedHref($0.href) == clean }),
+        idx < readingOrder.count - 1 else { return nil }
+  return readingOrder[idx + 1]
+}
+
+func isBackwardNavigation(from oldHref: String, to newHref: String, in readingOrder: [Link]) -> Bool {
+  let cleanOld = strippedHref(oldHref)
+  let cleanNew = strippedHref(newHref)
+  guard let oldIdx = readingOrder.firstIndex(where: { strippedHref($0.href) == cleanOld }),
+        let newIdx = readingOrder.firstIndex(where: { strippedHref($0.href) == cleanNew }) else {
+    return false
+  }
+  return newIdx < oldIdx
 }
 
 private func canScroll(locations: Locator.Locations?) -> Bool {

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -39,6 +39,12 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   // Retain the navigation adapter to prevent ARC deallocation
   private var directionalNavigationAdapter: DirectionalNavigationAdapter?
 
+  // Scroll-mode position memory: remembers the last scroll position per spine item
+  // so swipe-back can restore where the user was in the previous chapter.
+  private var spineItemHistory: [String: Locator] = [:]
+  private var lastSpineItemLocator: Locator?
+  private var currentSpineItemHref: String?
+
   var publicationIdentifier: String?
 
   func view() -> UIView {
@@ -213,7 +219,31 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   // override NavigatorDelegate::navigator:locationDidChange
   func navigator(_ navigator: Navigator, locationDidChange locator: Locator) {
     print(TAG, "onPageChanged: \(locator)")
-    if (!hasSentReady) {
+
+    let newHref = strippedHref(locator.href.string)
+
+    if isVerticalScroll, let oldHref = currentSpineItemHref, newHref != oldHref {
+      // Store last known position for the spine item we are leaving
+      if let outgoing = lastSpineItemLocator {
+        spineItemHistory[oldHref] = outgoing
+      }
+
+      // Restore position if swiping backward and we have a stored position
+      let readingOrder = readiumViewController.publication.readingOrder
+      if isBackwardNavigation(from: oldHref, to: newHref, in: readingOrder),
+         let stored = spineItemHistory[newHref] {
+        Task { @MainActor in
+          // emitOnPageChanged fires inside goToLocator — persistent save
+          // correctly updates to the restored position as a side effect.
+          await self.goToLocator(locator: stored, animated: false)
+        }
+      }
+    }
+
+    currentSpineItemHref = newHref
+    lastSpineItemLocator = locator
+
+    if !hasSentReady {
       self.readerStatusStreamHandler?.sendEvent(ReadiumReaderStatusReady)
       hasSentReady = true
     }
@@ -382,6 +412,11 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   }
 
   func goToLocator(locator: Locator, animated: Bool) async -> Void {
+    // Explicit navigation (TOC, skipToPrevious, etc.) must not trigger restoration.
+    // Clearing history for this target prevents a subsequent swipe-back from
+    // landing at a stale stored position rather than the TOC-specified location.
+    spineItemHistory.removeValue(forKey: strippedHref(locator.href.string))
+
     let locations = locator.locations
     let shouldScroll = canScroll(locations: locations)
     let shouldGo = readiumViewController.currentLocation?.href != locator.href

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/ScrollModeNavigationTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/ScrollModeNavigationTests.swift
@@ -1,0 +1,234 @@
+//
+//  ScrollModeNavigationTests.swift
+//  flureadiumTests
+//
+//  Unit tests for scroll mode chapter navigation helpers:
+//  chapterLink(before:in:), chapterLink(after:in:), strippedHref(_:)
+//
+
+import XCTest
+import ReadiumShared
+@testable import flureadium
+
+// MARK: - Helpers under test (free functions declared in ReadiumReaderView.swift)
+// They are internal (no access modifier), so @testable import exposes them.
+
+final class ScrollModeNavigationTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeLink(_ href: String) -> Link {
+        Link(href: href)
+    }
+
+    private var threeLinks: [Link] {
+        [makeLink("ch1.html"), makeLink("ch2.html"), makeLink("ch3.html")]
+    }
+
+    // MARK: - strippedHref
+
+    func testStrippedHref_noFragment_unchanged() {
+        XCTAssertEqual(strippedHref("ch1.html"), "ch1.html")
+    }
+
+    func testStrippedHref_removesFragment() {
+        XCTAssertEqual(strippedHref("ch1.html#section-2"), "ch1.html")
+    }
+
+    func testStrippedHref_removesQuery() {
+        XCTAssertEqual(strippedHref("ch1.html?page=3"), "ch1.html")
+    }
+
+    func testStrippedHref_removesFragmentAndQuery() {
+        // Fragment wins: components(separatedBy: "#") splits first
+        XCTAssertEqual(strippedHref("ch1.html#anchor?query=1"), "ch1.html")
+    }
+
+    func testStrippedHref_emptyString() {
+        XCTAssertEqual(strippedHref(""), "")
+    }
+
+    // MARK: - chapterLink(before:in:) — empty / boundary
+
+    func testChapterBefore_emptyReadingOrder_returnsNil() {
+        XCTAssertNil(chapterLink(before: "ch1.html", in: []))
+    }
+
+    func testChapterBefore_atFirstItem_returnsNil() {
+        XCTAssertNil(chapterLink(before: "ch1.html", in: threeLinks))
+    }
+
+    func testChapterBefore_hrefNotFound_returnsNil() {
+        XCTAssertNil(chapterLink(before: "unknown.html", in: threeLinks))
+    }
+
+    // MARK: - chapterLink(before:in:) — normal navigation
+
+    func testChapterBefore_atSecondItem_returnsFirst() {
+        let result = chapterLink(before: "ch2.html", in: threeLinks)
+        XCTAssertEqual(result?.href, "ch1.html")
+    }
+
+    func testChapterBefore_atLastItem_returnsSecond() {
+        let result = chapterLink(before: "ch3.html", in: threeLinks)
+        XCTAssertEqual(result?.href, "ch2.html")
+    }
+
+    // MARK: - chapterLink(before:in:) — href stripping
+
+    func testChapterBefore_currentHrefWithFragment_matchesCleanHref() {
+        let result = chapterLink(before: "ch2.html#section", in: threeLinks)
+        XCTAssertEqual(result?.href, "ch1.html")
+    }
+
+    func testChapterBefore_currentHrefWithQuery_matchesCleanHref() {
+        let result = chapterLink(before: "ch2.html?p=1", in: threeLinks)
+        XCTAssertEqual(result?.href, "ch1.html")
+    }
+
+    func testChapterBefore_linkHrefWithFragment_matchesCurrentClean() {
+        let linksWithFragments = [
+            makeLink("ch1.html#intro"),
+            makeLink("ch2.html#body"),
+            makeLink("ch3.html#end"),
+        ]
+        // Current href: "ch2.html" should match "ch2.html#body" after stripping
+        let result = chapterLink(before: "ch2.html", in: linksWithFragments)
+        XCTAssertEqual(result?.href, "ch1.html#intro")
+    }
+
+    // MARK: - chapterLink(after:in:) — empty / boundary
+
+    func testChapterAfter_emptyReadingOrder_returnsNil() {
+        XCTAssertNil(chapterLink(after: "ch1.html", in: []))
+    }
+
+    func testChapterAfter_atLastItem_returnsNil() {
+        XCTAssertNil(chapterLink(after: "ch3.html", in: threeLinks))
+    }
+
+    func testChapterAfter_hrefNotFound_returnsNil() {
+        XCTAssertNil(chapterLink(after: "unknown.html", in: threeLinks))
+    }
+
+    // MARK: - chapterLink(after:in:) — normal navigation
+
+    func testChapterAfter_atFirstItem_returnsSecond() {
+        let result = chapterLink(after: "ch1.html", in: threeLinks)
+        XCTAssertEqual(result?.href, "ch2.html")
+    }
+
+    func testChapterAfter_atSecondItem_returnsThird() {
+        let result = chapterLink(after: "ch2.html", in: threeLinks)
+        XCTAssertEqual(result?.href, "ch3.html")
+    }
+
+    // MARK: - chapterLink(after:in:) — href stripping
+
+    func testChapterAfter_currentHrefWithFragment_matchesCleanHref() {
+        let result = chapterLink(after: "ch2.html#section", in: threeLinks)
+        XCTAssertEqual(result?.href, "ch3.html")
+    }
+
+    func testChapterAfter_currentHrefWithQuery_matchesCleanHref() {
+        let result = chapterLink(after: "ch2.html?p=1", in: threeLinks)
+        XCTAssertEqual(result?.href, "ch3.html")
+    }
+
+    func testChapterAfter_linkHrefWithFragment_matchesCurrentClean() {
+        let linksWithFragments = [
+            makeLink("ch1.html#intro"),
+            makeLink("ch2.html#body"),
+            makeLink("ch3.html#end"),
+        ]
+        let result = chapterLink(after: "ch2.html", in: linksWithFragments)
+        XCTAssertEqual(result?.href, "ch3.html#end")
+    }
+
+    // MARK: - configureEdgeTapHandlers scroll mode: callback presence
+
+    func testScrollMode_tapCallbacksNil_evenWhenEdgeTapEnabled() {
+        // In scroll mode, ALL tap callbacks are unconditionally nil —
+        // even when enableEdgeTapNavigation is true.
+        // WKWebView handles native swipes; EdgeTapInterceptView must not intercept.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        view.onLeftEdgeTap = nil
+        view.onRightEdgeTap = nil
+
+        XCTAssertNil(view.onLeftEdgeTap, "Left tap callback must be nil in scroll mode regardless of edge tap setting")
+        XCTAssertNil(view.onRightEdgeTap, "Right tap callback must be nil in scroll mode regardless of edge tap setting")
+    }
+
+    func testScrollMode_tapCallbacksNil_whenEdgeTapDisabled() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        // Simulate the scroll-mode branch with enableEdgeTapNavigation = false
+        view.onLeftEdgeTap = nil
+        view.onRightEdgeTap = nil
+
+        XCTAssertNil(view.onLeftEdgeTap, "Left tap callback should be nil in scroll mode with edge tap disabled")
+        XCTAssertNil(view.onRightEdgeTap, "Right tap callback should be nil in scroll mode with edge tap disabled")
+    }
+
+    func testScrollMode_swipeCallbacksNil_evenWhenSwipeEnabled() {
+        // In scroll mode, ALL swipe callbacks are unconditionally nil —
+        // even when enableSwipeNavigation is true.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        view.onSwipeLeft = nil
+        view.onSwipeRight = nil
+
+        XCTAssertNil(view.onSwipeLeft, "Swipe left callback must be nil in scroll mode regardless of swipe setting")
+        XCTAssertNil(view.onSwipeRight, "Swipe right callback must be nil in scroll mode regardless of swipe setting")
+    }
+
+    func testScrollMode_swipeCallbacksNil_whenSwipeDisabled() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        view.onSwipeLeft = nil
+        view.onSwipeRight = nil
+
+        XCTAssertNil(view.onSwipeLeft, "Swipe left callback should be nil in scroll mode with swipe disabled")
+        XCTAssertNil(view.onSwipeRight, "Swipe right callback should be nil in scroll mode with swipe disabled")
+    }
+
+    func testPaginatedMode_tapCallbacksUnaffected() {
+        // Paginated mode should assign tap callbacks (existing behaviour must remain)
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        view.onLeftEdgeTap = { }
+        view.onRightEdgeTap = { }
+
+        XCTAssertNotNil(view.onLeftEdgeTap, "Paginated mode left tap must remain non-nil")
+        XCTAssertNotNil(view.onRightEdgeTap, "Paginated mode right tap must remain non-nil")
+    }
+
+    // MARK: - isBackwardNavigation(from:to:in:)
+
+    func testIsBackwardNavigation_emptyReadingOrder_returnsFalse() {
+        XCTAssertFalse(isBackwardNavigation(from: "ch2.html", to: "ch1.html", in: []))
+    }
+
+    func testIsBackwardNavigation_oldHrefNotFound_returnsFalse() {
+        XCTAssertFalse(isBackwardNavigation(from: "unknown.html", to: "ch1.html", in: threeLinks))
+    }
+
+    func testIsBackwardNavigation_newHrefNotFound_returnsFalse() {
+        XCTAssertFalse(isBackwardNavigation(from: "ch2.html", to: "unknown.html", in: threeLinks))
+    }
+
+    func testIsBackwardNavigation_backwardNav_returnsTrue() {
+        // ch3 → ch2: newIdx(1) < oldIdx(2) → true
+        XCTAssertTrue(isBackwardNavigation(from: "ch3.html", to: "ch2.html", in: threeLinks))
+    }
+
+    func testIsBackwardNavigation_forwardNav_returnsFalse() {
+        // ch1 → ch2: newIdx(1) > oldIdx(0) → false
+        XCTAssertFalse(isBackwardNavigation(from: "ch1.html", to: "ch2.html", in: threeLinks))
+    }
+
+    func testIsBackwardNavigation_sameItem_returnsFalse() {
+        XCTAssertFalse(isBackwardNavigation(from: "ch2.html", to: "ch2.html", in: threeLinks))
+    }
+
+    func testIsBackwardNavigation_fragmentsStrippedBeforeComparison() {
+        // ch3.html#end → ch1.html#intro: both stripped, newIdx(0) < oldIdx(2) → true
+        XCTAssertTrue(isBackwardNavigation(from: "ch3.html#end", to: "ch1.html#intro", in: threeLinks))
+    }
+}

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- Swipe-back in EPUB scroll mode now restores the last scroll position within the previous spine item (previously always landed at start).
- `isBackwardNavigation(from:to:in:)` pure helper detects backward spine-item transitions using reading order index comparison.
- Explicit navigation (TOC, `skipToPrevious`) clears history for the target item so restoration never overrides an intentional jump.
- `onLocatorChanged` fires after restoration — persistent save always reflects the final restored position.
- All `EdgeTapInterceptView` callbacks remain nil in scroll mode (WKWebView handles swipes natively).

## Test plan

- [ ] Open a multi-chapter EPUB in scroll mode on the simulator (or device)
- [ ] Scroll partway into a chapter (not at the top)
- [ ] Swipe forward to the next chapter, then swipe back — verify you land at the stored scroll position, not the top
- [ ] Open TOC, tap a chapter that's behind your current position, then swipe back — verify you land at the TOC-specified location (no restoration)
- [ ] Swipe forward — verify you land at the start of the next chapter (unchanged)
- [ ] Verify paginated mode is unaffected
- [ ] Run Flutter tests: `flutter test`