### PR TITLE
fix(android): convert error.cause to String in publicationError()

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.1
+
+### Bug Fixes
+
+- **Android**: Convert `error.cause` to `String?` in `publicationError()` before passing it to `MethodChannel.Result.error()`. The Readium `Error` object was not codec-safe, causing `StandardMessageCodec` to throw `IllegalArgumentException: Unsupported value` and silently swallowing EPUB subject metadata.
+
 ## 0.8.0
 
 ### New Features

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
@@ -514,6 +514,6 @@ fun MethodChannel.Result.publicationError(method: String, error: PublicationErro
     this.error(
         error.errorCode.name,
         error.message,
-        error.cause
+        error.cause?.toString()
     )
 }

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PublicationChannelErrorTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PublicationChannelErrorTest.kt
@@ -1,0 +1,82 @@
+package dev.mulev.flureadium
+
+import io.flutter.plugin.common.MethodChannel
+import kotlin.test.Test
+import kotlin.test.assertIs
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.readium.r2.shared.util.Error
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class PublicationChannelErrorTest {
+
+    /** Helper: build a Readium Error with an optional cause. */
+    private fun fakeError(
+        msg: String,
+        inner: Error? = null
+    ): Error = object : Error {
+        override val message: String = msg
+        override val cause: Error? = inner
+        override fun toString(): String = "FakeError($msg)"
+    }
+
+    @Test
+    fun publicationError_withCause_detailsIsString() {
+        val mockResult = Mockito.mock(MethodChannel.Result::class.java)
+
+        // Unexpected(outerError) stores outerError.cause as the PublicationError.cause.
+        // outerError.cause is a Readium Error object — not codec-safe before the fix.
+        val innerCause = fakeError("underlying cause")
+        val outerError = fakeError("wrapper", inner = innerCause)
+        val error = PublicationError.Unexpected(outerError)
+
+        mockResult.publicationError("testMethod", error)
+
+        val detailsCaptor = ArgumentCaptor.forClass(Any::class.java)
+        verify(mockResult).error(
+            Mockito.eq(PublicationError.ReadiumExceptionType.unknown.name),
+            Mockito.eq("wrapper"),
+            detailsCaptor.capture()
+        )
+        // details must be a String, not a Readium Error object
+        assertIs<String>(detailsCaptor.value)
+    }
+
+    @Test
+    fun publicationError_withoutCause_detailsIsNull() {
+        val mockResult = Mockito.mock(MethodChannel.Result::class.java)
+        val error = PublicationError.Unavailable()
+
+        mockResult.publicationError("testMethod", error)
+
+        verify(mockResult).error(
+            PublicationError.ReadiumExceptionType.unavailable.name,
+            "Resource unavailable",
+            null
+        )
+    }
+
+    @Test
+    fun publicationError_unexpected_errorCodeAndMessagePreserved() {
+        val mockResult = Mockito.mock(MethodChannel.Result::class.java)
+        val outerError = fakeError("specific error message")
+        val error = PublicationError.Unexpected(outerError)
+
+        mockResult.publicationError("testMethod", error)
+
+        verify(mockResult).error("unknown", "specific error message", null)
+    }
+
+    @Test
+    fun publicationError_unknown_errorCodeAndMessagePreserved() {
+        val mockResult = Mockito.mock(MethodChannel.Result::class.java)
+        val error = PublicationError.Unknown("something went wrong")
+
+        mockResult.publicationError("testMethod", error)
+
+        verify(mockResult).error("unknown", "something went wrong", null)
+    }
+}

--- a/flureadium/docs/guides/error-handling.md
+++ b/flureadium/docs/guides/error-handling.md
@@ -400,6 +400,8 @@ Native code throws platform exceptions with string codes that map to `OpeningRea
 | `incorrectCredentials` | incorrectCredentials | Auth failed |
 | (other) | unknown | Unmapped error |
 
+The `details` field in platform channel errors is always `String?` or `null` — never a complex object. On Android, `publicationError()` converts `error.cause` to a string via `toString()` before passing it to `MethodChannel.Result.error()`. On iOS, `ReadiumError.toFlutterError()` uses `.localizedDescription` for the same purpose. This keeps the value compatible with Flutter's `StandardMessageCodec`, which only accepts primitives, maps, lists, and null.
+
 ---
 
 ## Summary
@@ -430,7 +432,7 @@ const _trace = <String>[
 
 ---
 
-**Last Updated**: 2026-02-01
+**Last Updated**: 2026-03-21
 **Related Files:**
 - `lib/src/exceptions/readium_exceptions.dart`
 - `lib/src/utils/r2_log.dart`

--- a/flureadium/example/integration_test/all_tests.dart
+++ b/flureadium/example/integration_test/all_tests.dart
@@ -4,6 +4,7 @@ import 'launch_test.dart' as launch;
 import 'audiobook_test.dart' as audiobook;
 import 'epub_test.dart' as epub;
 import 'epub_tts_test.dart' as epub_tts;
+import 'error_handling_test.dart' as error_handling;
 import 'webpub_test.dart' as webpub;
 
 void main() {
@@ -13,5 +14,6 @@ void main() {
   audiobook.main();
   epub.main();
   epub_tts.main();
+  error_handling.main();
   webpub.main();
 }

--- a/flureadium/example/integration_test/all_tests_android_ci.dart
+++ b/flureadium/example/integration_test/all_tests_android_ci.dart
@@ -5,10 +5,12 @@ import 'package:integration_test/integration_test.dart';
 
 import 'launch_test.dart' as launch;
 import 'epub_test.dart' as epub;
+import 'error_handling_test.dart' as error_handling;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   launch.main();
   epub.main();
+  error_handling.main();
 }

--- a/flureadium/example/integration_test/error_handling_test.dart
+++ b/flureadium/example/integration_test/error_handling_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flureadium/flureadium.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Error handling', () {
+    late Flureadium flureadium;
+
+    setUp(() {
+      flureadium = Flureadium();
+    });
+
+    tearDown(() async {
+      await flureadium.closePublication();
+    });
+
+    testWidgets('opening a corrupted file throws ReadiumException', (
+      tester,
+    ) async {
+      // Write garbage bytes to a temp file disguised as an EPUB.
+      final tmp = File(
+        '${Directory.systemTemp.path}/'
+        '${DateTime.now().millisecondsSinceEpoch}_corrupted.epub',
+      );
+      await tmp.writeAsBytes([0x00, 0x01, 0x02, 0x03]);
+
+      // openPublication must surface a ReadiumException rather than
+      // crashing with a codec error (IllegalArgumentException).
+      expect(
+        () => flureadium.openPublication(tmp.path),
+        throwsA(isA<ReadiumException>()),
+      );
+    });
+
+    testWidgets('opening a non-existent file throws ReadiumException', (
+      tester,
+    ) async {
+      final bogusPath =
+          '${Directory.systemTemp.path}/nonexistent_${DateTime.now().millisecondsSinceEpoch}.epub';
+
+      expect(
+        () => flureadium.openPublication(bogusPath),
+        throwsA(isA<ReadiumException>()),
+      );
+    });
+  });
+}

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.8.1"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- Convert `error.cause` to `error.cause?.toString()` in `publicationError()` so `StandardMessageCodec` receives a codec-safe `String?` instead of a Readium `Error` object that throws `IllegalArgumentException: Unsupported value`
- Add 4 Android unit tests covering cause/no-cause paths and errorCode/message preservation
- Add integration test that opens a corrupted file and a non-existent file, verifying errors surface as `ReadiumException` without codec crashes
- Bump version to 0.8.1

## Test plan

- [x] Android unit tests pass (90 tests, 0 failures)
- [x] Flutter unit tests pass
- [ ] Run `error_handling_test.dart` integration test on Android emulator