### PR TITLE
fix: EdgeTapInterceptView always intercepts edge zones in paginated mode (iOS 26)

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 0.7.2
+
+### Bug fixes
+
+- **iOS / Edge tap interception (iOS 26+)**: iOS 26 changed how Flutter routes touches on
+  platform views. With `enableEdgeTapNavigation = false`, no tap callbacks were set on
+  `EdgeTapInterceptView`, so edge-zone touches fell through to WKWebView. Readium's
+  `DirectionalNavigationAdapter` picked them up and turned the page anyway.
+
+  Root cause: `hitTest` was gated on `onLeftEdgeTap != nil`, not on whether interception
+  was wanted.
+
+  Fix: `EdgeTapInterceptView` now has an `interceptEdgeTaps: Bool` property. `hitTest`
+  checks the flag, not callbacks. `ReadiumReaderView` sets it `true` in paginated mode
+  (regardless of `enableEdgeTapNavigation`) and `false` in scroll mode. `PdfReaderView`
+  sets it equal to `enableEdgeTapNavigation`. When `true`, edge-zone touches never reach
+  `DirectionalNavigationAdapter`; with no callbacks set, the touch does nothing. No Dart
+  changes. Behaviour on iOS 13-18 is unchanged.
+
+### Documentation
+
+- `docs/platform-specific/ios.md`: Added the iOS 26 `interceptEdgeTaps` fix and per-mode
+  behaviour (paginated always intercepts, scroll never, PDF follows
+  `enableEdgeTapNavigation`).
+
+---
+
 ## 0.7.1
 
 ### Bug Fixes

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -155,6 +155,18 @@ await flureadium.setNavigationConfig(
 
 Both default to enabled (`true`) when not set. The `edgeTapAreaPoints` value is in absolute iOS points (44–120, clamped automatically) and defaults to 44pt (iOS HIG minimum tap target).
 
+**iOS 26 touch routing — `interceptEdgeTaps`:**
+
+On iOS 26+, Flutter changed how platform view touches are routed. Edge-zone touches now fall through `EdgeTapInterceptView` to the underlying WKWebView when there are no intercept callbacks set, which lets Readium's `DirectionalNavigationAdapter` see those touches — even when edge tap navigation is turned off.
+
+To fix this, `EdgeTapInterceptView` has an `interceptEdgeTaps: Bool` property (default `false`) that is independent of callback presence:
+
+- **EPUB paginated mode** — `interceptEdgeTaps = true` always. The view absorbs all edge-zone touches regardless of whether callbacks are configured. `DirectionalNavigationAdapter` never sees them.
+- **EPUB scroll mode** — `interceptEdgeTaps = false`. WKWebView receives all touches natively for scrolling.
+- **PDF reader** — `interceptEdgeTaps = enableEdgeTapNavigation`. PDF has no scroll mode on this path, so the view only intercepts when the feature is on.
+
+This is a native iOS layer change only. No Dart or Flutter changes are required.
+
 **Files:**
 - `EdgeTapInterceptView.swift` - Shared edge tap and swipe detection view
 - `ReadiumReaderView.swift` - EPUB reader using EdgeTapInterceptView

--- a/flureadium/ios/flureadium/Sources/flureadium/EdgeTapInterceptView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/EdgeTapInterceptView.swift
@@ -22,6 +22,11 @@ class EdgeTapInterceptView: UIView {
     var onSwipeRight: (() -> Void)?
     /// Edge threshold in absolute points (default 44pt, iOS HIG minimum tap target)
     var edgeThresholdPoints: CGFloat = 44.0
+    /// When true, hitTest returns self for any touch in an edge zone,
+    /// preventing downstream gesture recognizers (e.g. DirectionalNavigationAdapter)
+    /// from seeing those touches. Set to true in paginated mode regardless of
+    /// whether edge tap callbacks are configured.
+    var interceptEdgeTaps: Bool = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -84,9 +89,7 @@ class EdgeTapInterceptView: UIView {
         let isLeftEdge = point.x < edgeSize
         let isRightEdge = point.x > bounds.width - edgeSize
 
-        // If we have edge tap callbacks and the touch is in an edge zone,
-        // return self so our gesture recognizer receives the tap
-        if (isLeftEdge && onLeftEdgeTap != nil) || (isRightEdge && onRightEdgeTap != nil) {
+        if interceptEdgeTaps && (isLeftEdge || isRightEdge) {
             return self
         }
 

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -229,6 +229,10 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
   private func configureEdgeTapHandlers() {
     guard let edgeTapView = _view as? EdgeTapInterceptView else { return }
 
+    // Intercept edge zones only when edge tap navigation is active.
+    // PDF reader has no scroll mode on this view path.
+    edgeTapView.interceptEdgeTaps = enableEdgeTapNavigation
+
     if enableEdgeTapNavigation {
       if let points = edgeTapAreaPoints {
         edgeTapView.edgeThresholdPoints = points

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -308,6 +308,11 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   private func configureEdgeTapHandlers(isScrollMode: Bool) {
     guard let edgeTapView = _view as? EdgeTapInterceptView else { return }
 
+    // In scroll mode, let WKWebView handle swipes natively — don't intercept.
+    // In paginated mode, always intercept edge zones so DirectionalNavigationAdapter
+    // cannot handle them, regardless of whether edge tap callbacks are set.
+    edgeTapView.interceptEdgeTaps = !isScrollMode
+
     if isScrollMode {
       // Scroll mode: all callbacks nil.
       // Swipes are handled natively by WKWebView — no interception needed.

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/EdgeTapInterceptViewTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/EdgeTapInterceptViewTests.swift
@@ -77,17 +77,19 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testHitTestReturnsNilWhenNoCallbacks() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.interceptEdgeTaps = false  // pass-through is gated on interceptEdgeTaps, not callback presence
         // No callbacks set
 
         let leftEdgePoint = CGPoint(x: 5, y: 50)
         let rightEdgePoint = CGPoint(x: 95, y: 50)
 
-        XCTAssertNil(view.hitTest(leftEdgePoint, with: nil), "Hit test should return nil for left edge when no callback")
-        XCTAssertNil(view.hitTest(rightEdgePoint, with: nil), "Hit test should return nil for right edge when no callback")
+        XCTAssertNil(view.hitTest(leftEdgePoint, with: nil), "Hit test should return nil for left edge when interceptEdgeTaps=false")
+        XCTAssertNil(view.hitTest(rightEdgePoint, with: nil), "Hit test should return nil for right edge when interceptEdgeTaps=false")
     }
 
     func testHitTestReturnsSelfForLeftEdgeWithCallback() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
 
         let leftEdgePoint = CGPoint(x: 20, y: 50)
@@ -96,6 +98,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testHitTestReturnsSelfForRightEdgeWithCallback() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.interceptEdgeTaps = true
         view.onRightEdgeTap = { }
 
         let rightEdgePoint = CGPoint(x: 75, y: 50)
@@ -149,6 +152,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testExactlyOnLeftEdgeBoundary() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
         let edgeSize = view.edgeThresholdPoints // 44
 
@@ -159,6 +163,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testExactlyOnRightEdgeBoundary() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.interceptEdgeTaps = true
         view.onRightEdgeTap = { }
         let edgeSize = view.edgeThresholdPoints // 44
         let rightBoundary = view.bounds.width - edgeSize // 56
@@ -172,6 +177,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
     func testEdgeDetectionWithLargeView() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 1000, height: 800))
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
@@ -188,6 +194,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testEdgeDetectionWithSmallView() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
         view.edgeThresholdPoints = 10.0  // Use a small threshold for this small view test
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
@@ -222,6 +229,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testCustomThresholdChangesEdgeZones() {
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.edgeThresholdPoints = 30.0  // 30pt threshold
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
@@ -243,6 +251,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
         // Simulates configureEdgeTapHandlers() updating edgeThresholdPoints at runtime
         // (the behavior relied on by ReadiumReaderView and PdfReaderView after setPreferences)
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
 
         // Default 44pt threshold: x=50 is outside left edge (50 >= 44)
@@ -258,6 +267,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testThresholdUpdateShrinksEdgeZone() {
         // Verify that shrinking the threshold takes effect immediately
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
         view.edgeThresholdPoints = 80.0
 
@@ -274,6 +284,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testThresholdUpdateAffectsBothEdgesSynchronously() {
         // Verify both left and right edge zones update when threshold changes
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
         view.onRightEdgeTap = { }
 
@@ -291,6 +302,7 @@ final class EdgeTapInterceptViewTests: XCTestCase {
     func testThresholdCanBeUpdatedMultipleTimes() {
         // Verify multiple sequential updates all take effect (regression check for var mutation)
         let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.interceptEdgeTaps = true
         view.onLeftEdgeTap = { }
 
         let testPoint = CGPoint(x: 60, y: 50)
@@ -306,5 +318,68 @@ final class EdgeTapInterceptViewTests: XCTestCase {
 
         view.edgeThresholdPoints = 70.0  // 60 < 70 → in edge
         XCTAssertEqual(view.hitTest(testPoint, with: nil), view, "x=60 in left edge at 70pt")
+    }
+
+    // MARK: - interceptEdgeTaps Property Tests
+
+    func testInterceptEdgeTapsDefaultIsFalse() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        XCTAssertFalse(view.interceptEdgeTaps, "interceptEdgeTaps should default to false")
+    }
+
+    func testHitTestReturnsSelfWithInterceptEnabledAndNoCallback() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.interceptEdgeTaps = true
+        // No callbacks set
+
+        XCTAssertEqual(view.hitTest(CGPoint(x: 5, y: 50), with: nil), view,
+            "Left edge should return self when interceptEdgeTaps=true even with no callback")
+        XCTAssertEqual(view.hitTest(CGPoint(x: 95, y: 50), with: nil), view,
+            "Right edge should return self when interceptEdgeTaps=true even with no callback")
+    }
+
+    func testHitTestPassesThroughWithInterceptDisabledRegardlessOfCallbacks() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.interceptEdgeTaps = false
+        view.onLeftEdgeTap = { }
+        view.onRightEdgeTap = { }
+
+        // With interceptEdgeTaps=false, hitTest falls through to super even if callbacks are set.
+        // super.hitTest in XCTest (no window) returns nil for edge points — assert not self.
+        let leftResult = view.hitTest(CGPoint(x: 5, y: 50), with: nil)
+        let rightResult = view.hitTest(CGPoint(x: 95, y: 50), with: nil)
+        XCTAssertNotEqual(leftResult, view, "Should not return self for left edge when interceptEdgeTaps=false")
+        XCTAssertNotEqual(rightResult, view, "Should not return self for right edge when interceptEdgeTaps=false")
+    }
+
+    func testHitTestReturnsSelfForBothEdgesWhenInterceptEnabled() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 812))
+        view.interceptEdgeTaps = true
+
+        XCTAssertEqual(view.hitTest(CGPoint(x: 9, y: 400), with: nil), view,
+            "Left edge (x=9) intercepted on iPhone-sized view")
+        XCTAssertEqual(view.hitTest(CGPoint(x: 366, y: 400), with: nil), view,
+            "Right edge (x=366) intercepted on iPhone-sized view")
+    }
+
+    func testCenterZoneAlwaysPassesThroughWhenInterceptEnabled() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 812))
+        view.interceptEdgeTaps = true
+        view.onLeftEdgeTap = { }
+        view.onRightEdgeTap = { }
+
+        let centerResult = view.hitTest(CGPoint(x: 187, y: 400), with: nil)
+        XCTAssertNotEqual(centerResult, view,
+            "Center zone should never be intercepted even when interceptEdgeTaps=true")
+    }
+
+    func testInterceptDisabledByDefaultPreventsAccidentalBlocking() {
+        // Regression: freshly created view (before configureEdgeTapHandlers) must not intercept.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 812))
+
+        XCTAssertNotEqual(view.hitTest(CGPoint(x: 9, y: 400), with: nil), view,
+            "Edge zones should not be intercepted in default state")
+        XCTAssertNotEqual(view.hitTest(CGPoint(x: 366, y: 400), with: nil), view,
+            "Edge zones should not be intercepted in default state")
     }
 }

--- a/flureadium/ios/flureadium/Tests/flureadiumTests/ScrollModeNavigationTests.swift
+++ b/flureadium/ios/flureadium/Tests/flureadiumTests/ScrollModeNavigationTests.swift
@@ -199,6 +199,26 @@ final class ScrollModeNavigationTests: XCTestCase {
         XCTAssertNotNil(view.onRightEdgeTap, "Paginated mode right tap must remain non-nil")
     }
 
+    func testScrollMode_interceptEdgeTapsFalse() {
+        // In scroll mode, configureEdgeTapHandlers sets interceptEdgeTaps = false
+        // so WKWebView receives all touches natively.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        view.interceptEdgeTaps = false  // simulate scroll mode branch
+
+        XCTAssertFalse(view.interceptEdgeTaps,
+            "interceptEdgeTaps must be false in scroll mode")
+    }
+
+    func testPaginatedMode_interceptEdgeTapsTrue() {
+        // In paginated mode, configureEdgeTapHandlers sets interceptEdgeTaps = true
+        // regardless of enableEdgeTapNavigation, to block DirectionalNavigationAdapter.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        view.interceptEdgeTaps = true  // simulate paginated mode branch
+
+        XCTAssertTrue(view.interceptEdgeTaps,
+            "interceptEdgeTaps must be true in paginated mode")
+    }
+
     // MARK: - isBackwardNavigation(from:to:in:)
 
     func testIsBackwardNavigation_emptyReadingOrder_returnsFalse() {

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## What

On iOS 26+, Flutter changed how platform view touches are routed. When `enableEdgeTapNavigation = false` there are no tap callbacks set on `EdgeTapInterceptView`, so edge-zone touches fall through to WKWebView and Readium's `DirectionalNavigationAdapter` turns the page anyway.

The root cause: `hitTest` was gated on callback presence (`onLeftEdgeTap != nil`) rather than on whether interception was wanted.

## Fix

Added `interceptEdgeTaps: Bool = false` to `EdgeTapInterceptView`. `hitTest` now checks this flag, not callbacks.

`ReadiumReaderView` sets it `true` in paginated mode (regardless of `enableEdgeTapNavigation`) and `false` in scroll mode. `PdfReaderView` sets it equal to `enableEdgeTapNavigation`.

When `interceptEdgeTaps = true`, an edge-zone touch returns `self` from `hitTest` and `DirectionalNavigationAdapter` never sees it. If no callbacks are set, `handleTap` does nothing. Native iOS only — no Dart changes, no behavior change on iOS 13–18.

## Tests

- 9 existing `EdgeTapInterceptViewTests` regressions updated to set `interceptEdgeTaps` alongside callbacks
- 6 new `EdgeTapInterceptViewTests` covering the flag: default false, intercept with no callback, pass-through when flag is off, both edges, center zone, accidental-blocking guard
- 2 new `ScrollModeNavigationTests` for scroll and paginated mode state
- `flutter test` passed, Android `testDebugUnitTest` passed, `flutter build ios --simulator` passed