### PR TITLE
feat(android): edge tap & swipe navigation parity with iOS

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.7.0
+
+### New Features
+
+- **Android / Edge tap & swipe navigation**: `setNavigationConfig()` now works on Android, matching iOS behaviour.
+  A transparent overlay is placed on top of the Readium navigator (EPUB and PDF) and intercepts touches in
+  the configurable left/right edge zones. Center touches always pass through to the reader content.
+  - `enableEdgeTapNavigation` — tap the left/right edge to turn pages (default: enabled)
+  - `enableSwipeNavigation` — horizontal fling to turn pages (default: enabled)
+  - `edgeTapAreaPoints` — edge zone width in dp, clamped to 44–120 (default: 44)
+  - In EPUB vertical scroll mode, all overlay gestures are automatically disabled so Readium's
+    WebView can handle native scrolling; gestures are re-enabled when scroll mode is turned off.
+
+---
+
 ## 0.6.0
 
 ### New Features

--- a/flureadium/android/build.gradle
+++ b/flureadium/android/build.gradle
@@ -96,11 +96,9 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
   implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
 
-  // Flutter embedding — compileOnly so it's available when building standalone
-  // (e.g. for running Android unit tests via ./gradlew testDebugUnitTest).
-  // The Flutter Gradle plugin provides this at runtime in the normal app build.
-  compileOnly 'io.flutter:flutter_embedding_debug:1.0.0-587c18f873b8ab57330422bce09047420d9c7f42'
-
+  // Flutter embedding — provided by the Flutter Gradle plugin at compile and runtime.
+  // testImplementation makes Flutter classes available when compiling main sources
+  // during standalone ./gradlew testDebugUnitTest runs.
   testImplementation 'io.flutter:flutter_embedding_debug:1.0.0-587c18f873b8ab57330422bce09047420d9c7f42'
   testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
   testImplementation 'org.mockito:mockito-core:5.17.0'

--- a/flureadium/android/build.gradle
+++ b/flureadium/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
     google()
     mavenCentral()
     maven { url 'https://jitpack.io' }
+    maven { url 'https://storage.googleapis.com/download.flutter.io' }
   }
 }
 
@@ -90,4 +91,13 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
   implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+
+  // Flutter embedding — compileOnly so it's available when building standalone
+  // (e.g. for running Android unit tests via ./gradlew testDebugUnitTest).
+  // The Flutter Gradle plugin provides this at runtime in the normal app build.
+  compileOnly 'io.flutter:flutter_embedding_debug:1.0.0-587c18f873b8ab57330422bce09047420d9c7f42'
+
+  testImplementation 'io.flutter:flutter_embedding_debug:1.0.0-587c18f873b8ab57330422bce09047420d9c7f42'
+  testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+  testImplementation 'org.mockito:mockito-core:5.17.0'
 }

--- a/flureadium/android/build.gradle
+++ b/flureadium/android/build.gradle
@@ -60,6 +60,10 @@ android {
   buildFeatures {
     viewBinding = true
   }
+
+  testOptions {
+    unitTests.returnDefaultValues = true
+  }
 }
 
 dependencies {
@@ -100,4 +104,8 @@ dependencies {
   testImplementation 'io.flutter:flutter_embedding_debug:1.0.0-587c18f873b8ab57330422bce09047420d9c7f42'
   testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
   testImplementation 'org.mockito:mockito-core:5.17.0'
+  // Provides real org.json.JSONObject/JSONArray in JVM unit tests (Android stubs are no-ops).
+  testImplementation 'org.json:json:20240303'
+  // Robolectric provides real Android framework implementations (android.net.Uri etc.) in JVM tests.
+  testImplementation 'org.robolectric:robolectric:4.14.1'
 }

--- a/flureadium/android/build.gradle
+++ b/flureadium/android/build.gradle
@@ -96,9 +96,13 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
   implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
 
-  // Flutter embedding — provided by the Flutter Gradle plugin at compile and runtime.
-  // testImplementation makes Flutter classes available when compiling main sources
-  // during standalone ./gradlew testDebugUnitTest runs.
+  // Flutter embedding — the Flutter Gradle plugin provides the correct version at runtime.
+  // compileOnly uses 'prefer' (soft constraint) so a full-app build can override our hash
+  // with the actual engine version pulled in by other plugins (e.g. wakelock_plus) without
+  // a version conflict. testImplementation covers the test compilation phase.
+  compileOnly('io.flutter:flutter_embedding_debug') {
+    version { prefer '1.0.0-587c18f873b8ab57330422bce09047420d9c7f42' }
+  }
   testImplementation 'io.flutter:flutter_embedding_debug:1.0.0-587c18f873b8ab57330422bce09047420d9c7f42'
   testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
   testImplementation 'org.mockito:mockito-core:5.17.0'

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/EdgeTapInterceptView.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/EdgeTapInterceptView.kt
@@ -1,0 +1,197 @@
+package dev.mulev.flureadium
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Log
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.ViewConfiguration
+import android.widget.FrameLayout
+import androidx.core.view.GestureDetectorCompat
+import kotlin.math.abs
+
+private const val TAG = "EdgeTapInterceptView"
+
+/**
+ * Transparent FrameLayout overlay placed on top of the Readium navigator view.
+ * Intercepts touch events in left/right edge zones to provide configurable
+ * edge-tap and swipe gesture navigation — matching the iOS EdgeTapInterceptView.
+ *
+ * Center touches always pass through to child views (Readium WebView / PDF view).
+ */
+class EdgeTapInterceptView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    // ── Base callbacks wired by the fragment (never cleared externally) ────────
+
+    private var baseOnLeftEdgeTap: (() -> Unit)? = null
+    private var baseOnRightEdgeTap: (() -> Unit)? = null
+    private var baseOnSwipeLeft: (() -> Unit)? = null
+    private var baseOnSwipeRight: (() -> Unit)? = null
+
+    // ── Computed effective callbacks (may be null'd by config / scroll mode) ──
+
+    private var onLeftEdgeTap: (() -> Unit)? = null
+    private var onRightEdgeTap: (() -> Unit)? = null
+    private var onSwipeLeft: (() -> Unit)? = null
+    private var onSwipeRight: (() -> Unit)? = null
+
+    // ── State ─────────────────────────────────────────────────────────────────
+
+    private var storedConfig: FlutterNavigationConfig? = null
+    private var isInScrollMode: Boolean = false
+    private var edgeTapThresholdDp: Float = 44f
+
+    private val minFlingVelocityPx: Float by lazy {
+        ViewConfiguration.get(context).scaledMinimumFlingVelocity.toFloat()
+    }
+
+    // ── Gesture detector ──────────────────────────────────────────────────────
+
+    private val gestureDetector = GestureDetectorCompat(context, object : GestureDetector.SimpleOnGestureListener() {
+
+        override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+            val thresholdPx = dpToPx(edgeTapThresholdDp, resources.displayMetrics.density)
+            val x = e.x
+            return when {
+                x < thresholdPx -> {
+                    Log.d(TAG, "onSingleTapConfirmed: left edge tap")
+                    onLeftEdgeTap?.invoke()
+                    true
+                }
+                x > width - thresholdPx -> {
+                    Log.d(TAG, "onSingleTapConfirmed: right edge tap")
+                    onRightEdgeTap?.invoke()
+                    true
+                }
+                else -> false
+            }
+        }
+
+        override fun onFling(
+            e1: MotionEvent?,
+            e2: MotionEvent,
+            velocityX: Float,
+            velocityY: Float,
+        ): Boolean {
+            val absVX = abs(velocityX)
+            val absVY = abs(velocityY)
+            if (absVX < minFlingVelocityPx || absVY > absVX) return false
+
+            return if (velocityX < 0) {
+                Log.d(TAG, "onFling: swipe left → next")
+                onSwipeLeft?.invoke()
+                true
+            } else {
+                Log.d(TAG, "onFling: swipe right → prev")
+                onSwipeRight?.invoke()
+                true
+            }
+        }
+    })
+
+    // ── Touch interception ────────────────────────────────────────────────────
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        if (ev.action == MotionEvent.ACTION_DOWN) {
+            val thresholdPx = dpToPx(edgeTapThresholdDp, resources.displayMetrics.density)
+            val x = ev.x
+            val inLeftEdge = isInLeftEdge(x, thresholdPx) &&
+                (onLeftEdgeTap != null || onSwipeRight != null)
+            val inRightEdge = isInRightEdge(x, width, thresholdPx) &&
+                (onRightEdgeTap != null || onSwipeLeft != null)
+            if (inLeftEdge || inRightEdge) {
+                gestureDetector.onTouchEvent(ev)
+                return true
+            }
+        }
+        return false
+    }
+
+    override fun onTouchEvent(ev: MotionEvent): Boolean {
+        return gestureDetector.onTouchEvent(ev)
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Wire the navigation callbacks once after the navigator is attached.
+     * Call this from the reader fragment's attachNavigator().
+     */
+    fun wireCallbacks(
+        onLeft: () -> Unit,
+        onRight: () -> Unit,
+        onSwipeLeft: () -> Unit,
+        onSwipeRight: () -> Unit,
+    ) {
+        baseOnLeftEdgeTap = onLeft
+        baseOnRightEdgeTap = onRight
+        baseOnSwipeLeft = onSwipeLeft
+        baseOnSwipeRight = onSwipeRight
+        recompute()
+    }
+
+    /**
+     * Apply a navigation config received from Flutter via setNavigationConfig.
+     * Stores the config and recomputes effective callbacks.
+     */
+    fun applyConfig(config: FlutterNavigationConfig) {
+        storedConfig = config
+        recompute()
+    }
+
+    /**
+     * Enable or disable all gestures for scroll mode.
+     * In scroll mode, Readium's WebView handles native scrolling so the overlay
+     * must not intercept touches.
+     */
+    fun setScrollMode(isScrollMode: Boolean) {
+        isInScrollMode = isScrollMode
+        recompute()
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────────────
+
+    private fun recompute() {
+        val config = storedConfig
+        edgeTapThresholdDp = effectiveThresholdDp(config)
+
+        if (isInScrollMode) {
+            onLeftEdgeTap = null
+            onRightEdgeTap = null
+            onSwipeLeft = null
+            onSwipeRight = null
+            return
+        }
+
+        onLeftEdgeTap = if (effectiveEdgeTapEnabled(config, false)) baseOnLeftEdgeTap else null
+        onRightEdgeTap = if (effectiveEdgeTapEnabled(config, false)) baseOnRightEdgeTap else null
+        onSwipeLeft = if (effectiveSwipeEnabled(config, false)) baseOnSwipeLeft else null
+        onSwipeRight = if (effectiveSwipeEnabled(config, false)) baseOnSwipeRight else null
+    }
+
+    companion object {
+        internal fun isInLeftEdge(x: Float, thresholdPx: Float): Boolean = x < thresholdPx
+
+        internal fun isInRightEdge(x: Float, viewWidth: Int, thresholdPx: Float): Boolean =
+            x > viewWidth - thresholdPx
+
+        internal fun dpToPx(dp: Float, density: Float): Float = dp * density
+
+        internal fun effectiveEdgeTapEnabled(
+            config: FlutterNavigationConfig?,
+            isScrollMode: Boolean,
+        ): Boolean = !isScrollMode && config?.enableEdgeTapNavigation != false
+
+        internal fun effectiveSwipeEnabled(
+            config: FlutterNavigationConfig?,
+            isScrollMode: Boolean,
+        ): Boolean = !isScrollMode && config?.enableSwipeNavigation != false
+
+        internal fun effectiveThresholdDp(config: FlutterNavigationConfig?): Float =
+            config?.edgeTapAreaPoints?.toFloat() ?: 44f
+    }
+}

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/EdgeTapInterceptView.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/EdgeTapInterceptView.kt
@@ -93,26 +93,53 @@ class EdgeTapInterceptView @JvmOverloads constructor(
         }
     })
 
-    // ── Touch interception ────────────────────────────────────────────────────
+    // ── Touch dispatch ────────────────────────────────────────────────────────
 
-    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
-        if (ev.action == MotionEvent.ACTION_DOWN) {
-            val thresholdPx = dpToPx(edgeTapThresholdDp, resources.displayMetrics.density)
-            val x = ev.x
-            val inLeftEdge = isInLeftEdge(x, thresholdPx) &&
-                (onLeftEdgeTap != null || onSwipeRight != null)
-            val inRightEdge = isInRightEdge(x, width, thresholdPx) &&
-                (onRightEdgeTap != null || onSwipeLeft != null)
-            if (inLeftEdge || inRightEdge) {
-                gestureDetector.onTouchEvent(ev)
-                return true
+    /**
+     * Tracks whether the current touch sequence was claimed by this overlay.
+     * Set on ACTION_DOWN; cleared on ACTION_UP / ACTION_CANCEL.
+     */
+    private var isClaimed = false
+
+    /**
+     * Intercepts edge-zone touches by claiming the gesture in dispatchTouchEvent.
+     *
+     * Why not onInterceptTouchEvent + onTouchEvent?
+     * onInterceptTouchEvent returning true causes ViewGroup to call onTouchEvent.
+     * onTouchEvent returns gestureDetector.onTouchEvent() which returns onDown() = false
+     * (SimpleOnGestureListener default). The false return propagates out of
+     * dispatchTouchEvent, so the parent FrameLayout never registers this view as the
+     * touch target — subsequent ACTION_MOVE and ACTION_UP events never arrive, and
+     * onSingleTapConfirmed never fires.
+     *
+     * Overriding dispatchTouchEvent directly lets us return true unconditionally for
+     * claimed gestures, keeping the gesture sequence alive until ACTION_UP / CANCEL.
+     * Center touches return false immediately, passing through to the Readium WebView.
+     */
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                val thresholdPx = dpToPx(edgeTapThresholdDp, resources.displayMetrics.density)
+                val x = ev.x
+                val hasLeft = onLeftEdgeTap != null || onSwipeRight != null
+                val hasRight = onRightEdgeTap != null || onSwipeLeft != null
+                isClaimed = (hasLeft && isInLeftEdge(x, thresholdPx)) ||
+                    (hasRight && isInRightEdge(x, width, thresholdPx))
+                Log.d(TAG, "dispatchTouchEvent ACTION_DOWN x=$x width=$width threshold=$thresholdPx claimed=$isClaimed")
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                val wasClaimed = isClaimed
+                isClaimed = false
+                if (wasClaimed) {
+                    gestureDetector.onTouchEvent(ev)
+                }
+                return wasClaimed
             }
         }
-        return false
-    }
 
-    override fun onTouchEvent(ev: MotionEvent): Boolean {
-        return gestureDetector.onTouchEvent(ev)
+        if (!isClaimed) return false
+        gestureDetector.onTouchEvent(ev)
+        return true
     }
 
     // ── Public API ────────────────────────────────────────────────────────────

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/FlutterNavigationConfig.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/FlutterNavigationConfig.kt
@@ -1,0 +1,23 @@
+package dev.mulev.flureadium
+
+data class FlutterNavigationConfig(
+    val enableEdgeTapNavigation: Boolean? = null,
+    val enableSwipeNavigation: Boolean? = null,
+    val edgeTapAreaPoints: Double? = null,
+) {
+    companion object {
+        private const val MIN_EDGE_TAP_DP = 44.0
+        private const val MAX_EDGE_TAP_DP = 120.0
+
+        fun fromMap(map: Map<*, *>?): FlutterNavigationConfig {
+            if (map == null) return FlutterNavigationConfig()
+            val rawPts = (map["edgeTapAreaPoints"] as? Number)?.toDouble()
+            val clamped = rawPts?.coerceIn(MIN_EDGE_TAP_DP, MAX_EDGE_TAP_DP)
+            return FlutterNavigationConfig(
+                enableEdgeTapNavigation = map["enableEdgeTapNavigation"] as? Boolean,
+                enableSwipeNavigation = map["enableSwipeNavigation"] as? Boolean,
+                edgeTapAreaPoints = clamped,
+            )
+        }
+    }
+}

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
@@ -756,6 +756,13 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
     }
 
     /**
+     * Apply a navigation config to the PDF navigator overlay.
+     */
+    fun pdfSetNavigationConfig(config: FlutterNavigationConfig) {
+        pdfNavigator?.setNavigationConfig(config)
+    }
+
+    /**
      * Go left (previous page) in the PDF navigator.
      */
     fun pdfGoLeft(animated: Boolean) {
@@ -989,6 +996,20 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
      */
     suspend fun epubGo(locator: Locator, animated: Boolean) {
         epubNavigator?.go(locator, animated)
+    }
+
+    /**
+     * Apply a navigation config to the EPUB navigator overlay.
+     */
+    fun epubSetNavigationConfig(config: FlutterNavigationConfig) {
+        epubNavigator?.setNavigationConfig(config)
+    }
+
+    /**
+     * Enable or disable EPUB overlay gestures for scroll mode.
+     */
+    fun epubSetScrollMode(isScrollMode: Boolean) {
+        epubNavigator?.setScrollMode(isScrollMode)
     }
 
     /**

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReaderWidget.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReaderWidget.kt
@@ -64,6 +64,8 @@ class ReadiumReaderWidget(
     private val isPdf: Boolean
         get() = ReadiumReader.currentPublication?.conformsTo(Publication.Profile.PDF) == true
 
+    private var storedNavigationConfig: FlutterNavigationConfig? = null
+
     override fun getView(): View {
         //Log.d(TAG, "::getView")
         return layout
@@ -612,11 +614,21 @@ class ReadiumReaderWidget(
                             ReadiumReader.pdfUpdatePreferences(pdfPrefs)
                         } else {
                             setPreferencesFromMap(prefsMap)
+                            val isScrollMode = prefsMap["verticalScroll"]?.toBoolean() == true
+                            ReadiumReader.epubSetScrollMode(isScrollMode)
                         }
                         result.success(null)
                     } catch (ex: Exception) {
                         result.error("Flureadium", "Failed to set preferences", ex.message)
                     }
+                }
+
+                "setNavigationConfig" -> {
+                    @Suppress("UNCHECKED_CAST")
+                    val args = call.arguments as? Map<*, *>
+                    val config = FlutterNavigationConfig.fromMap(args)
+                    applyNavigationConfig(config)
+                    result.success(null)
                 }
 
                 "go" -> {
@@ -776,6 +788,15 @@ class ReadiumReaderWidget(
         Log.d(TAG, "::go ${locator.href}")
         mainScope.launch {
             ReadiumReader.epubGoToLocator(locator, animated)
+        }
+    }
+
+    private fun applyNavigationConfig(config: FlutterNavigationConfig) {
+        storedNavigationConfig = config
+        if (isPdf) {
+            ReadiumReader.pdfSetNavigationConfig(config)
+        } else {
+            ReadiumReader.epubSetNavigationConfig(config)
         }
     }
 

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/fragments/EpubReaderFragment.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/fragments/EpubReaderFragment.kt
@@ -3,8 +3,12 @@ package dev.mulev.flureadium.fragments
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.lifecycleScope
+import dev.mulev.flureadium.EdgeTapInterceptView
+import dev.mulev.flureadium.FlutterNavigationConfig
 import dev.mulev.flureadium.R
 import dev.mulev.flureadium.ReadiumReader
 import dev.mulev.flureadium.models.EpubReaderViewModel
@@ -50,6 +54,9 @@ class EpubReaderFragment : VisualReaderFragment(), EpubNavigatorFragment.Listene
     var listener: Listener? = null
 
     val started = MutableStateFlow(false)
+
+    private var edgeTapInterceptView: EdgeTapInterceptView? = null
+    private var storedNavigationConfig: FlutterNavigationConfig? = null
 
     private val instance = ++instanceNo
 
@@ -130,6 +137,23 @@ class EpubReaderFragment : VisualReaderFragment(), EpubNavigatorFragment.Listene
     fun updatePreferences(preferences: EpubPreferences) {
         Log.d(TAG, "::updatePreferences")
         epubNavigator?.submitPreferences(preferences)
+    }
+
+    /**
+     * Apply a navigation config received from Flutter. Stored so it can be
+     * re-applied when the overlay is re-created after a lifecycle pause/resume.
+     */
+    fun setNavigationConfig(config: FlutterNavigationConfig) {
+        storedNavigationConfig = config
+        edgeTapInterceptView?.applyConfig(config)
+    }
+
+    /**
+     * Enable or disable all overlay gestures when the EPUB reader enters/exits
+     * vertical scroll mode. In scroll mode Readium's WebView handles scrolling.
+     */
+    fun setScrollMode(isScrollMode: Boolean) {
+        edgeTapInterceptView?.setScrollMode(isScrollMode)
     }
 
     /**
@@ -248,6 +272,9 @@ class EpubReaderFragment : VisualReaderFragment(), EpubNavigatorFragment.Listene
 
             attachingNavigatorFragment = false
 
+            edgeTapInterceptView?.let { (view as? FrameLayout)?.removeView(it) }
+            edgeTapInterceptView = null
+
             super.onPause()
         } finally {
             Log.d(TAG, "::onPause - $instance - ended")
@@ -315,6 +342,25 @@ class EpubReaderFragment : VisualReaderFragment(), EpubNavigatorFragment.Listene
         Log.d(TAG, "::attachNavigator() - $instance - got navigator = $navigator")
 
         started.value = true
+
+        // Add edge tap overlay on top of the navigator
+        val rootView = view as? FrameLayout
+        if (rootView != null) {
+            val overlay = EdgeTapInterceptView(requireContext())
+            overlay.layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            overlay.wireCallbacks(
+                onLeft = { goLeft(animated = true) },
+                onRight = { goRight(animated = true) },
+                onSwipeLeft = { goRight(animated = true) },
+                onSwipeRight = { goLeft(animated = true) },
+            )
+            storedNavigationConfig?.let { overlay.applyConfig(it) }
+            rootView.addView(overlay)
+            edgeTapInterceptView = overlay
+        }
     }
 
     companion object {

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/fragments/PdfReaderFragment.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/fragments/PdfReaderFragment.kt
@@ -3,8 +3,12 @@ package dev.mulev.flureadium.fragments
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.lifecycleScope
+import dev.mulev.flureadium.EdgeTapInterceptView
+import dev.mulev.flureadium.FlutterNavigationConfig
 import dev.mulev.flureadium.R
 import dev.mulev.flureadium.ReadiumReader
 import dev.mulev.flureadium.models.PdfReaderViewModel
@@ -50,6 +54,9 @@ class PdfReaderFragment : VisualReaderFragment(), PdfNavigatorFragment.Listener,
 
     val started = MutableStateFlow(false)
 
+    private var edgeTapInterceptView: EdgeTapInterceptView? = null
+    private var storedNavigationConfig: FlutterNavigationConfig? = null
+
     private val instance = ++instanceNo
 
     private var pdfNavigator
@@ -79,6 +86,15 @@ class PdfReaderFragment : VisualReaderFragment(), PdfNavigatorFragment.Listener,
         // PDF preferences are set at navigator creation time
         // Readium's PdfNavigatorFragment doesn't support dynamic preference updates
         // like EpubNavigatorFragment does with submitPreferences()
+    }
+
+    /**
+     * Apply a navigation config received from Flutter. Stored so it can be
+     * re-applied when the overlay is re-created after a lifecycle pause/resume.
+     */
+    fun setNavigationConfig(config: FlutterNavigationConfig) {
+        storedNavigationConfig = config
+        edgeTapInterceptView?.applyConfig(config)
     }
 
     /**
@@ -199,6 +215,9 @@ class PdfReaderFragment : VisualReaderFragment(), PdfNavigatorFragment.Listener,
 
             attachingNavigatorFragment = false
 
+            edgeTapInterceptView?.let { (view as? FrameLayout)?.removeView(it) }
+            edgeTapInterceptView = null
+
             super.onPause()
         } finally {
             Log.d(TAG, "::onPause - $instance - ended")
@@ -257,6 +276,25 @@ class PdfReaderFragment : VisualReaderFragment(), PdfNavigatorFragment.Listener,
         Log.d(TAG, "::attachNavigator() - $instance - got navigator = $navigator")
 
         started.value = true
+
+        // Add edge tap overlay on top of the navigator (PDF is always paginated)
+        val rootView = view as? FrameLayout
+        if (rootView != null) {
+            val overlay = EdgeTapInterceptView(requireContext())
+            overlay.layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            overlay.wireCallbacks(
+                onLeft = { goLeft(animated = true) },
+                onRight = { goRight(animated = true) },
+                onSwipeLeft = { goRight(animated = true) },
+                onSwipeRight = { goLeft(animated = true) },
+            )
+            storedNavigationConfig?.let { overlay.applyConfig(it) }
+            rootView.addView(overlay)
+            edgeTapInterceptView = overlay
+        }
 
         // Notify that page is loaded after navigator is attached
         listener?.onPageLoaded()

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/EpubNavigator.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/EpubNavigator.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commitNow
+import dev.mulev.flureadium.FlutterNavigationConfig
 import dev.mulev.flureadium.ReadiumReaderWidget.Companion.NAVIGATOR_FRAGMENT_TAG
 import dev.mulev.flureadium.canScroll
 import dev.mulev.flureadium.fragments.EpubReaderFragment
@@ -376,6 +377,14 @@ class EpubNavigator : BaseNavigator, EpubReaderFragment.Listener {
         return withScope(mainScope) {
             navigator.evaluateJavascript(script)
         }
+    }
+
+    fun setNavigationConfig(config: FlutterNavigationConfig) {
+        epubNavigator?.setNavigationConfig(config)
+    }
+
+    fun setScrollMode(isScrollMode: Boolean) {
+        epubNavigator?.setScrollMode(isScrollMode)
     }
 
     fun goLeft(animated: Boolean) {

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/PdfNavigator.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/PdfNavigator.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commitNow
+import dev.mulev.flureadium.FlutterNavigationConfig
 import dev.mulev.flureadium.FlutterPdfPreferences
 import dev.mulev.flureadium.ReadiumReaderWidget.Companion.NAVIGATOR_FRAGMENT_TAG
 import dev.mulev.flureadium.fragments.PdfReaderFragment
@@ -273,6 +274,10 @@ class PdfNavigator : BaseNavigator, PdfReaderFragment.Listener {
         }
 
         state.clear()
+    }
+
+    fun setNavigationConfig(config: FlutterNavigationConfig) {
+        pdfNavigator?.setNavigationConfig(config)
     }
 
     fun goLeft(animated: Boolean) {

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/EdgeTapInterceptViewDispatchTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/EdgeTapInterceptViewDispatchTest.kt
@@ -1,0 +1,219 @@
+package dev.mulev.flureadium
+
+import android.os.SystemClock
+import android.view.MotionEvent
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Behavioural tests for EdgeTapInterceptView.dispatchTouchEvent.
+ *
+ * These tests guard against the original bug where onInterceptTouchEvent + onTouchEvent
+ * failed to claim the gesture sequence: onTouchEvent returned gestureDetector.onTouchEvent()
+ * which returned onDown() = false, causing dispatchTouchEvent to return false, so the parent
+ * FrameLayout never forwarded ACTION_UP and onSingleTapConfirmed never fired.
+ *
+ * Uses Robolectric to instantiate a real View with layout bounds set.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], manifest = Config.NONE)
+internal class EdgeTapInterceptViewDispatchTest {
+
+    private lateinit var view: EdgeTapInterceptView
+
+    // Simulate a typical phone screen width in px (density=1 for simplicity)
+    private val viewWidth = 400
+    private val viewHeight = 800
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        view = EdgeTapInterceptView(context)
+        // Set layout bounds so view.width returns the expected value
+        view.layout(0, 0, viewWidth, viewHeight)
+    }
+
+    private fun down(x: Float, y: Float = 400f): MotionEvent {
+        val now = SystemClock.uptimeMillis()
+        return MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, x, y, 0)
+    }
+
+    private fun up(x: Float, y: Float = 400f): MotionEvent {
+        val now = SystemClock.uptimeMillis()
+        return MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, x, y, 0)
+    }
+
+    // ── Gesture claiming ──────────────────────────────────────────────────────
+
+    @Test
+    fun dispatchTouchEvent_leftEdge_claimsGesture() {
+        view.wireCallbacks(onLeft = {}, onRight = {}, onSwipeLeft = {}, onSwipeRight = {})
+        // 20px is well inside the 44dp left edge zone (density=1 in test)
+        val ev = down(x = 20f)
+        assertTrue(view.dispatchTouchEvent(ev), "Left edge ACTION_DOWN should return true (claimed)")
+        ev.recycle()
+    }
+
+    @Test
+    fun dispatchTouchEvent_rightEdge_claimsGesture() {
+        view.wireCallbacks(onLeft = {}, onRight = {}, onSwipeLeft = {}, onSwipeRight = {})
+        // 390px > 400-44=356, inside right edge zone
+        val ev = down(x = 390f)
+        assertTrue(view.dispatchTouchEvent(ev), "Right edge ACTION_DOWN should return true (claimed)")
+        ev.recycle()
+    }
+
+    @Test
+    fun dispatchTouchEvent_center_passesThroughGesture() {
+        view.wireCallbacks(onLeft = {}, onRight = {}, onSwipeLeft = {}, onSwipeRight = {})
+        // 200px is the center — outside both edge zones
+        val ev = down(x = 200f)
+        assertFalse(view.dispatchTouchEvent(ev), "Center ACTION_DOWN should return false (pass-through)")
+        ev.recycle()
+    }
+
+    // ── Gesture sequence continuity ───────────────────────────────────────────
+
+    @Test
+    fun dispatchTouchEvent_upAfterClaimedDown_returnsTrueAndClearsState() {
+        view.wireCallbacks(onLeft = {}, onRight = {}, onSwipeLeft = {}, onSwipeRight = {})
+        val d = down(x = 390f)
+        view.dispatchTouchEvent(d)
+
+        val u = up(x = 390f)
+        assertTrue(view.dispatchTouchEvent(u), "ACTION_UP after claimed DOWN should return true")
+        d.recycle()
+        u.recycle()
+    }
+
+    @Test
+    fun dispatchTouchEvent_upAfterUnclaimedDown_returnsFalse() {
+        view.wireCallbacks(onLeft = {}, onRight = {}, onSwipeLeft = {}, onSwipeRight = {})
+        val d = down(x = 200f)
+        view.dispatchTouchEvent(d)
+
+        val u = up(x = 200f)
+        assertFalse(view.dispatchTouchEvent(u), "ACTION_UP after unclaimed DOWN should return false")
+        d.recycle()
+        u.recycle()
+    }
+
+    @Test
+    fun dispatchTouchEvent_secondDownAfterUnclaimed_reassessesEdgeZone() {
+        view.wireCallbacks(onLeft = {}, onRight = {}, onSwipeLeft = {}, onSwipeRight = {})
+
+        // First tap in center — not claimed
+        val d1 = down(x = 200f)
+        assertFalse(view.dispatchTouchEvent(d1))
+        view.dispatchTouchEvent(up(x = 200f))
+        d1.recycle()
+
+        // Second tap on right edge — should be claimed
+        val d2 = down(x = 390f)
+        assertTrue(view.dispatchTouchEvent(d2), "Edge tap after center tap should still be claimed")
+        d2.recycle()
+    }
+
+    // ── Scroll mode ───────────────────────────────────────────────────────────
+
+    @Test
+    fun dispatchTouchEvent_scrollMode_edgePassesThroughGesture() {
+        view.wireCallbacks(onLeft = {}, onRight = {}, onSwipeLeft = {}, onSwipeRight = {})
+        view.setScrollMode(true)
+
+        val ev = down(x = 390f)
+        assertFalse(view.dispatchTouchEvent(ev), "Edge tap in scroll mode should pass through (return false)")
+        ev.recycle()
+    }
+
+    @Test
+    fun dispatchTouchEvent_exitScrollMode_resumesEdgeClaiming() {
+        view.wireCallbacks(onLeft = {}, onRight = {}, onSwipeLeft = {}, onSwipeRight = {})
+        view.setScrollMode(true)
+        view.setScrollMode(false)
+
+        val ev = down(x = 390f)
+        assertTrue(view.dispatchTouchEvent(ev), "Edge tap after exiting scroll mode should be claimed")
+        ev.recycle()
+    }
+
+    // ── Callbacks ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun dispatchTouchEvent_rightEdgeTap_firesOnRightCallback() {
+        var rightFired = false
+        view.wireCallbacks(
+            onLeft = { },
+            onRight = { rightFired = true },
+            onSwipeLeft = { },
+            onSwipeRight = { },
+        )
+
+        view.dispatchTouchEvent(down(x = 390f))
+        view.dispatchTouchEvent(up(x = 390f))
+
+        // GestureDetector delays onSingleTapConfirmed by DOUBLE_TAP_TIMEOUT (~300 ms)
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertTrue(rightFired, "onRight callback should fire after right-edge single tap")
+    }
+
+    @Test
+    fun dispatchTouchEvent_leftEdgeTap_firesOnLeftCallback() {
+        var leftFired = false
+        view.wireCallbacks(
+            onLeft = { leftFired = true },
+            onRight = { },
+            onSwipeLeft = { },
+            onSwipeRight = { },
+        )
+
+        view.dispatchTouchEvent(down(x = 20f))
+        view.dispatchTouchEvent(up(x = 20f))
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertTrue(leftFired, "onLeft callback should fire after left-edge single tap")
+    }
+
+    @Test
+    fun dispatchTouchEvent_centerTap_doesNotFireAnyCallback() {
+        var anyFired = false
+        view.wireCallbacks(
+            onLeft = { anyFired = true },
+            onRight = { anyFired = true },
+            onSwipeLeft = { anyFired = true },
+            onSwipeRight = { anyFired = true },
+        )
+
+        view.dispatchTouchEvent(down(x = 200f))
+        view.dispatchTouchEvent(up(x = 200f))
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertFalse(anyFired, "No callback should fire for a center tap")
+    }
+
+    @Test
+    fun dispatchTouchEvent_noCallbacksWired_centerDoesNotCrash() {
+        // wireCallbacks not called — all effective callbacks are null
+        val ev = down(x = 200f)
+        assertFalse(view.dispatchTouchEvent(ev))
+        ev.recycle()
+    }
+
+    @Test
+    fun dispatchTouchEvent_noCallbacksWired_edgePassesThrough() {
+        // Before wireCallbacks, no effective callbacks exist — edge zone not entered
+        val ev = down(x = 390f)
+        assertFalse(view.dispatchTouchEvent(ev), "Edge with no callbacks should pass through")
+        ev.recycle()
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/EdgeTapInterceptViewTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/EdgeTapInterceptViewTest.kt
@@ -1,0 +1,106 @@
+package dev.mulev.flureadium
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class EdgeTapInterceptViewTest {
+
+    // ── Zone detection ────────────────────────────────────────────────────────
+
+    @Test
+    fun isInLeftEdgeZone_returnsTrue_whenXWithinThreshold() {
+        assertTrue(EdgeTapInterceptView.isInLeftEdge(x = 30f, thresholdPx = 44f))
+    }
+
+    @Test
+    fun isInLeftEdgeZone_returnsFalse_whenXOutsideThreshold() {
+        assertFalse(EdgeTapInterceptView.isInLeftEdge(x = 100f, thresholdPx = 44f))
+    }
+
+    @Test
+    fun isInRightEdgeZone_returnsTrue_whenXWithinThreshold() {
+        // viewWidth = 400, threshold = 44 → right edge starts at 356
+        assertTrue(EdgeTapInterceptView.isInRightEdge(x = 380f, viewWidth = 400, thresholdPx = 44f))
+    }
+
+    @Test
+    fun isInRightEdgeZone_returnsFalse_whenXOutsideThreshold() {
+        assertFalse(EdgeTapInterceptView.isInRightEdge(x = 200f, viewWidth = 400, thresholdPx = 44f))
+    }
+
+    // ── Density conversion ────────────────────────────────────────────────────
+
+    @Test
+    fun dpToPixels_convertsCorrectly() {
+        // 44dp at density 2.0 → 88px
+        assertEquals(88f, EdgeTapInterceptView.dpToPx(dp = 44f, density = 2.0f))
+    }
+
+    // ── Config application ────────────────────────────────────────────────────
+
+    @Test
+    fun applyConfig_disablesEdgeTap_whenFlagFalse() {
+        val config = FlutterNavigationConfig(enableEdgeTapNavigation = false)
+        assertFalse(EdgeTapInterceptView.effectiveEdgeTapEnabled(config, isScrollMode = false))
+    }
+
+    @Test
+    fun applyConfig_keepsEdgeTap_whenFlagTrue() {
+        val config = FlutterNavigationConfig(enableEdgeTapNavigation = true)
+        assertTrue(EdgeTapInterceptView.effectiveEdgeTapEnabled(config, isScrollMode = false))
+    }
+
+    @Test
+    fun applyConfig_keepsEdgeTap_whenFlagNull() {
+        val config = FlutterNavigationConfig(enableEdgeTapNavigation = null)
+        assertTrue(EdgeTapInterceptView.effectiveEdgeTapEnabled(config, isScrollMode = false))
+    }
+
+    @Test
+    fun applyConfig_disablesSwipe_whenFlagFalse() {
+        val config = FlutterNavigationConfig(enableSwipeNavigation = false)
+        assertFalse(EdgeTapInterceptView.effectiveSwipeEnabled(config, isScrollMode = false))
+    }
+
+    @Test
+    fun applyConfig_keepsSwipe_whenFlagTrue() {
+        val config = FlutterNavigationConfig(enableSwipeNavigation = true)
+        assertTrue(EdgeTapInterceptView.effectiveSwipeEnabled(config, isScrollMode = false))
+    }
+
+    @Test
+    fun applyConfig_updatesEdgeZoneSize() {
+        val config = FlutterNavigationConfig(edgeTapAreaPoints = 80.0)
+        assertEquals(80f, EdgeTapInterceptView.effectiveThresholdDp(config))
+    }
+
+    @Test
+    fun applyConfig_usesDefaultThreshold_whenEdgeTapAreaPointsNull() {
+        val config = FlutterNavigationConfig(edgeTapAreaPoints = null)
+        assertEquals(44f, EdgeTapInterceptView.effectiveThresholdDp(config))
+    }
+
+    // ── Scroll mode ───────────────────────────────────────────────────────────
+
+    @Test
+    fun setScrollMode_disablesAllGestures_whenTrue() {
+        val config = FlutterNavigationConfig(
+            enableEdgeTapNavigation = true,
+            enableSwipeNavigation = true,
+        )
+        assertFalse(EdgeTapInterceptView.effectiveEdgeTapEnabled(config, isScrollMode = true))
+        assertFalse(EdgeTapInterceptView.effectiveSwipeEnabled(config, isScrollMode = true))
+    }
+
+    @Test
+    fun setScrollMode_restoresGestures_whenFalse() {
+        val config = FlutterNavigationConfig(
+            enableEdgeTapNavigation = true,
+            enableSwipeNavigation = true,
+        )
+        assertTrue(EdgeTapInterceptView.effectiveEdgeTapEnabled(config, isScrollMode = false))
+        assertTrue(EdgeTapInterceptView.effectiveSwipeEnabled(config, isScrollMode = false))
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/FlureadiumPluginTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/FlureadiumPluginTest.kt
@@ -15,13 +15,13 @@ import org.mockito.Mockito
 
 internal class FlureadiumPluginTest {
   @Test
-  fun onMethodCall_getPlatformVersion_returnsExpectedValue() {
+  fun onMethodCall_unknownMethod_returnsNotImplemented() {
     val plugin = FlureadiumPlugin()
 
-    val call = MethodCall("getPlatformVersion", null)
+    val call = MethodCall("unknownMethod", null)
     val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
     plugin.onMethodCall(call, mockResult)
 
-    Mockito.verify(mockResult).success("Android " + android.os.Build.VERSION.RELEASE)
+    Mockito.verify(mockResult).notImplemented()
   }
 }

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/FlutterNavigationConfigTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/FlutterNavigationConfigTest.kt
@@ -1,0 +1,76 @@
+package dev.mulev.flureadium
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+internal class FlutterNavigationConfigTest {
+
+    @Test
+    fun fromMap_parsesAllFields() {
+        val map = mapOf(
+            "enableEdgeTapNavigation" to true,
+            "enableSwipeNavigation" to false,
+            "edgeTapAreaPoints" to 80.0,
+        )
+        val config = FlutterNavigationConfig.fromMap(map)
+
+        assertTrue(config.enableEdgeTapNavigation!!)
+        assertFalse(config.enableSwipeNavigation!!)
+        assertEquals(80.0, config.edgeTapAreaPoints)
+    }
+
+    @Test
+    fun fromMap_handlesEmptyMap() {
+        val config = FlutterNavigationConfig.fromMap(emptyMap<String, Any>())
+
+        assertNull(config.enableEdgeTapNavigation)
+        assertNull(config.enableSwipeNavigation)
+        assertNull(config.edgeTapAreaPoints)
+    }
+
+    @Test
+    fun fromMap_handlesNullMap() {
+        val config = FlutterNavigationConfig.fromMap(null)
+
+        assertNull(config.enableEdgeTapNavigation)
+        assertNull(config.enableSwipeNavigation)
+        assertNull(config.edgeTapAreaPoints)
+    }
+
+    @Test
+    fun fromMap_clampsEdgeTapAreaPoints_belowMin() {
+        val map = mapOf("edgeTapAreaPoints" to 10.0)
+        val config = FlutterNavigationConfig.fromMap(map)
+
+        assertEquals(44.0, config.edgeTapAreaPoints)
+    }
+
+    @Test
+    fun fromMap_clampsEdgeTapAreaPoints_aboveMax() {
+        val map = mapOf("edgeTapAreaPoints" to 200.0)
+        val config = FlutterNavigationConfig.fromMap(map)
+
+        assertEquals(120.0, config.edgeTapAreaPoints)
+    }
+
+    @Test
+    fun fromMap_clampsEdgeTapAreaPoints_withinRange() {
+        val map = mapOf("edgeTapAreaPoints" to 60.0)
+        val config = FlutterNavigationConfig.fromMap(map)
+
+        assertEquals(60.0, config.edgeTapAreaPoints)
+    }
+
+    @Test
+    fun fromMap_defaultsToEnabledWhenNotSet() {
+        // Null fields mean enabled per iOS semantics — the overlay checks != false
+        val config = FlutterNavigationConfig.fromMap(emptyMap<String, Any>())
+
+        // null != false → enabled
+        assertTrue(config.enableEdgeTapNavigation != false)
+        assertTrue(config.enableSwipeNavigation != false)
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/EpubNavigatorRestoreTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/EpubNavigatorRestoreTest.kt
@@ -3,8 +3,10 @@ package dev.mulev.flureadium.navigators
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.Url
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.junit.runner.RunWith
 
 /**
  * Tests for EPUB restore behavior to prevent position drift regression.
@@ -19,7 +21,11 @@ import org.readium.r2.shared.util.Url
  * Fix: Skip scrollToLocations() when already positioned correctly (within 1% delta).
  *
  * See: /Users/mulev/Documents/projects/project_plans/epist/todo/epist_fix_epub_location_restore_android.md
+ *
+ * Uses Robolectric so that Readium's Url class can call android.net.Uri.parse.
  */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], manifest = Config.NONE)
 internal class EpubNavigatorRestoreTest {
 
     /**

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -150,6 +150,55 @@ await flureadium.setPDFPreferences(PDFPreferences(
 - `PdfReaderFragment.kt` - Android Fragment hosting the PDF view
 - `FlutterPdfPreferences.kt` - Maps Flutter preferences to Readium
 
+## Edge Tap and Swipe Navigation
+
+Android supports the same configurable gesture overlay as iOS via `setNavigationConfig()`.
+
+### Overview
+
+A transparent `EdgeTapInterceptView` overlay is placed on top of the Readium navigator
+(both EPUB and PDF). It intercepts touches in the left and right edge zones and fires
+navigation callbacks; center touches always pass through to the reader content.
+
+### setNavigationConfig
+
+```dart
+await flureadium.setNavigationConfig(NavigationConfig(
+  enableEdgeTapNavigation: true,   // tap left/right edges to turn pages
+  enableSwipeNavigation: true,     // horizontal fling to turn pages
+  edgeTapAreaPoints: 60,           // edge zone width in dp (44–120, clamped)
+));
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enableEdgeTapNavigation` | `bool?` | enabled | Tap in the edge zone → navigate |
+| `enableSwipeNavigation` | `bool?` | enabled | Horizontal fling → navigate |
+| `edgeTapAreaPoints` | `double?` | 44 dp | Edge zone width, clamped to 44–120 dp |
+
+`null` fields are treated as **enabled** (matching iOS semantics).
+
+### Scroll Mode (EPUB only)
+
+When the EPUB reader switches to vertical scroll mode (via `setPreferences` with
+`verticalScroll: true`), the overlay automatically disables all gesture interception
+so Readium's WebView can handle native scrolling. Gestures are re-enabled when
+scroll mode is turned off.
+
+PDF is always paginated; scroll mode does not apply.
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `FlutterNavigationConfig.kt` | Data class mirroring the Flutter config map |
+| `EdgeTapInterceptView.kt` | Transparent FrameLayout overlay; intercepts edge touches |
+| `EpubReaderFragment.kt` | Creates and tears down the overlay per lifecycle; propagates scroll mode |
+| `PdfReaderFragment.kt` | Creates and tears down the overlay per lifecycle |
+| `EpubNavigator.kt` / `PdfNavigator.kt` | Delegates `setNavigationConfig` / `setScrollMode` to the fragment |
+| `ReadiumReader.kt` | Exposes `epubSetNavigationConfig`, `epubSetScrollMode`, `pdfSetNavigationConfig` |
+| `ReadiumReaderWidget.kt` | Handles `setNavigationConfig` method call; detects scroll mode from `setPreferences` |
+
 ## Troubleshooting
 
 ### "MainActivity cannot be cast to FragmentActivity"

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -199,6 +199,22 @@ PDF is always paginated; scroll mode does not apply.
 | `ReadiumReader.kt` | Exposes `epubSetNavigationConfig`, `epubSetScrollMode`, `pdfSetNavigationConfig` |
 | `ReadiumReaderWidget.kt` | Handles `setNavigationConfig` method call; detects scroll mode from `setPreferences` |
 
+#### Touch dispatch design
+
+`EdgeTapInterceptView` overrides `dispatchTouchEvent` rather than `onInterceptTouchEvent` +
+`onTouchEvent`. The reason matters for future maintenance:
+
+- `onInterceptTouchEvent` returning `true` causes the ViewGroup to call `onTouchEvent`.
+- `onTouchEvent` returns `gestureDetector.onTouchEvent()`, which returns `onDown() = false`
+  (the `SimpleOnGestureListener` default).
+- That `false` propagates out of `dispatchTouchEvent`, so the **parent `FrameLayout` never
+  records this view as the touch target** — `ACTION_UP` never arrives, and
+  `onSingleTapConfirmed` never fires.
+
+`dispatchTouchEvent` avoids this by returning `true` unconditionally for any `ACTION_DOWN`
+that lands in an edge zone (claiming the gesture sequence), and `false` for centre touches
+(passing them straight to the Readium WebView / PDF view).
+
 ## Troubleshooting
 
 ### "MainActivity cannot be cast to FragmentActivity"
@@ -222,6 +238,19 @@ android {
 1. Check TTS engine is installed (Settings > Accessibility > TTS)
 2. Download language data if prompted
 3. Test with system TTS settings
+
+### Edge taps not responding
+
+If edge taps appear in Flutter's `Listener` logs but no navigation occurs:
+
+1. Check logcat for `D/EdgeTapInterceptView: dispatchTouchEvent ACTION_DOWN x=... claimed=true`.
+   If `claimed=false` for a tap at the screen edge, the tap coordinate in **dp** is outside
+   the configured zone — verify `edgeTapAreaPoints` and screen density.
+2. If there are no `EdgeTapInterceptView` logs at all, the overlay was not created. Confirm
+   `attachNavigator()` ran and `view as? FrameLayout` succeeded (the fragment root must be a
+   `FrameLayout`, which it is by default via `fragment_reader.xml`).
+3. In EPUB scroll mode, all overlay gestures are intentionally disabled; check that
+   `setScrollMode(false)` was called when leaving scroll mode.
 
 ### WebView rendering issues
 

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.6.0
+version: 0.7.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- Adds `FlutterNavigationConfig` data class for deserializing `setNavigationConfig()` calls on Android, matching the existing iOS model
- Adds `EdgeTapInterceptView` — a transparent `FrameLayout` overlay placed on top of the Readium navigator (EPUB and PDF) that intercepts touches in the configurable left/right edge zones; center touches always pass through to the WebView/PDF view
- Wires the overlay into `EpubReaderFragment` and `PdfReaderFragment` lifecycle: created in `attachNavigator()`, torn down in `onPause()`, config stored and re-applied on resume
- Detects EPUB vertical scroll mode from `setPreferences` and disables overlay gestures automatically so Readium's WebView can handle native scrolling
- Fixes standalone Android unit test environment: adds Flutter embedding, kotlin-test, Mockito, org.json, and Robolectric to test classpath; corrects pre-existing test failures in `FlureadiumPluginTest`, `FlutterPdfPreferencesTest`, and `EpubNavigatorRestoreTest`

## Touch dispatch design

`EdgeTapInterceptView` overrides `dispatchTouchEvent` rather than `onInterceptTouchEvent` + `onTouchEvent`. The `onInterceptTouchEvent` approach failed silently: `onTouchEvent` returned `gestureDetector.onTouchEvent()` = `onDown()` = `false`, so the parent `FrameLayout` never registered the overlay as the touch target and `ACTION_UP` never arrived — edge taps had no effect. `dispatchTouchEvent` returns `true` unconditionally for claimed edge-zone gestures, keeping the sequence alive until `ACTION_UP`.

## Test plan

- [x] Android unit tests: 65 tests, 0 failures (`./gradlew testDebugUnitTest`)
  - `FlutterNavigationConfigTest` — 7 tests: config parsing, clamping, defaults
  - `EdgeTapInterceptViewTest` — 13 tests: zone detection, dp conversion, config and scroll mode helpers
  - `EdgeTapInterceptViewDispatchTest` — 11 Robolectric behavioural tests: gesture claiming, pass-through, callback firing, scroll mode
  - `EpubNavigatorRestoreTest` — 8 Robolectric tests: progression delta and locator equivalence
  - `FlutterPdfPreferencesTest`, `FlureadiumPluginTest` — existing tests fixed and passing
- [x] Flutter unit tests: all pass (`flutter test`)
- [x] Manual: edge tap and swipe navigation on a physical Android device (EPUB and PDF)