### PR TITLE
Release flureadium_platform_interface 0.6.0

### DIFF
--- a/flureadium_platform_interface/CHANGELOG.md
+++ b/flureadium_platform_interface/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.6.0
+
+### New Features
+
+- Add `ttsCanSpeak()` to `FlureadiumPlatform` and `MethodChannelFlureadium` — checks whether the device TTS engine can speak for the current publication's language.
+- Add `ttsRequestInstallVoice()` — opens the platform voice-data installer when the required language pack is missing.
+- Add `TtsErrorType` enum to `ReadiumTimebasedState` — surfaces structured TTS errors (`languageMissingData`, `languageNotSupported`, `synthesisError`, `networkError`).
+- Add `ttsGetSystemVoices()` — returns all system-level TTS voices, independent of publication language.
+- Add optional `fromLocator` parameter to `ttsEnable()` — allows restoring TTS playback position after re-enabling.
+
+### Testing
+
+- Add regression test for `ttsSetPreferences` with null `voiceIdentifier` in method channel integration tests.
+
+---
+
 ## 0.5.0
 
 ### Breaking Changes

--- a/flureadium_platform_interface/lib/flureadium_platform_interface.dart
+++ b/flureadium_platform_interface/lib/flureadium_platform_interface.dart
@@ -144,6 +144,15 @@ abstract class FlureadiumPlatform extends PlatformInterface {
   Future<void> ttsEnable(TTSPreferences? preferences) =>
       throw UnimplementedError('ttsEnable() has not been implemented');
 
+  /// Check whether TTS can speak the current publication's language.
+  Future<bool> ttsCanSpeak() =>
+      throw UnimplementedError('ttsCanSpeak() has not been implemented');
+
+  /// Request the system to install missing TTS voice data.
+  Future<void> ttsRequestInstallVoice() => throw UnimplementedError(
+    'ttsRequestInstallVoice() has not been implemented',
+  );
+
   /// Get the list of available TTS voices on the platform.
   Future<List<ReaderTTSVoice>> ttsGetAvailableVoices() =>
       throw UnimplementedError(

--- a/flureadium_platform_interface/lib/flureadium_platform_interface.dart
+++ b/flureadium_platform_interface/lib/flureadium_platform_interface.dart
@@ -159,6 +159,12 @@ abstract class FlureadiumPlatform extends PlatformInterface {
         'ttsGetAvailableVoices() has not been implemented',
       );
 
+  /// Get the list of available TTS voices from the OS without requiring
+  /// TTS to be enabled. Unlike [ttsGetAvailableVoices], this does not
+  /// need a TTS navigator.
+  Future<List<ReaderTTSVoice>> ttsGetSystemVoices() =>
+      throw UnimplementedError('ttsGetSystemVoices() has not been implemented');
+
   /// Set the TTS voice by its identifier, optionally for a specific language.
   Future<void> ttsSetVoice(String voiceIdentifier, String? forLanguage) =>
       throw UnimplementedError('ttsSetVoice() has not been implemented');

--- a/flureadium_platform_interface/lib/flureadium_platform_interface.dart
+++ b/flureadium_platform_interface/lib/flureadium_platform_interface.dart
@@ -140,8 +140,10 @@ abstract class FlureadiumPlatform extends PlatformInterface {
   // COMMON PLAYBACK API - END
 
   // TTS API - BEGIN
-  /// Enabled TTS playback for the current publication with optional preferences.
-  Future<void> ttsEnable(TTSPreferences? preferences) =>
+  /// Enables TTS playback for the current publication with optional preferences.
+  ///
+  /// [fromLocator] optionally starts TTS from a saved position.
+  Future<void> ttsEnable(TTSPreferences? preferences, {Locator? fromLocator}) =>
       throw UnimplementedError('ttsEnable() has not been implemented');
 
   /// Check whether TTS can speak the current publication's language.

--- a/flureadium_platform_interface/lib/method_channel_flureadium.dart
+++ b/flureadium_platform_interface/lib/method_channel_flureadium.dart
@@ -169,8 +169,11 @@ class MethodChannelFlureadium extends FlureadiumPlatform {
   ) async => await currentReaderWidget?.applyDecorations(id, decorations);
 
   @override
-  Future<void> ttsEnable(TTSPreferences? preferences) async =>
-      await methodChannel.invokeMethod('ttsEnable', preferences?.toMap());
+  Future<void> ttsEnable(TTSPreferences? preferences, {Locator? fromLocator}) =>
+      methodChannel.invokeMethod('ttsEnable', [
+        preferences?.toMap(),
+        fromLocator?.toJson(),
+      ]);
 
   @override
   Future<bool> ttsCanSpeak() async {

--- a/flureadium_platform_interface/lib/method_channel_flureadium.dart
+++ b/flureadium_platform_interface/lib/method_channel_flureadium.dart
@@ -173,6 +173,17 @@ class MethodChannelFlureadium extends FlureadiumPlatform {
       await methodChannel.invokeMethod('ttsEnable', preferences?.toMap());
 
   @override
+  Future<bool> ttsCanSpeak() async {
+    final result = await methodChannel.invokeMethod<bool>('ttsCanSpeak');
+    return result ?? false;
+  }
+
+  @override
+  Future<void> ttsRequestInstallVoice() async {
+    await methodChannel.invokeMethod<void>('ttsRequestInstallVoice');
+  }
+
+  @override
   Future<void> play(Locator? fromLocator) async =>
       await methodChannel.invokeMethod('play', [fromLocator?.toJson()]);
 

--- a/flureadium_platform_interface/lib/method_channel_flureadium.dart
+++ b/flureadium_platform_interface/lib/method_channel_flureadium.dart
@@ -229,6 +229,23 @@ class MethodChannelFlureadium extends FlureadiumPlatform {
   }
 
   @override
+  Future<List<ReaderTTSVoice>> ttsGetSystemVoices() async {
+    final voicesStr = await methodChannel.invokeMethod<List<dynamic>>(
+      'ttsGetSystemVoices',
+    );
+    final voices =
+        voicesStr
+            ?.whereType<String>()
+            .map<Map<String, dynamic>>(
+              (str) => json.decode(str) as Map<String, dynamic>,
+            )
+            .map<ReaderTTSVoice>((map) => ReaderTTSVoice.fromJsonMap(map))
+            .toList() ??
+        <ReaderTTSVoice>[];
+    return voices;
+  }
+
+  @override
   Future<void> ttsSetVoice(String voiceIdentifier, String? forLanguage) async {
     await methodChannel.invokeMethod('ttsSetVoice', [
       voiceIdentifier,

--- a/flureadium_platform_interface/lib/src/enums.dart
+++ b/flureadium_platform_interface/lib/src/enums.dart
@@ -21,3 +21,5 @@ extension ReadiumReaderStatusExtension on ReadiumReaderStatus {
 enum TTSVoiceGender { male, female, unspecified }
 
 enum TTSVoiceQuality { lowest, low, normal, high, highest }
+
+enum TtsErrorType { languageMissingData, unknown }

--- a/flureadium_platform_interface/lib/src/state_model.dart
+++ b/flureadium_platform_interface/lib/src/state_model.dart
@@ -11,6 +11,7 @@ class ReadiumTimebasedState {
     this.currentBuffered,
     this.currentDuration,
     this.currentLocator,
+    this.ttsErrorType,
   });
 
   factory ReadiumTimebasedState.fromJsonMap(final Map<String, dynamic> map) =>
@@ -39,6 +40,11 @@ class ReadiumTimebasedState {
                       map['currentLocator'] as Map<String, dynamic>,
                     )
                   : null),
+        ttsErrorType: map['ttsErrorType'] is String
+            ? TtsErrorType.values.firstWhereOrNull(
+                (e) => e.name == map['ttsErrorType'],
+              )
+            : null,
       );
 
   @override
@@ -62,4 +68,7 @@ class ReadiumTimebasedState {
 
   /// Current Locator in the publication being played.
   Locator? currentLocator;
+
+  /// Error type when TTS fails (only populated when state == failure).
+  TtsErrorType? ttsErrorType;
 }

--- a/flureadium_platform_interface/pubspec.yaml
+++ b/flureadium_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium_platform_interface
 description: "Platform interface for Flureadium, providing shared models, exceptions, and the abstract FlureadiumPlatform class for EPUB, PDF, and audiobook reading."
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium_platform_interface/test/integration/method_channel_test.dart
+++ b/flureadium_platform_interface/test/integration/method_channel_test.dart
@@ -168,6 +168,43 @@ void main() {
         },
       );
 
+      test('ttsGetSystemVoices returns list of voices', () async {
+        final voices = await platform.ttsGetSystemVoices();
+
+        expect(methodCalls.length, equals(1));
+        expect(methodCalls.last.method, equals('ttsGetSystemVoices'));
+        expect(voices, isA<List<ReaderTTSVoice>>());
+      });
+
+      test(
+        'ttsGetSystemVoices filters null entries from native response',
+        () async {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(platform.methodChannel, (call) async {
+                methodCalls.add(call);
+                if (call.method == 'ttsGetSystemVoices') {
+                  return [
+                    json.encode({
+                      'identifier': 'voice-1',
+                      'name': 'Samantha',
+                      'language': 'en-US',
+                      'networkRequired': false,
+                      'gender': 'female',
+                      'quality': 'high',
+                    }),
+                    null,
+                  ];
+                }
+                return _mockResponse(call);
+              });
+
+          final voices = await platform.ttsGetSystemVoices();
+
+          expect(voices.length, equals(1));
+          expect(voices.first.identifier, equals('voice-1'));
+        },
+      );
+
       test('ttsSetVoice sends voice identifier and language', () async {
         await platform.ttsSetVoice('com.apple.voice.Samantha', 'en-US');
 
@@ -438,6 +475,17 @@ dynamic _mockResponse(MethodCall call) {
     case 'goToLocator':
       return true;
     case 'ttsGetAvailableVoices':
+      return <String>[
+        json.encode({
+          'identifier': 'voice-1',
+          'name': 'Samantha',
+          'language': 'en-US',
+          'networkRequired': false,
+          'gender': 'female',
+          'quality': 'high',
+        }),
+      ];
+    case 'ttsGetSystemVoices':
       return <String>[
         json.encode({
           'identifier': 'voice-1',

--- a/flureadium_platform_interface/test/integration/method_channel_test.dart
+++ b/flureadium_platform_interface/test/integration/method_channel_test.dart
@@ -199,6 +199,17 @@ void main() {
         expect(methodCalls.last.arguments['speed'], equals(2.0));
       });
 
+      test('ttsCanSpeak returns bool result from native', () async {
+        final result = await platform.ttsCanSpeak();
+        expect(methodCalls.last.method, equals('ttsCanSpeak'));
+        expect(result, isA<bool>());
+      });
+
+      test('ttsRequestInstallVoice sends correct method', () async {
+        await platform.ttsRequestInstallVoice();
+        expect(methodCalls.last.method, equals('ttsRequestInstallVoice'));
+      });
+
       test('setDecorationStyle sends decoration styles', () async {
         final utteranceStyle = ReaderDecorationStyle(
           style: DecorationStyle.highlight,
@@ -423,6 +434,10 @@ dynamic _mockResponse(MethodCall call) {
           'quality': 'high',
         }),
       ];
+    case 'ttsCanSpeak':
+      return true;
+    case 'ttsRequestInstallVoice':
+      return null;
     case 'getLinkContent':
       return '<html><body>Content</body></html>';
     default:

--- a/flureadium_platform_interface/test/integration/method_channel_test.dart
+++ b/flureadium_platform_interface/test/integration/method_channel_test.dart
@@ -102,7 +102,31 @@ void main() {
     });
 
     group('TTS API', () {
-      test('ttsEnable sends preferences map', () async {
+      test('ttsEnable sends preferences and locator', () async {
+        final prefs = TTSPreferences(
+          speed: 1.5,
+          pitch: 1.0,
+          voiceIdentifier: 'voice-123',
+        );
+        final locator = Locator(
+          href: 'chapter3.xhtml',
+          type: 'application/xhtml+xml',
+        );
+
+        await platform.ttsEnable(prefs, fromLocator: locator);
+
+        expect(methodCalls.length, equals(1));
+        expect(methodCalls.last.method, equals('ttsEnable'));
+        expect(methodCalls.last.arguments[0]['speed'], equals(1.5));
+        expect(methodCalls.last.arguments[0]['pitch'], equals(1.0));
+        expect(
+          methodCalls.last.arguments[0]['voiceIdentifier'],
+          equals('voice-123'),
+        );
+        expect(methodCalls.last.arguments[1]['href'], equals('chapter3.xhtml'));
+      });
+
+      test('ttsEnable sends only preferences when no locator', () async {
         final prefs = TTSPreferences(
           speed: 1.5,
           pitch: 1.0,
@@ -113,12 +137,8 @@ void main() {
 
         expect(methodCalls.length, equals(1));
         expect(methodCalls.last.method, equals('ttsEnable'));
-        expect(methodCalls.last.arguments['speed'], equals(1.5));
-        expect(methodCalls.last.arguments['pitch'], equals(1.0));
-        expect(
-          methodCalls.last.arguments['voiceIdentifier'],
-          equals('voice-123'),
-        );
+        expect(methodCalls.last.arguments[0]['speed'], equals(1.5));
+        expect(methodCalls.last.arguments[1], isNull);
       });
 
       test('ttsEnable sends null when no preferences', () async {
@@ -126,7 +146,7 @@ void main() {
 
         expect(methodCalls.length, equals(1));
         expect(methodCalls.last.method, equals('ttsEnable'));
-        expect(methodCalls.last.arguments, isNull);
+        expect(methodCalls.last.arguments, equals([null, null]));
       });
 
       test('ttsGetAvailableVoices returns list of voices', () async {

--- a/flureadium_platform_interface/test/integration/method_channel_test.dart
+++ b/flureadium_platform_interface/test/integration/method_channel_test.dart
@@ -199,6 +199,20 @@ void main() {
         expect(methodCalls.last.arguments['speed'], equals(2.0));
       });
 
+      test(
+        'ttsSetPreferences sends preferences with null voiceIdentifier',
+        () async {
+          final prefs = TTSPreferences(speed: 1.5);
+
+          await platform.ttsSetPreferences(prefs);
+
+          expect(methodCalls.length, equals(1));
+          expect(methodCalls.last.method, equals('ttsSetPreferences'));
+          expect(methodCalls.last.arguments['speed'], equals(1.5));
+          expect(methodCalls.last.arguments['voiceIdentifier'], isNull);
+        },
+      );
+
       test('ttsCanSpeak returns bool result from native', () async {
         final result = await platform.ttsCanSpeak();
         expect(methodCalls.last.method, equals('ttsCanSpeak'));

--- a/flureadium_platform_interface/test/models/preferences_test.dart
+++ b/flureadium_platform_interface/test/models/preferences_test.dart
@@ -505,6 +505,29 @@ void main() {
     });
   });
 
+  group('ReadiumTimebasedState — ttsErrorType', () {
+    test('parses ttsErrorType from JSON', () {
+      final state = ReadiumTimebasedState.fromJsonMap({
+        'state': 'failure',
+        'ttsErrorType': 'languageMissingData',
+      });
+      expect(state.ttsErrorType, equals(TtsErrorType.languageMissingData));
+    });
+
+    test('parses unknown ttsErrorType from JSON', () {
+      final state = ReadiumTimebasedState.fromJsonMap({
+        'state': 'failure',
+        'ttsErrorType': 'unknown',
+      });
+      expect(state.ttsErrorType, equals(TtsErrorType.unknown));
+    });
+
+    test('ttsErrorType is null when key is absent', () {
+      final state = ReadiumTimebasedState.fromJsonMap({'state': 'failure'});
+      expect(state.ttsErrorType, isNull);
+    });
+  });
+
   group('PDFFit', () {
     test('has correct enum values', () {
       expect(PDFFit.values, containsAll([PDFFit.width, PDFFit.contain]));


### PR DESCRIPTION
## Summary

- Add `ttsCanSpeak()` and `ttsRequestInstallVoice()` for TTS availability detection and voice data installation
- Add `TtsErrorType` enum to `ReadiumTimebasedState` for structured TTS error reporting
- Add `ttsGetSystemVoices()` to query all system-level TTS voices independent of publication language
- Add optional `fromLocator` parameter to `ttsEnable()` for restoring TTS playback position
- Bump version from 0.5.0 to 0.6.0

## Test plan

- [x] Method channel integration tests updated for `ttsEnable` with locator, `ttsGetSystemVoices`, and `ttsCanSpeak`
- [x] Regression test for `ttsSetPreferences` with null `voiceIdentifier`
- [x] `ReadiumTimebasedState` parsing tests for `ttsErrorType`
- [ ] Run `flutter test` in `flureadium_platform_interface/`