### PR TITLE
test(ios): add comprehensive iOS native unit tests

### DIFF
--- a/flureadium/docs/05-testing/ios-unit-tests.md
+++ b/flureadium/docs/05-testing/ios-unit-tests.md
@@ -20,6 +20,9 @@ flureadium/example/ios/RunnerTests/
 ├── UtilityTests.swift                 # clamp, firstMap, asyncCompactMap
 ├── ModelTests.swift                   # ControlPanelInfoType, NavigationConfig, TTS/Audio/PDF preferences
 ├── StateSerializationTests.swift      # ReadiumTimebasedState toJson, toJsonString, Equatable
+├── ReadiumExtensionsTests.swift       # Locator extensions, state mappings, EPUB/PDF preferences fromMap, TTSVoice.Quality
+├── FlutterMediaOverlayTests.swift     # FlutterMediaOverlayItem parsing/matching/locators, FlutterMediaOverlay matching/fromJson
+├── ReadiumErrorTests.swift            # ReadiumError/FlureadiumError to FlutterError conversions
 └── <YourNewTests>.swift               # Add new files here
 ```
 
@@ -81,16 +84,22 @@ Alternatively, open `Runner.xcworkspace` in Xcode once, drag the file into Runne
 
 ## Running Tests
 
-### Prerequisites
+### Prerequisites — MUST BUILD BEFORE TESTING
 
-The example app must be built for the iOS simulator at least once before running tests. This generates Flutter build artifacts that `xcodebuild` depends on. Without this step, `xcodebuild test` fails with a `PhaseScriptExecution` / `kernel_snapshot_program` error.
+**This step is mandatory before every test run where files or project configuration changed.** Without it, `xcodebuild test` fails silently (exit code 1, no useful error output) or with stale-artifact errors.
 
 ```bash
 cd flureadium/example
 flutter build ios --simulator --debug
 ```
 
-Re-run this when Flutter dependencies change (pubspec.yaml, plugin registration, etc.). Subsequent test runs reuse the cached build.
+**You MUST re-run this build step when:**
+- New `.swift` test files are added
+- `project.pbxproj` is modified (file registrations, build settings)
+- Flutter dependencies change (pubspec.yaml, plugin registration)
+- Pod dependencies are updated
+
+The build regenerates all Flutter artifacts, runs `pod install`, and ensures `xcodebuild` has a consistent workspace. Skipping it after structural changes causes failures that produce no diagnostic output — just an empty error with exit code 1.
 
 ### Picking a Simulator
 

--- a/flureadium/docs/05-testing/ios-unit-tests.md
+++ b/flureadium/docs/05-testing/ios-unit-tests.md
@@ -23,6 +23,8 @@ flureadium/example/ios/RunnerTests/
 ├── ReadiumExtensionsTests.swift       # Locator extensions, state mappings, EPUB/PDF preferences fromMap, TTSVoice.Quality
 ├── FlutterMediaOverlayTests.swift     # FlutterMediaOverlayItem parsing/matching/locators, FlutterMediaOverlay matching/fromJson
 ├── ReadiumErrorTests.swift            # ReadiumError/FlureadiumError to FlutterError conversions
+├── EdgeTapInterceptViewTests.swift   # hitTest geometry, edge interception, subview bypass
+├── NowPlayingInfoUpdaterTests.swift  # Chapter formatting for all ControlPanelInfoType variants
 └── <YourNewTests>.swift               # Add new files here
 ```
 
@@ -106,15 +108,18 @@ The build regenerates all Flutter artifacts, runs `pod install`, and ensures `xc
 Use the simulator UUID rather than its name. Name-based destinations (`platform=iOS Simulator,name=iPhone 16 Pro`) fail when multiple iOS runtimes define a simulator with the same name.
 
 ```bash
-# Grab the UUID of the first matching iPhone simulator
-SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
-# Fallback if no "Flutter Sim" custom simulator exists
+# Grab the UUID of the BOOTED Flutter Sim simulator
+SIM_ID=$(xcrun simctl list devices available | grep 'Flutter Sim.*Booted' | grep -oE '[A-F0-9-]{36}')
+# Fallback if no booted Flutter Sim exists
 [ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
 ```
 
-**Important:** The sim detection lines must be separate statements (no `&&` chaining with subsequent commands). When `SIM_ID` is found, `[ -z "$SIM_ID" ]` returns false, which breaks an `&&` chain and prevents `xcodebuild` from running.
+**Critical:** Always grep for `Flutter Sim.*Booted` — never `grep -m1 'iPhone.*Flutter Sim'`. Multiple Flutter Sim devices exist across iOS runtimes, and `-m1` picks the first match which may be Shutdown. xcodebuild silently fails (exit code 1, zero output) when targeting a Shutdown simulator.
 
-The simulator does not need to be booted — `xcodebuild` boots it automatically.
+If no simulator is booted, boot one first:
+```bash
+xcrun simctl boot $(xcrun simctl list devices available | grep -m1 'Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+```
 
 If you need a specific runtime version:
 
@@ -126,7 +131,7 @@ xcrun simctl list devices available "iOS 18.3"
 ### Run All iOS Unit Tests
 
 ```bash
-SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+SIM_ID=$(xcrun simctl list devices available | grep 'Flutter Sim.*Booted' | grep -oE '[A-F0-9-]{36}')
 [ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
 cd flureadium/example/ios && \
   xcodebuild test \
@@ -135,13 +140,13 @@ cd flureadium/example/ios && \
     -configuration Debug \
     -destination "id=$SIM_ID" \
     -only-testing:RunnerTests \
-    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -50
+    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed|SUCCEEDED|FAILED)' | tail -50
 ```
 
 ### Run a Specific Test Class
 
 ```bash
-SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+SIM_ID=$(xcrun simctl list devices available | grep 'Flutter Sim.*Booted' | grep -oE '[A-F0-9-]{36}')
 [ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
 cd flureadium/example/ios && \
   xcodebuild test \
@@ -150,13 +155,13 @@ cd flureadium/example/ios && \
     -configuration Debug \
     -destination "id=$SIM_ID" \
     -only-testing:RunnerTests/FlutterTTSNavigatorTests \
-    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -50
+    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed|SUCCEEDED|FAILED)' | tail -50
 ```
 
 ### Run a Single Test Method
 
 ```bash
-SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+SIM_ID=$(xcrun simctl list devices available | grep 'Flutter Sim.*Booted' | grep -oE '[A-F0-9-]{36}')
 [ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
 cd flureadium/example/ios && \
   xcodebuild test \
@@ -165,7 +170,7 @@ cd flureadium/example/ios && \
     -configuration Debug \
     -destination "id=$SIM_ID" \
     -only-testing:RunnerTests/FlutterTTSNavigatorTests/testPlayConsumesInitialLocator \
-    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -50
+    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed|SUCCEEDED|FAILED)' | tail -50
 ```
 
 ### Reading Output
@@ -180,7 +185,7 @@ The `grep` filter at the end shows pass/fail lines. Full xcodebuild output is ex
 For full output (debugging build failures), drop the `grep` pipe:
 
 ```bash
-SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+SIM_ID=$(xcrun simctl list devices available | grep 'Flutter Sim.*Booted' | grep -oE '[A-F0-9-]{36}')
 [ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
 cd flureadium/example/ios && \
   xcodebuild test \

--- a/flureadium/docs/05-testing/ios-unit-tests.md
+++ b/flureadium/docs/05-testing/ios-unit-tests.md
@@ -17,6 +17,9 @@ Instead, tests live in the **example app's RunnerTests target** and run via `xco
 flureadium/example/ios/RunnerTests/
 ├── RunnerTests.swift                  # Plugin handler tests
 ├── FlutterTTSNavigatorTests.swift     # TTS navigator tests
+├── UtilityTests.swift                 # clamp, firstMap, asyncCompactMap
+├── ModelTests.swift                   # ControlPanelInfoType, NavigationConfig, TTS/Audio/PDF preferences
+├── StateSerializationTests.swift      # ReadiumTimebasedState toJson, toJsonString, Equatable
 └── <YourNewTests>.swift               # Add new files here
 ```
 
@@ -100,6 +103,8 @@ SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | 
 [ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
 ```
 
+**Important:** The sim detection lines must be separate statements (no `&&` chaining with subsequent commands). When `SIM_ID` is found, `[ -z "$SIM_ID" ]` returns false, which breaks an `&&` chain and prevents `xcodebuild` from running.
+
 The simulator does not need to be booted — `xcodebuild` boots it automatically.
 
 If you need a specific runtime version:
@@ -112,38 +117,46 @@ xcrun simctl list devices available "iOS 18.3"
 ### Run All iOS Unit Tests
 
 ```bash
-cd flureadium/example/ios
-xcodebuild test \
-  -workspace Runner.xcworkspace \
-  -scheme Runner \
-  -configuration Debug \
-  -destination "id=$SIM_ID" \
-  -only-testing:RunnerTests \
-  2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -30
+SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+[ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
+cd flureadium/example/ios && \
+  xcodebuild test \
+    -workspace Runner.xcworkspace \
+    -scheme Runner \
+    -configuration Debug \
+    -destination "id=$SIM_ID" \
+    -only-testing:RunnerTests \
+    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -50
 ```
 
 ### Run a Specific Test Class
 
 ```bash
-xcodebuild test \
-  -workspace Runner.xcworkspace \
-  -scheme Runner \
-  -configuration Debug \
-  -destination "id=$SIM_ID" \
-  -only-testing:RunnerTests/FlutterTTSNavigatorTests \
-  2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -30
+SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+[ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
+cd flureadium/example/ios && \
+  xcodebuild test \
+    -workspace Runner.xcworkspace \
+    -scheme Runner \
+    -configuration Debug \
+    -destination "id=$SIM_ID" \
+    -only-testing:RunnerTests/FlutterTTSNavigatorTests \
+    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -50
 ```
 
 ### Run a Single Test Method
 
 ```bash
-xcodebuild test \
-  -workspace Runner.xcworkspace \
-  -scheme Runner \
-  -configuration Debug \
-  -destination "id=$SIM_ID" \
-  -only-testing:RunnerTests/FlutterTTSNavigatorTests/testPlayConsumesInitialLocator \
-  2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -30
+SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+[ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
+cd flureadium/example/ios && \
+  xcodebuild test \
+    -workspace Runner.xcworkspace \
+    -scheme Runner \
+    -configuration Debug \
+    -destination "id=$SIM_ID" \
+    -only-testing:RunnerTests/FlutterTTSNavigatorTests/testPlayConsumesInitialLocator \
+    2>&1 | grep -E '(Test Case|TEST |Executed|error:|failed)' | tail -50
 ```
 
 ### Reading Output
@@ -158,13 +171,16 @@ The `grep` filter at the end shows pass/fail lines. Full xcodebuild output is ex
 For full output (debugging build failures), drop the `grep` pipe:
 
 ```bash
-xcodebuild test \
-  -workspace Runner.xcworkspace \
-  -scheme Runner \
-  -configuration Debug \
-  -destination 'platform=iOS Simulator,name=<simulator-name>' \
-  -only-testing:RunnerTests \
-  2>&1 | tail -50
+SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone.*Flutter Sim' | grep -oE '[A-F0-9-]{36}')
+[ -z "$SIM_ID" ] && SIM_ID=$(xcrun simctl list devices available | grep -m1 'iPhone 16 Pro' | grep -oE '[A-F0-9-]{36}')
+cd flureadium/example/ios && \
+  xcodebuild test \
+    -workspace Runner.xcworkspace \
+    -scheme Runner \
+    -configuration Debug \
+    -destination "id=$SIM_ID" \
+    -only-testing:RunnerTests \
+    2>&1 | tail -80
 ```
 
 ## Deployment Target

--- a/flureadium/docs/05-testing/ios-unit-tests.md
+++ b/flureadium/docs/05-testing/ios-unit-tests.md
@@ -15,18 +15,19 @@ Instead, tests live in the **example app's RunnerTests target** and run via `xco
 
 ```
 flureadium/example/ios/RunnerTests/
-├── RunnerTests.swift                  # Plugin handler tests
-├── FlutterTTSNavigatorTests.swift     # TTS navigator tests
-├── UtilityTests.swift                 # clamp, firstMap, asyncCompactMap
-├── ModelTests.swift                   # ControlPanelInfoType, NavigationConfig, TTS/Audio/PDF preferences
-├── StateSerializationTests.swift      # ReadiumTimebasedState toJson, toJsonString, Equatable
-├── ReadiumExtensionsTests.swift       # Locator extensions, state mappings, EPUB/PDF preferences fromMap, TTSVoice.Quality
-├── FlutterMediaOverlayTests.swift     # FlutterMediaOverlayItem parsing/matching/locators, FlutterMediaOverlay matching/fromJson
-├── ReadiumErrorTests.swift            # ReadiumError/FlureadiumError to FlutterError conversions
-├── EdgeTapInterceptViewTests.swift   # hitTest geometry, edge interception, subview bypass
-├── NowPlayingInfoUpdaterTests.swift  # Chapter formatting for all ControlPanelInfoType variants
-└── <YourNewTests>.swift               # Add new files here
+├── RunnerTests.swift                  # Plugin handler dispatch tests (~11 tests)
+├── FlutterTTSNavigatorTests.swift     # TTS navigator lifecycle, play/suppression, dispose (~18 tests)
+├── UtilityTests.swift                 # clamp, firstMap, asyncCompactMap (~8 tests)
+├── ModelTests.swift                   # ControlPanelInfoType, NavigationConfig, TTS/Audio/PDF preferences (~30 tests)
+├── StateSerializationTests.swift      # ReadiumTimebasedState toJson, toJsonString, Equatable (~8 tests)
+├── ReadiumExtensionsTests.swift       # Locator extensions, state mappings, EPUB/PDF preferences fromMap (~16 tests)
+├── FlutterMediaOverlayTests.swift     # FlutterMediaOverlayItem parsing/matching/locators (~14 tests)
+├── ReadiumErrorTests.swift            # ReadiumError/FlureadiumError to FlutterError conversions (~9 tests)
+├── EdgeTapInterceptViewTests.swift   # hitTest geometry, edge interception, subview bypass (~8 tests)
+└── NowPlayingInfoUpdaterTests.swift  # Chapter formatting for all ControlPanelInfoType variants (~8 tests)
 ```
+
+Total: ~130 tests across 10 test classes.
 
 All test files go in `flureadium/example/ios/RunnerTests/`. Do NOT put tests in the SPM test target at `ios/flureadium/Tests/flureadiumTests/` — those cannot be executed.
 

--- a/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		C1D2E3F4A5B6C7D800004002 /* ReadiumExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D800004001 /* ReadiumExtensionsTests.swift */; };
 		C1D2E3F4A5B6C7D800005002 /* FlutterMediaOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D800005001 /* FlutterMediaOverlayTests.swift */; };
 		C1D2E3F4A5B6C7D800006002 /* ReadiumErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */; };
+		D1E2F3A4B5C6D7E800007002 /* EdgeTapInterceptViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */; };
+		D1E2F3A4B5C6D7E800008002 /* NowPlayingInfoUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -63,6 +65,8 @@
 		C1D2E3F4A5B6C7D800004001 /* ReadiumExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumExtensionsTests.swift; sourceTree = "<group>"; };
 		C1D2E3F4A5B6C7D800005001 /* FlutterMediaOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterMediaOverlayTests.swift; sourceTree = "<group>"; };
 		C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumErrorTests.swift; sourceTree = "<group>"; };
+		D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeTapInterceptViewTests.swift; sourceTree = "<group>"; };
+		D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoUpdaterTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5BDBF082C9CC180601979FB5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -123,6 +127,8 @@
 				C1D2E3F4A5B6C7D800004001 /* ReadiumExtensionsTests.swift */,
 				C1D2E3F4A5B6C7D800005001 /* FlutterMediaOverlayTests.swift */,
 				C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */,
+				D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */,
+				D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -405,6 +411,8 @@
 				C1D2E3F4A5B6C7D800004002 /* ReadiumExtensionsTests.swift in Sources */,
 				C1D2E3F4A5B6C7D800005002 /* FlutterMediaOverlayTests.swift in Sources */,
 				C1D2E3F4A5B6C7D800006002 /* ReadiumErrorTests.swift in Sources */,
+				D1E2F3A4B5C6D7E800007002 /* EdgeTapInterceptViewTests.swift in Sources */,
+				D1E2F3A4B5C6D7E800008002 /* NowPlayingInfoUpdaterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		B1C2D3E4F5A6B7C800001002 /* UtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B7C800001001 /* UtilityTests.swift */; };
 		B1C2D3E4F5A6B7C800002002 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B7C800002001 /* ModelTests.swift */; };
 		B1C2D3E4F5A6B7C800003002 /* StateSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B7C800003001 /* StateSerializationTests.swift */; };
+		C1D2E3F4A5B6C7D800004002 /* ReadiumExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D800004001 /* ReadiumExtensionsTests.swift */; };
+		C1D2E3F4A5B6C7D800005002 /* FlutterMediaOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D800005001 /* FlutterMediaOverlayTests.swift */; };
+		C1D2E3F4A5B6C7D800006002 /* ReadiumErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -57,6 +60,9 @@
 		B1C2D3E4F5A6B7C800001001 /* UtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityTests.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5A6B7C800002001 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5A6B7C800003001 /* StateSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSerializationTests.swift; sourceTree = "<group>"; };
+		C1D2E3F4A5B6C7D800004001 /* ReadiumExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumExtensionsTests.swift; sourceTree = "<group>"; };
+		C1D2E3F4A5B6C7D800005001 /* FlutterMediaOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterMediaOverlayTests.swift; sourceTree = "<group>"; };
+		C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumErrorTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5BDBF082C9CC180601979FB5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -114,6 +120,9 @@
 				B1C2D3E4F5A6B7C800001001 /* UtilityTests.swift */,
 				B1C2D3E4F5A6B7C800002001 /* ModelTests.swift */,
 				B1C2D3E4F5A6B7C800003001 /* StateSerializationTests.swift */,
+				C1D2E3F4A5B6C7D800004001 /* ReadiumExtensionsTests.swift */,
+				C1D2E3F4A5B6C7D800005001 /* FlutterMediaOverlayTests.swift */,
+				C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -393,6 +402,9 @@
 				B1C2D3E4F5A6B7C800001002 /* UtilityTests.swift in Sources */,
 				B1C2D3E4F5A6B7C800002002 /* ModelTests.swift in Sources */,
 				B1C2D3E4F5A6B7C800003002 /* StateSerializationTests.swift in Sources */,
+				C1D2E3F4A5B6C7D800004002 /* ReadiumExtensionsTests.swift in Sources */,
+				C1D2E3F4A5B6C7D800005002 /* FlutterMediaOverlayTests.swift in Sources */,
+				C1D2E3F4A5B6C7D800006002 /* ReadiumErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		2C8C9790D19F265196B605F7 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F00BEB05694A47F9D63C5A77 /* Pods_RunnerTests.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		A1B2C3D4E5F6A7B800112233 /* FlutterTTSNavigatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B800112234 /* FlutterTTSNavigatorTests.swift */; };
+		B1C2D3E4F5A6B7C800001002 /* UtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B7C800001001 /* UtilityTests.swift */; };
+		B1C2D3E4F5A6B7C800002002 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B7C800002001 /* ModelTests.swift */; };
+		B1C2D3E4F5A6B7C800003002 /* StateSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B7C800003001 /* StateSerializationTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -51,6 +54,9 @@
 		2AA8E60CAAF8449F02AA4208 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A7B800112234 /* FlutterTTSNavigatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterTTSNavigatorTests.swift; sourceTree = "<group>"; };
+		B1C2D3E4F5A6B7C800001001 /* UtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityTests.swift; sourceTree = "<group>"; };
+		B1C2D3E4F5A6B7C800002001 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
+		B1C2D3E4F5A6B7C800003001 /* StateSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSerializationTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5BDBF082C9CC180601979FB5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -105,6 +111,9 @@
 			children = (
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 				A1B2C3D4E5F6A7B800112234 /* FlutterTTSNavigatorTests.swift */,
+				B1C2D3E4F5A6B7C800001001 /* UtilityTests.swift */,
+				B1C2D3E4F5A6B7C800002001 /* ModelTests.swift */,
+				B1C2D3E4F5A6B7C800003001 /* StateSerializationTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -381,6 +390,9 @@
 			files = (
 				331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */,
 				A1B2C3D4E5F6A7B800112233 /* FlutterTTSNavigatorTests.swift in Sources */,
+				B1C2D3E4F5A6B7C800001002 /* UtilityTests.swift in Sources */,
+				B1C2D3E4F5A6B7C800002002 /* ModelTests.swift in Sources */,
+				B1C2D3E4F5A6B7C800003002 /* StateSerializationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/flureadium/example/ios/RunnerTests/EdgeTapInterceptViewTests.swift
+++ b/flureadium/example/ios/RunnerTests/EdgeTapInterceptViewTests.swift
@@ -1,0 +1,188 @@
+import XCTest
+@testable import flureadium
+
+final class EdgeTapInterceptViewTests: XCTestCase {
+
+    // MARK: - Defaults
+
+    func testDefaultEdgeThreshold() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        XCTAssertEqual(view.edgeThresholdPoints, 44.0)
+    }
+
+    func testDefaultInterceptEdgeTaps() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        XCTAssertFalse(view.interceptEdgeTaps)
+    }
+
+    func testDefaultCallbacksAreNil() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        XCTAssertNil(view.onLeftEdgeTap)
+        XCTAssertNil(view.onRightEdgeTap)
+        XCTAssertNil(view.onSwipeLeft)
+        XCTAssertNil(view.onSwipeRight)
+    }
+
+    // MARK: - hitTest with interceptEdgeTaps = true (no subviews)
+
+    func testHitTestLeftEdgeWithInterceptReturnsView() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        view.interceptEdgeTaps = true
+        let result = view.hitTest(CGPoint(x: 10, y: 284), with: nil)
+        XCTAssertEqual(result, view)
+    }
+
+    func testHitTestRightEdgeWithInterceptReturnsView() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        view.interceptEdgeTaps = true
+        let result = view.hitTest(CGPoint(x: 300, y: 284), with: nil)
+        XCTAssertEqual(result, view)
+    }
+
+    func testHitTestCenterWithInterceptReturnsSelf() {
+        // Center touches fall through to super.hitTest, which returns self
+        // for in-bounds points with no subviews.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        view.interceptEdgeTaps = true
+        let result = view.hitTest(CGPoint(x: 160, y: 284), with: nil)
+        XCTAssertEqual(result, view)
+    }
+
+    // MARK: - hitTest with interceptEdgeTaps = false (no subviews)
+
+    func testHitTestEdgeWithoutInterceptReturnsSelf() {
+        // Without interceptEdgeTaps, super.hitTest still returns self for in-bounds points.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        view.interceptEdgeTaps = false
+        let result = view.hitTest(CGPoint(x: 10, y: 284), with: nil)
+        XCTAssertEqual(result, view)
+    }
+
+    // MARK: - hitTest with subview proves override behavior
+
+    func testHitTestEdgeWithInterceptBypassesSubview() {
+        // With interceptEdgeTaps, the override returns self even when a subview
+        // covers the edge zone — proving the override intercepts.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = true
+        let result = view.hitTest(CGPoint(x: 10, y: 284), with: nil)
+        XCTAssertEqual(result, view, "Edge touch with intercept should return self, not the subview")
+    }
+
+    func testHitTestEdgeWithoutInterceptReturnsSubview() {
+        // Without interceptEdgeTaps, super.hitTest finds the subview in the edge zone.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = false
+        let result = view.hitTest(CGPoint(x: 10, y: 284), with: nil)
+        XCTAssertEqual(result, subview, "Edge touch without intercept should return the subview")
+    }
+
+    func testHitTestCenterReturnsSubviewRegardlessOfIntercept() {
+        // Center touches are never intercepted — subview is returned if present.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 100, y: 0, width: 120, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = true
+        let result = view.hitTest(CGPoint(x: 160, y: 284), with: nil)
+        XCTAssertEqual(result, subview, "Center touch should return the subview even with interceptEdgeTaps")
+    }
+
+    // MARK: - Custom threshold
+
+    func testHitTestWithCustomThresholdInterceptsSubview() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = true
+        view.edgeThresholdPoints = 80.0
+        // x=50 is within 80pt left edge — override should bypass subview
+        let result = view.hitTest(CGPoint(x: 50, y: 284), with: nil)
+        XCTAssertEqual(result, view)
+    }
+
+    func testHitTestOutsideCustomThresholdReturnsSubview() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = true
+        view.edgeThresholdPoints = 30.0
+        // x=35 is outside 30pt edge — super.hitTest returns the subview
+        let result = view.hitTest(CGPoint(x: 35, y: 284), with: nil)
+        XCTAssertEqual(result, subview, "Touch outside custom threshold should go to subview")
+    }
+
+    // MARK: - Edge boundary precision
+
+    func testHitTestExactlyAtLeftEdgeBoundaryReturnsSubview() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = true
+        view.edgeThresholdPoints = 44.0
+        // x=44 is exactly at boundary — point.x < edgeSize is false, so NOT intercepted
+        let result = view.hitTest(CGPoint(x: 44, y: 284), with: nil)
+        XCTAssertEqual(result, subview, "Touch exactly at edge boundary (not <) should go to subview")
+    }
+
+    func testHitTestJustInsideLeftEdge() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = true
+        view.edgeThresholdPoints = 44.0
+        let result = view.hitTest(CGPoint(x: 43.9, y: 284), with: nil)
+        XCTAssertEqual(result, view, "Touch just inside edge should be intercepted")
+    }
+
+    func testHitTestExactlyAtRightEdgeBoundaryReturnsSubview() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 200, y: 0, width: 120, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = true
+        view.edgeThresholdPoints = 44.0
+        // Right boundary: 320 - 44 = 276. point.x > 276 is false for x=276, so NOT intercepted
+        let result = view.hitTest(CGPoint(x: 276, y: 284), with: nil)
+        XCTAssertEqual(result, subview, "Touch exactly at right edge boundary should go to subview")
+    }
+
+    func testHitTestJustInsideRightEdge() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let subview = UIView(frame: CGRect(x: 200, y: 0, width: 120, height: 568))
+        view.addSubview(subview)
+        view.interceptEdgeTaps = true
+        view.edgeThresholdPoints = 44.0
+        let result = view.hitTest(CGPoint(x: 276.1, y: 284), with: nil)
+        XCTAssertEqual(result, view, "Touch just inside right edge should be intercepted")
+    }
+
+    // MARK: - Out of bounds
+
+    func testHitTestOutOfBoundsWithInterceptReturnsSelf() {
+        // x=-10 is out of bounds but satisfies point.x < edgeSize,
+        // so the override returns self. This bypasses super.hitTest's
+        // bounds check — possibly unintended but matches current behavior.
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        view.interceptEdgeTaps = true
+        let result = view.hitTest(CGPoint(x: -10, y: 284), with: nil)
+        XCTAssertEqual(result, view)
+    }
+
+    func testHitTestOutOfBoundsWithoutInterceptReturnsNil() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        view.interceptEdgeTaps = false
+        let result = view.hitTest(CGPoint(x: -10, y: 284), with: nil)
+        XCTAssertNil(result, "Out-of-bounds touch without intercept should return nil")
+    }
+
+    // MARK: - Gesture recognizer count
+
+    func testViewHasThreeGestureRecognizers() {
+        let view = EdgeTapInterceptView(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        // 1 tap + 2 swipes = 3
+        XCTAssertEqual(view.gestureRecognizers?.count, 3)
+    }
+}

--- a/flureadium/example/ios/RunnerTests/FlutterMediaOverlayTests.swift
+++ b/flureadium/example/ios/RunnerTests/FlutterMediaOverlayTests.swift
@@ -1,0 +1,279 @@
+import XCTest
+import ReadiumShared
+@testable import flureadium
+
+// MARK: - FlutterMediaOverlayItem Tests
+
+final class FlutterMediaOverlayItemTests: XCTestCase {
+
+    // MARK: - Init & Parsing
+
+    func testInitParsesAudioFields() {
+        let item = FlutterMediaOverlayItem(
+            audio: "audio/chapter1.mp3#t=1.5,5.0",
+            text: "text/chapter1.xhtml#para1",
+            position: 0
+        )
+        XCTAssertEqual(item.audioFile, "audio/chapter1.mp3")
+        XCTAssertEqual(item.audioStart, 1.5)
+        XCTAssertEqual(item.audioEnd, 5.0)
+        XCTAssertEqual(item.textFile, "text/chapter1.xhtml")
+        XCTAssertEqual(item.textId, "para1")
+    }
+
+    func testInitAudioWithoutFragment() {
+        let item = FlutterMediaOverlayItem(audio: "audio/ch1.mp3", text: "text/ch1.xhtml#p1", position: 0)
+        XCTAssertEqual(item.audioFile, "audio/ch1.mp3")
+        XCTAssertNil(item.audioStart)
+        XCTAssertNil(item.audioEnd)
+    }
+
+    func testInitAudioWithStartOnly() {
+        let item = FlutterMediaOverlayItem(audio: "audio/ch1.mp3#t=3.0", text: "text/ch1.xhtml#p1", position: 0)
+        XCTAssertEqual(item.audioStart, 3.0)
+        XCTAssertNil(item.audioEnd)
+    }
+
+    func testAudioDuration() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=1.0,4.0", text: "t.xhtml#p1", position: 0)
+        XCTAssertEqual(item.audioDuration, 3.0)
+    }
+
+    func testAudioDurationNilWhenNoEnd() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=1.0", text: "t.xhtml#p1", position: 0)
+        XCTAssertNil(item.audioDuration)
+    }
+
+    func testAudioMediaTypeMP3() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=0,1", text: "t.xhtml#p", position: 0)
+        XCTAssertEqual(item.audioMediaType, .mpegAudio)
+    }
+
+    func testAudioMediaTypeOpus() {
+        let item = FlutterMediaOverlayItem(audio: "a.opus#t=0,1", text: "t.xhtml#p", position: 0)
+        XCTAssertEqual(item.audioMediaType, .opus)
+    }
+
+    // MARK: - isAudioInRangeOfTime
+
+    func testIsAudioInRangeOfTimeMatches() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=1.0,5.0", text: "t.xhtml#p", position: 0)
+        XCTAssertTrue(item.isAudioInRangeOfTime(3.0, inHref: "a.mp3"))
+    }
+
+    func testIsAudioInRangeOfTimeOutOfRange() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=1.0,5.0", text: "t.xhtml#p", position: 0)
+        XCTAssertFalse(item.isAudioInRangeOfTime(6.0, inHref: "a.mp3"))
+    }
+
+    func testIsAudioInRangeOfTimeWrongHref() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=1.0,5.0", text: "t.xhtml#p", position: 0)
+        XCTAssertFalse(item.isAudioInRangeOfTime(3.0, inHref: "other.mp3"))
+    }
+
+    func testIsAudioInRangeOfTimeStartOnly() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=2.0", text: "t.xhtml#p", position: 0)
+        XCTAssertTrue(item.isAudioInRangeOfTime(5.0, inHref: "a.mp3"))
+        XCTAssertFalse(item.isAudioInRangeOfTime(1.0, inHref: "a.mp3"))
+    }
+
+    // MARK: - Locator creation
+
+    func testAsTextLocator() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=0,1", text: "text/ch1.xhtml#para1", position: 0)
+        let locator = item.asTextLocator
+        XCTAssertNotNil(locator)
+        XCTAssertEqual(locator?.href.string, "text/ch1.xhtml")
+        XCTAssertTrue(locator?.locations.fragments.contains("#para1") ?? false)
+    }
+
+    func testAsAudioLocator() {
+        let item = FlutterMediaOverlayItem(audio: "audio/ch1.mp3#t=1.5,5.0", text: "t.xhtml#p", position: 0)
+        let locator = item.asAudioLocator
+        XCTAssertNotNil(locator)
+        XCTAssertEqual(locator?.href.string, "audio/ch1.mp3")
+        XCTAssertTrue(locator?.locations.fragments.contains("t=1.5") ?? false)
+    }
+
+    func testToCombinedLocator() {
+        let item = FlutterMediaOverlayItem(audio: "a.mp3#t=1.0,5.0", text: "text/ch1.xhtml#para1", position: 0)
+        let audioLocator = Locator(
+            href: URL(string: "a.mp3")!,
+            mediaType: .mpegAudio,
+            locations: .init(fragments: ["t=2.5"], progression: 0.5)
+        )
+        let combined = item.toCombinedLocator(fromPlaybackLocator: audioLocator)
+        XCTAssertNotNil(combined)
+        XCTAssertEqual(combined?.href.string, "text/ch1.xhtml")
+        XCTAssertTrue(combined?.locations.fragments.contains("t=2.5") ?? false)
+        XCTAssertEqual(combined?.locations.progression, 0.5)
+    }
+
+    // MARK: - JSON parsing
+
+    func testFromJsonValid() {
+        let json: [String: Any] = ["audio": "a.mp3#t=0,1", "text": "t.xhtml#p"]
+        let item = FlutterMediaOverlayItem.fromJson(json, atPosition: 0)
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.audioFile, "a.mp3")
+    }
+
+    func testFromJsonMissingAudio() {
+        let json: [String: Any] = ["text": "t.xhtml#p"]
+        XCTAssertNil(FlutterMediaOverlayItem.fromJson(json, atPosition: 0))
+    }
+
+    func testFromJsonMissingText() {
+        let json: [String: Any] = ["audio": "a.mp3"]
+        XCTAssertNil(FlutterMediaOverlayItem.fromJson(json, atPosition: 0))
+    }
+
+    func testFromJsonEmptyStrings() {
+        let json: [String: Any] = ["audio": "", "text": "t.xhtml#p"]
+        XCTAssertNil(FlutterMediaOverlayItem.fromJson(json, atPosition: 0))
+    }
+
+    // MARK: - Equality
+
+    func testEquality() {
+        let a = FlutterMediaOverlayItem(audio: "a.mp3#t=0,1", text: "t.xhtml#p", position: 0)
+        let b = FlutterMediaOverlayItem(audio: "a.mp3#t=0,1", text: "t.xhtml#p", position: 0)
+        XCTAssertTrue(a == b)
+    }
+
+    func testInequalityDifferentAudio() {
+        let a = FlutterMediaOverlayItem(audio: "a.mp3#t=0,1", text: "t.xhtml#p", position: 0)
+        let b = FlutterMediaOverlayItem(audio: "b.mp3#t=0,1", text: "t.xhtml#p", position: 0)
+        XCTAssertFalse(a == b)
+    }
+}
+
+// MARK: - FlutterMediaOverlay Tests
+
+final class FlutterMediaOverlayCollectionTests: XCTestCase {
+
+    private func makeOverlay() -> FlutterMediaOverlay {
+        FlutterMediaOverlay(items: [
+            FlutterMediaOverlayItem(audio: "a.mp3#t=0.0,5.0", text: "ch1.xhtml#p1", position: 0),
+            FlutterMediaOverlayItem(audio: "a.mp3#t=5.0,10.0", text: "ch1.xhtml#p2", position: 0),
+            FlutterMediaOverlayItem(audio: "a.mp3#t=10.0,15.0", text: "ch1.xhtml#p3", position: 0),
+        ])
+    }
+
+    func testAudioFile() {
+        XCTAssertEqual(makeOverlay().audioFile, "a.mp3")
+    }
+
+    func testTextFile() {
+        XCTAssertEqual(makeOverlay().textFile, "ch1.xhtml")
+    }
+
+    func testDuration() {
+        XCTAssertEqual(makeOverlay().duration, 15.0)
+    }
+
+    func testItemInRangeOfTimeFindsMatch() {
+        let item = makeOverlay().itemInRangeOfTime(3.0, inHref: "a.mp3")
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.textId, "p1")
+    }
+
+    func testItemInRangeOfTimeSecondItem() {
+        let item = makeOverlay().itemInRangeOfTime(7.0, inHref: "a.mp3")
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.textId, "p2")
+    }
+
+    func testItemInRangeOfTimeWrongHref() {
+        XCTAssertNil(makeOverlay().itemInRangeOfTime(3.0, inHref: "other.mp3"))
+    }
+
+    func testItemFromTextId() {
+        let item = makeOverlay().itemFromTextId("p2", inHref: "ch1.xhtml")
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.audioStart, 5.0)
+    }
+
+    func testItemFromTextIdWrongHref() {
+        XCTAssertNil(makeOverlay().itemFromTextId("p2", inHref: "other.xhtml"))
+    }
+
+    func testItemFromLocatorWithTimeOffset() {
+        let locator = Locator(
+            href: URL(string: "a.mp3")!,
+            mediaType: .mpegAudio,
+            locations: .init(fragments: ["t=7.0"])
+        )
+        let item = makeOverlay().itemFromLocator(locator)
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.textId, "p2")
+    }
+
+    func testItemFromLocatorWithCssSelector() {
+        let locator = Locator(
+            href: URL(string: "ch1.xhtml")!,
+            mediaType: .xhtml,
+            locations: .init(fragments: ["#p3"])
+        )
+        let item = makeOverlay().itemFromLocator(locator)
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.audioStart, 10.0)
+    }
+
+    func testItemFromLocatorNoFragmentsHtml() {
+        let locator = Locator(
+            href: URL(string: "ch1.xhtml")!,
+            mediaType: .xhtml
+        )
+        let item = makeOverlay().itemFromLocator(locator)
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.textId, "p1")
+    }
+
+    func testItemFromLocatorWrongHref() {
+        let locator = Locator(href: URL(string: "other.xhtml")!, mediaType: .xhtml)
+        XCTAssertNil(makeOverlay().itemFromLocator(locator))
+    }
+
+    // MARK: - fromJson
+
+    func testFromJsonValid() {
+        let json: [String: Any] = [
+            "narration": [
+                ["audio": "a.mp3#t=0,5", "text": "ch1.xhtml#p1"],
+                ["audio": "a.mp3#t=5,10", "text": "ch1.xhtml#p2"],
+            ]
+        ]
+        let overlay = FlutterMediaOverlay.fromJson(json, atPosition: 0)
+        XCTAssertNotNil(overlay)
+        XCTAssertEqual(overlay?.items.count, 2)
+    }
+
+    func testFromJsonMissingNarration() {
+        let json: [String: Any] = ["other": "value"]
+        XCTAssertNil(FlutterMediaOverlay.fromJson(json, atPosition: 0))
+    }
+
+    func testFromJsonEmptyNarration() {
+        let json: [String: Any] = ["narration": [[String: Any]]()]
+        let overlay = FlutterMediaOverlay.fromJson(json, atPosition: 0)
+        XCTAssertNotNil(overlay)
+        XCTAssertEqual(overlay?.items.count, 0)
+    }
+
+    func testFromJsonNested() {
+        let json: [String: Any] = [
+            "narration": [
+                ["audio": "a.mp3#t=0,5", "text": "ch1.xhtml#p1"],
+                [
+                    "narration": [
+                        ["audio": "a.mp3#t=5,10", "text": "ch1.xhtml#p2"],
+                    ]
+                ],
+            ]
+        ]
+        let overlay = FlutterMediaOverlay.fromJson(json, atPosition: 0)
+        XCTAssertNotNil(overlay)
+        XCTAssertEqual(overlay?.items.count, 2)
+    }
+}

--- a/flureadium/example/ios/RunnerTests/FlutterTTSNavigatorTests.swift
+++ b/flureadium/example/ios/RunnerTests/FlutterTTSNavigatorTests.swift
@@ -222,4 +222,86 @@ final class FlutterTTSNavigatorTests: XCTestCase {
         XCTAssertEqual(mock.reachedLocatorCalls.count, 0,
                         "Word range during suppressed utterance should not reach listener")
     }
+
+    // MARK: - dispose()
+
+    @MainActor
+    func testDisposeSendsEndedStateToListener() {
+        let (navigator, mock) = makeNavigatorWithMock(initialLocator: nil)
+        navigator.dispose()
+        XCTAssertTrue(mock.stateChanges.contains(where: { $0.state == .ended }),
+                      "dispose should send .ended state to listener")
+    }
+
+    @MainActor
+    func testDisposeNilsOutListener() {
+        let (navigator, _) = makeNavigatorWithMock(initialLocator: nil)
+        XCTAssertNotNil(navigator.listener)
+        navigator.dispose()
+        XCTAssertNil(navigator.listener,
+                     "dispose should set listener to nil")
+    }
+
+    @MainActor
+    func testDisposeCancelsSubscriptions() async {
+        let (navigator, mock) = makeNavigatorWithMock(initialLocator: nil)
+        navigator.dispose()
+        // After dispose, setting playingUtterance should NOT trigger listener
+        navigator.playingUtterance = makeLocator(href: "page1.xhtml")
+
+        // Wait for Combine pipeline flush
+        let waitExpectation = expectation(description: "wait for Combine")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            waitExpectation.fulfill()
+        }
+        await fulfillment(of: [waitExpectation], timeout: 1.0)
+
+        XCTAssertEqual(mock.reachedLocatorCalls.count, 0,
+                       "No locator events should reach listener after dispose cancels subscriptions")
+    }
+
+    // MARK: - seekRelative / seek(toOffset:)
+
+    func testSeekRelativeReturnsFalse() async {
+        let navigator = FlutterTTSNavigator(
+            publication: makeUnspeakablePublication(),
+            initialLocator: nil
+        )
+        let result = await navigator.seekRelative(byOffsetSeconds: 10.0)
+        XCTAssertFalse(result, "seekRelative should return false for TTS navigator")
+    }
+
+    func testSeekToOffsetReturnsFalse() async {
+        let navigator = FlutterTTSNavigator(
+            publication: makeUnspeakablePublication(),
+            initialLocator: nil
+        )
+        let result = await navigator.seek(toOffset: 30.0)
+        XCTAssertFalse(result, "seek(toOffset:) should return false for TTS navigator")
+    }
+
+    // MARK: - ttsSetPreferences
+
+    func testTtsSetPreferencesUpdatesRateAndPitch() {
+        let navigator = FlutterTTSNavigator(
+            publication: makeUnspeakablePublication(),
+            initialLocator: nil
+        )
+        let newPrefs = TTSPreferences(rate: 0.75, pitch: 1.5)
+        navigator.ttsSetPreferences(prefs: newPrefs)
+        XCTAssertEqual(navigator.preferences.rate, 0.75)
+        XCTAssertEqual(navigator.preferences.pitch, 1.5)
+    }
+
+    // MARK: - ttsSetVoice error (no synthesizer)
+
+    func testTtsSetVoiceThrowsWithoutSynthesizer() {
+        let navigator = FlutterTTSNavigator(
+            publication: makeUnspeakablePublication(),
+            initialLocator: nil
+        )
+        XCTAssertThrowsError(try navigator.ttsSetVoice(voiceIdentifier: "nonexistent")) { error in
+            XCTAssertTrue(error is ReadiumError)
+        }
+    }
 }

--- a/flureadium/example/ios/RunnerTests/ModelTests.swift
+++ b/flureadium/example/ios/RunnerTests/ModelTests.swift
@@ -1,0 +1,348 @@
+import XCTest
+import AVFAudio
+@testable import flureadium
+
+// MARK: - ControlPanelInfoType Tests
+
+final class ControlPanelInfoTypeTests: XCTestCase {
+
+    func testInitFromStandard() {
+        XCTAssertEqual(ControlPanelInfoType(from: "standard"), .standard)
+    }
+
+    func testInitFromStandardWCh() {
+        XCTAssertEqual(ControlPanelInfoType(from: "standardWCh"), .standardWCh)
+    }
+
+    func testInitFromChapterTitleAuthor() {
+        XCTAssertEqual(ControlPanelInfoType(from: "chapterTitleAuthor"), .chapterTitleAuthor)
+    }
+
+    func testInitFromChapterTitle() {
+        XCTAssertEqual(ControlPanelInfoType(from: "chapterTitle"), .chapterTitle)
+    }
+
+    func testInitFromTitleChapter() {
+        XCTAssertEqual(ControlPanelInfoType(from: "titleChapter"), .titleChapter)
+    }
+
+    func testInitFromNil() {
+        XCTAssertEqual(ControlPanelInfoType(from: nil), .standard)
+    }
+
+    func testInitFromUnknownString() {
+        XCTAssertEqual(ControlPanelInfoType(from: "bogus"), .standard)
+    }
+}
+
+// MARK: - FlutterNavigationConfig Tests
+
+final class FlutterNavigationConfigTests: XCTestCase {
+
+    func testInitFromMapAllFields() {
+        let map: [String: Any] = [
+            "enableEdgeTapNavigation": true,
+            "enableSwipeNavigation": false,
+            "edgeTapAreaPoints": 80.0,
+            "disableDoubleTapZoom": true,
+            "disableTextSelection": true,
+            "disableDragGestures": false,
+            "disableDoubleTapTextSelection": true,
+        ]
+        let config = FlutterNavigationConfig(fromMap: map)
+        XCTAssertEqual(config.enableEdgeTapNavigation, true)
+        XCTAssertEqual(config.enableSwipeNavigation, false)
+        XCTAssertEqual(config.edgeTapAreaPoints, 80.0)
+        XCTAssertEqual(config.disableDoubleTapZoom, true)
+        XCTAssertEqual(config.disableTextSelection, true)
+        XCTAssertEqual(config.disableDragGestures, false)
+        XCTAssertEqual(config.disableDoubleTapTextSelection, true)
+    }
+
+    func testInitFromNilMap() {
+        let config = FlutterNavigationConfig(fromMap: nil)
+        XCTAssertNil(config.enableEdgeTapNavigation)
+        XCTAssertNil(config.enableSwipeNavigation)
+        XCTAssertNil(config.edgeTapAreaPoints)
+        XCTAssertNil(config.disableDoubleTapZoom)
+        XCTAssertNil(config.disableTextSelection)
+        XCTAssertNil(config.disableDragGestures)
+        XCTAssertNil(config.disableDoubleTapTextSelection)
+    }
+
+    func testInitFromEmptyMap() {
+        let config = FlutterNavigationConfig(fromMap: [:])
+        XCTAssertNil(config.enableEdgeTapNavigation)
+        XCTAssertNil(config.edgeTapAreaPoints)
+    }
+
+    func testInitFromPartialMap() {
+        let map: [String: Any] = ["enableEdgeTapNavigation": true]
+        let config = FlutterNavigationConfig(fromMap: map)
+        XCTAssertEqual(config.enableEdgeTapNavigation, true)
+        XCTAssertNil(config.enableSwipeNavigation)
+        XCTAssertNil(config.edgeTapAreaPoints)
+    }
+}
+
+// MARK: - TTSPreferences Tests
+
+final class TTSPreferencesTests: XCTestCase {
+
+    func testInitDefaults() {
+        let prefs = TTSPreferences()
+        XCTAssertNil(prefs.rate)
+        XCTAssertNil(prefs.pitch)
+        XCTAssertNil(prefs.overrideLanguage)
+        XCTAssertNil(prefs.voiceIdentifier)
+    }
+
+    func testInitFromMapDefaults() throws {
+        let prefs = try TTSPreferences(fromMap: [:])
+        // Default speed 1.0 * AVSpeechUtteranceDefaultSpeechRate
+        XCTAssertEqual(prefs.rate!, AVSpeechUtteranceDefaultSpeechRate, accuracy: 0.001)
+        XCTAssertEqual(prefs.pitch!, Float(1.0), accuracy: 0.001)
+        XCTAssertNil(prefs.overrideLanguage)
+        XCTAssertNil(prefs.voiceIdentifier)
+    }
+
+    func testInitFromMapWithValues() throws {
+        let map: [String: Any] = [
+            "speed": 1.5,
+            "pitch": 1.2,
+            "voiceIdentifier": "com.apple.voice.compact.en-US.Samantha",
+            "languageOverride": "en-US",
+        ]
+        let prefs = try TTSPreferences(fromMap: map)
+        XCTAssertNotNil(prefs.rate)
+        XCTAssertEqual(prefs.pitch!, Float(1.2), accuracy: 0.001)
+        XCTAssertEqual(prefs.voiceIdentifier, "com.apple.voice.compact.en-US.Samantha")
+        XCTAssertNotNil(prefs.overrideLanguage)
+    }
+
+    func testRateNormalization() throws {
+        // speed=1.0 should produce rate = 1.0 * AVSpeechUtteranceDefaultSpeechRate
+        let prefs = try TTSPreferences(fromMap: ["speed": 1.0])
+        XCTAssertEqual(prefs.rate!, AVSpeechUtteranceDefaultSpeechRate, accuracy: 0.001)
+    }
+
+    func testRateClampedToMin() throws {
+        // speed=0.0 → rate = 0.0 * default = 0.0, clamped to AVSpeechUtteranceMinimumSpeechRate
+        let prefs = try TTSPreferences(fromMap: ["speed": 0.0])
+        XCTAssertEqual(prefs.rate!, AVSpeechUtteranceMinimumSpeechRate, accuracy: 0.001)
+    }
+
+    func testRateClampedToMax() throws {
+        // speed=100.0 → rate = 100.0 * default, clamped to AVSpeechUtteranceMaximumSpeechRate
+        let prefs = try TTSPreferences(fromMap: ["speed": 100.0])
+        XCTAssertEqual(prefs.rate!, AVSpeechUtteranceMaximumSpeechRate, accuracy: 0.001)
+    }
+
+    func testPitchClampedToMin() throws {
+        let prefs = try TTSPreferences(fromMap: ["pitch": 0.1])
+        XCTAssertEqual(prefs.pitch!, Float(0.5), accuracy: 0.001)
+    }
+
+    func testPitchClampedToMax() throws {
+        let prefs = try TTSPreferences(fromMap: ["pitch": 5.0])
+        XCTAssertEqual(prefs.pitch!, Float(2.0), accuracy: 0.001)
+    }
+
+    func testControlPanelInfoType() throws {
+        let prefs = try TTSPreferences(fromMap: ["controlPanelInfoType": "chapterTitle"])
+        XCTAssertEqual(prefs.controlPanelInfoType, .chapterTitle)
+    }
+}
+
+// MARK: - FlutterAudioPreferences Tests
+
+final class FlutterAudioPreferencesTests: XCTestCase {
+
+    func testInitDefaults() {
+        let prefs = FlutterAudioPreferences()
+        XCTAssertEqual(prefs.volume, 1.0)
+        XCTAssertEqual(prefs.speed, 1.0)
+        XCTAssertEqual(prefs.pitch, 1.0)
+        XCTAssertEqual(prefs.seekInterval, 30)
+        XCTAssertEqual(prefs.allowExternalSeeking, true)
+    }
+
+    func testInitFromMapDefaults() throws {
+        let prefs = try FlutterAudioPreferences(fromMap: [:])
+        XCTAssertEqual(prefs.volume, 1.0)
+        XCTAssertEqual(prefs.speed, 1.0)
+        XCTAssertEqual(prefs.pitch, 1.0)
+        XCTAssertEqual(prefs.seekInterval, 30)
+        XCTAssertEqual(prefs.allowExternalSeeking, true)
+    }
+
+    func testInitFromMapWithValues() throws {
+        let map: [String: Any] = [
+            "volume": 0.8,
+            "speed": 1.5,
+            "pitch": 0.9,
+            "seekInterval": 15.0,
+            "allowExternalSeeking": false,
+            "controlPanelInfoType": "chapterTitleAuthor",
+            "updateIntervalSecs": 0.5,
+        ]
+        let prefs = try FlutterAudioPreferences(fromMap: map)
+        XCTAssertEqual(prefs.volume, 0.8)
+        XCTAssertEqual(prefs.speed, 1.5)
+        XCTAssertEqual(prefs.pitch, 0.9, accuracy: 0.001)
+        XCTAssertEqual(prefs.seekInterval, 15.0)
+        XCTAssertEqual(prefs.allowExternalSeeking, false)
+        XCTAssertEqual(prefs.controlPanelInfoType, .chapterTitleAuthor)
+        XCTAssertEqual(prefs.updateIntervalSecs, 0.5)
+    }
+
+    func testRateClampedToMin() throws {
+        let prefs = try FlutterAudioPreferences(fromMap: ["speed": 0.01])
+        XCTAssertEqual(prefs.speed, 0.1, accuracy: 0.001)
+    }
+
+    func testRateClampedToMax() throws {
+        let prefs = try FlutterAudioPreferences(fromMap: ["speed": 10.0])
+        XCTAssertEqual(prefs.speed, 5.0, accuracy: 0.001)
+    }
+
+    func testPitchClampedToMin() throws {
+        let prefs = try FlutterAudioPreferences(fromMap: ["pitch": 0.1])
+        XCTAssertEqual(prefs.pitch, 0.5, accuracy: 0.001)
+    }
+
+    func testPitchClampedToMax() throws {
+        let prefs = try FlutterAudioPreferences(fromMap: ["pitch": 5.0])
+        XCTAssertEqual(prefs.pitch, 2.0, accuracy: 0.001)
+    }
+}
+
+// MARK: - FlutterPdfPreferences Tests
+
+final class FlutterPdfPreferencesTests: XCTestCase {
+
+    // FlutterPdfFit enum
+
+    func testPdfFitFromStringWidth() {
+        XCTAssertEqual(FlutterPdfFit.fromString("width"), .width)
+    }
+
+    func testPdfFitFromStringContain() {
+        XCTAssertEqual(FlutterPdfFit.fromString("contain"), .contain)
+    }
+
+    func testPdfFitFromStringCaseInsensitive() {
+        XCTAssertEqual(FlutterPdfFit.fromString("Width"), .width)
+        XCTAssertEqual(FlutterPdfFit.fromString("CONTAIN"), .contain)
+    }
+
+    func testPdfFitFromStringNil() {
+        XCTAssertNil(FlutterPdfFit.fromString(nil))
+    }
+
+    func testPdfFitFromStringInvalid() {
+        XCTAssertNil(FlutterPdfFit.fromString("bogus"))
+    }
+
+    func testPdfFitToReadiumScroll() {
+        XCTAssertTrue(FlutterPdfFit.width.toReadiumScroll())
+        XCTAssertFalse(FlutterPdfFit.contain.toReadiumScroll())
+    }
+
+    // FlutterPdfScrollMode enum
+
+    func testPdfScrollModeFromStringHorizontal() {
+        XCTAssertEqual(FlutterPdfScrollMode.fromString("horizontal"), .horizontal)
+    }
+
+    func testPdfScrollModeFromStringVertical() {
+        XCTAssertEqual(FlutterPdfScrollMode.fromString("vertical"), .vertical)
+    }
+
+    func testPdfScrollModeFromStringNil() {
+        XCTAssertNil(FlutterPdfScrollMode.fromString(nil))
+    }
+
+    func testPdfScrollModeFromStringInvalid() {
+        XCTAssertNil(FlutterPdfScrollMode.fromString("diagonal"))
+    }
+
+    // FlutterPdfPageLayout enum
+
+    func testPdfPageLayoutFromStringSingle() {
+        XCTAssertEqual(FlutterPdfPageLayout.fromString("single"), .single)
+    }
+
+    func testPdfPageLayoutFromStringDouble() {
+        XCTAssertEqual(FlutterPdfPageLayout.fromString("double"), .double)
+    }
+
+    func testPdfPageLayoutFromStringAutomatic() {
+        XCTAssertEqual(FlutterPdfPageLayout.fromString("automatic"), .automatic)
+    }
+
+    func testPdfPageLayoutFromStringNil() {
+        XCTAssertNil(FlutterPdfPageLayout.fromString(nil))
+    }
+
+    // FlutterPdfPreferences model
+
+    func testPdfPreferencesFromMapFull() {
+        let map: [String: Any] = [
+            "fit": "width",
+            "scrollMode": "vertical",
+            "pageLayout": "double",
+            "offsetFirstPage": true,
+        ]
+        let prefs = FlutterPdfPreferences(fromMap: map)
+        XCTAssertEqual(prefs.fit, .width)
+        XCTAssertEqual(prefs.scrollMode, .vertical)
+        XCTAssertEqual(prefs.pageLayout, .double)
+        XCTAssertEqual(prefs.offsetFirstPage, true)
+    }
+
+    func testPdfPreferencesFromNilMap() {
+        let prefs = FlutterPdfPreferences(fromMap: nil)
+        XCTAssertNil(prefs.fit)
+        XCTAssertNil(prefs.scrollMode)
+        XCTAssertNil(prefs.pageLayout)
+        XCTAssertNil(prefs.offsetFirstPage)
+    }
+
+    func testPdfPreferencesFromEmptyMap() {
+        let prefs = FlutterPdfPreferences(fromMap: [:])
+        XCTAssertNil(prefs.fit)
+    }
+
+    func testPdfPreferencesToReadiumPreferences() {
+        let prefs = FlutterPdfPreferences(
+            fit: .width,
+            scrollMode: .vertical,
+            pageLayout: .single,
+            offsetFirstPage: true
+        )
+        let readium = prefs.toReadiumPreferences()
+        XCTAssertEqual(readium.scroll, true)     // width → scroll
+        XCTAssertEqual(readium.offsetFirstPage, true)
+    }
+
+    func testPdfPreferencesToMap() {
+        let prefs = FlutterPdfPreferences(
+            fit: .contain,
+            scrollMode: .horizontal,
+            pageLayout: .automatic,
+            offsetFirstPage: false
+        )
+        let map = prefs.toMap()
+        XCTAssertEqual(map["fit"] as? String, "contain")
+        XCTAssertEqual(map["scrollMode"] as? String, "horizontal")
+        XCTAssertEqual(map["pageLayout"] as? String, "automatic")
+        XCTAssertEqual(map["offsetFirstPage"] as? Bool, false)
+    }
+
+    func testPdfPreferencesToMapOmitsNils() {
+        let prefs = FlutterPdfPreferences()
+        let map = prefs.toMap()
+        XCTAssertTrue(map.isEmpty)
+    }
+}

--- a/flureadium/example/ios/RunnerTests/NowPlayingInfoUpdaterTests.swift
+++ b/flureadium/example/ios/RunnerTests/NowPlayingInfoUpdaterTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+import ReadiumShared
+import ReadiumNavigator
+import MediaPlayer
+@testable import flureadium
+
+final class NowPlayingInfoUpdaterTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makePublication(
+        title: String = "Test Book",
+        authors: [String] = ["Author One"],
+        chapters: [(href: String, title: String?)] = [
+            ("ch1.xhtml", "First Chapter"),
+            ("ch2.xhtml", "Second Chapter"),
+            ("ch3.xhtml", nil),
+        ]
+    ) -> Publication {
+        let readingOrder = chapters.map { ch in
+            Link(href: ch.href, mediaType: .xhtml, title: ch.title)
+        }
+        let contributors = authors.map { Contributor(name: $0) }
+        return Publication(manifest: Manifest(
+            metadata: Metadata(
+                title: title,
+                authors: contributors
+            ),
+            readingOrder: readingOrder
+        ))
+    }
+
+    override func tearDown() {
+        NowPlayingInfo.shared.clear()
+        super.tearDown()
+    }
+
+    // MARK: - setupNowPlayingInfo
+
+    func testSetupNowPlayingInfoSetsTitle() {
+        let pub = makePublication(title: "My Book")
+        let updater = NowPlayingInfoUpdater(withPublication: pub)
+        updater.setupNowPlayingInfo()
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "My Book")
+    }
+
+    func testSetupNowPlayingInfoSetsArtist() {
+        let pub = makePublication(authors: ["Alice", "Bob"])
+        let updater = NowPlayingInfoUpdater(withPublication: pub)
+        updater.setupNowPlayingInfo()
+        XCTAssertEqual(NowPlayingInfo.shared.media?.artist, "Alice, Bob")
+    }
+
+    func testSetupNowPlayingInfoSetsChapterCount() {
+        let pub = makePublication(chapters: [("a", "A"), ("b", "B")])
+        let updater = NowPlayingInfoUpdater(withPublication: pub)
+        updater.setupNowPlayingInfo()
+        XCTAssertEqual(NowPlayingInfo.shared.media?.chapterCount, 2)
+    }
+
+    // MARK: - updateChapterNo: standard
+
+    func testStandardInfoTypeUsesBookTitleAndAuthors() {
+        let pub = makePublication(title: "Book", authors: ["Alice", "Bob"])
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .standard)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "Book")
+        XCTAssertEqual(NowPlayingInfo.shared.media?.artist, "Alice, Bob")
+    }
+
+    // MARK: - updateChapterNo: standardWCh
+
+    func testStandardWChAppendsChapterToTitle() {
+        let pub = makePublication(title: "Book", chapters: [("a", "Ch 1"), ("b", "Ch 2")])
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .standardWCh)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "Book - Ch 1")
+    }
+
+    func testStandardWChFallsBackToGeneratedChapterTitle() {
+        let pub = makePublication(title: "Book", chapters: [("a", nil)])
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .standardWCh)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+        let title = NowPlayingInfo.shared.media?.title ?? ""
+        XCTAssertTrue(title.hasPrefix("Book - "), "Title should start with 'Book - ' followed by fallback chapter name")
+    }
+
+    // MARK: - updateChapterNo: chapterTitle
+
+    func testChapterTitleSetsChapterAsTitle() {
+        let pub = makePublication(title: "Book", authors: ["Alice"])
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .chapterTitle)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "First Chapter")
+        XCTAssertEqual(NowPlayingInfo.shared.media?.artist, "Book")
+    }
+
+    // MARK: - updateChapterNo: chapterTitleAuthor
+
+    func testChapterTitleAuthorSetsChapterAsTitleWithBookAndAuthors() {
+        let pub = makePublication(title: "Book", authors: ["Alice"])
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .chapterTitleAuthor)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "First Chapter")
+        XCTAssertEqual(NowPlayingInfo.shared.media?.artist, "Book - Alice")
+    }
+
+    // MARK: - updateChapterNo: titleChapter
+
+    func testTitleChapterSetsChapterAsArtist() {
+        let pub = makePublication(title: "Book")
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .titleChapter)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "Book")
+        XCTAssertEqual(NowPlayingInfo.shared.media?.artist, "First Chapter")
+    }
+
+    // MARK: - updateChapterNo: dedup
+
+    func testUpdateChapterNoSkipsDuplicate() {
+        let pub = makePublication()
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .chapterTitle)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+
+        // Manually modify the title to detect whether the second call is a no-op
+        NowPlayingInfo.shared.media?.title = "modified"
+        updater.updateChapterNo(0)
+        // Title should remain "modified" because the duplicate was skipped
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "modified")
+    }
+
+    func testUpdateChapterNoUpdatesOnDifferentChapter() {
+        let pub = makePublication()
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .chapterTitle)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "First Chapter")
+
+        updater.updateChapterNo(1)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.title, "Second Chapter")
+    }
+
+    func testUpdateChapterNoSetsChapterNumber() {
+        let pub = makePublication()
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .standard)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(2)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.chapterNumber, 2)
+    }
+
+    func testUpdateChapterNoNilResetsChapterNumber() {
+        let pub = makePublication()
+        let updater = NowPlayingInfoUpdater(withPublication: pub, infoType: .standard)
+        updater.setupNowPlayingInfo()
+        updater.updateChapterNo(0)
+        XCTAssertEqual(NowPlayingInfo.shared.media?.chapterNumber, 0)
+        updater.updateChapterNo(nil)
+        XCTAssertNil(NowPlayingInfo.shared.media?.chapterNumber)
+    }
+
+    // MARK: - clearNowPlaying
+
+    func testClearNowPlaying() {
+        let pub = makePublication()
+        let updater = NowPlayingInfoUpdater(withPublication: pub)
+        updater.setupNowPlayingInfo()
+        XCTAssertNotNil(NowPlayingInfo.shared.media)
+        updater.clearNowPlaying()
+        XCTAssertNil(NowPlayingInfo.shared.media)
+    }
+}

--- a/flureadium/example/ios/RunnerTests/ReadiumErrorTests.swift
+++ b/flureadium/example/ios/RunnerTests/ReadiumErrorTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import Flutter
+import ReadiumShared
+@testable import flureadium
+
+final class ReadiumErrorTests: XCTestCase {
+
+    func testFormatNotSupportedToFlutterError() {
+        let error = ReadiumError.formatNotSupported("PDF 2.0")
+        let flutterError = error.toFlutterError()
+        XCTAssertEqual(flutterError.code, "formatNotSupported")
+    }
+
+    func testNotFoundToFlutterError() {
+        let error = ReadiumError.notFound("book.epub")
+        let flutterError = error.toFlutterError()
+        XCTAssertEqual(flutterError.code, "notFound")
+        XCTAssertEqual(flutterError.details as? String, "book.epub")
+    }
+
+    func testNotFoundNilDetailsToFlutterError() {
+        let error = ReadiumError.notFound(nil)
+        let flutterError = error.toFlutterError()
+        XCTAssertEqual(flutterError.code, "notFound")
+    }
+
+    func testReaderViewNotFoundToFlutterError() {
+        let error = ReadiumError.readerViewNotFound
+        let flutterError = error.toFlutterError()
+        XCTAssertEqual(flutterError.code, "readerViewNotFound")
+    }
+
+    func testVoiceNotFoundToFlutterError() {
+        let error = ReadiumError.voiceNotFound
+        let flutterError = error.toFlutterError()
+        XCTAssertEqual(flutterError.code, "voiceNotFound")
+    }
+
+    func testUnknownToFlutterError() {
+        let error = ReadiumError.unknown(nil)
+        let flutterError = error.toFlutterError()
+        XCTAssertEqual(flutterError.code, "unknown")
+    }
+
+    func testReadingErrorToFlutterError() {
+        let inner = NSError(domain: "test", code: 42)
+        let error = ReadiumError.readingError(inner)
+        let flutterError = error.toFlutterError()
+        XCTAssertEqual(flutterError.code, "readingError")
+    }
+
+    func testForbiddenToFlutterError() {
+        let inner = NSError(domain: "DRM", code: 1)
+        let error = ReadiumError.publicationIsRestricted(inner)
+        let flutterError = error.toFlutterError()
+        XCTAssertEqual(flutterError.code, "forbidden")
+    }
+}
+
+// MARK: - FlureadiumError Tests
+
+final class FlureadiumErrorTests: XCTestCase {
+
+    func testToJsonAllFields() {
+        let error = FlureadiumError(
+            message: "Something broke",
+            code: "ERR_001",
+            data: "extra data",
+            details: ["key": "value"]
+        )
+        let json = error.toJson()
+        XCTAssertEqual(json["message"] as? String, "Something broke")
+        XCTAssertEqual(json["code"] as? String, "ERR_001")
+        XCTAssertEqual(json["data"] as? String, "extra data")
+        XCTAssertNotNil(json["stack"])
+    }
+
+    func testToJsonMinimal() {
+        let error = FlureadiumError(message: "Oops")
+        let json = error.toJson()
+        XCTAssertEqual(json["message"] as? String, "Oops")
+    }
+}

--- a/flureadium/example/ios/RunnerTests/ReadiumExtensionsTests.swift
+++ b/flureadium/example/ios/RunnerTests/ReadiumExtensionsTests.swift
@@ -1,0 +1,254 @@
+import XCTest
+import ReadiumShared
+import ReadiumNavigator
+@testable import flureadium
+
+// MARK: - Locator Extension Tests
+
+final class LocatorExtensionTests: XCTestCase {
+
+    func testTimeOffsetFromFragment() {
+        let locator = Locator(
+            href: URL(string: "ch1.xhtml")!,
+            mediaType: .html,
+            locations: .init(fragments: ["t=1.5"])
+        )
+        XCTAssertEqual(locator.timeOffset, 1.5)
+    }
+
+    func testTimeOffsetNilWhenNoFragment() {
+        let locator = Locator(href: URL(string: "ch1.xhtml")!, mediaType: .html)
+        XCTAssertNil(locator.timeOffset)
+    }
+
+    func testTimeOffsetNilWhenNonTimeFragment() {
+        let locator = Locator(
+            href: URL(string: "ch1.xhtml")!,
+            mediaType: .html,
+            locations: .init(fragments: ["#heading1"])
+        )
+        XCTAssertNil(locator.timeOffset)
+    }
+
+    func testTextIdFromHashFragment() {
+        let locator = Locator(
+            href: URL(string: "ch1.xhtml")!,
+            mediaType: .html,
+            locations: .init(fragments: ["#heading1"])
+        )
+        XCTAssertEqual(locator.textId, "heading1")
+    }
+
+    func testTextIdFromCssSelector() {
+        let locator = Locator(
+            href: URL(string: "ch1.xhtml")!,
+            mediaType: .html,
+            locations: .init(otherLocations: ["cssSelector": "#para5"])
+        )
+        XCTAssertEqual(locator.textId, "para5")
+    }
+
+    func testTextIdNil() {
+        let locator = Locator(href: URL(string: "ch1.xhtml")!, mediaType: .html)
+        XCTAssertNil(locator.textId)
+    }
+}
+
+// MARK: - State Mapping Tests
+
+final class StateMappingTests: XCTestCase {
+
+    // Note: .paused(Utterance) and .playing(Utterance, range:) cannot be tested here
+    // because PublicationSpeechSynthesizer.Utterance has an internal initializer
+    // (auto-generated memberwise init in Readium module is not public).
+
+    func testSynthesizerStateStoppedMapping() {
+        XCTAssertEqual(PublicationSpeechSynthesizer.State.stopped.asTimebasedState, .ended)
+    }
+}
+
+// MARK: - EPUBPreferences Extension Tests
+
+final class EPUBPreferencesExtensionTests: XCTestCase {
+
+    func testFromMapBackgroundColor() {
+        let prefs = EPUBPreferences(fromMap: ["backgroundColor": "#FF0000"])
+        XCTAssertNotNil(prefs.backgroundColor)
+    }
+
+    func testFromMapFontSize() {
+        let prefs = EPUBPreferences(fromMap: ["fontSize": "18.0"])
+        XCTAssertEqual(prefs.fontSize, 18.0)
+    }
+
+    func testFromMapFontFamily() {
+        let prefs = EPUBPreferences(fromMap: ["fontFamily": "Georgia"])
+        XCTAssertNotNil(prefs.fontFamily)
+    }
+
+    func testFromMapVerticalScroll() {
+        let prefs = EPUBPreferences(fromMap: ["verticalScroll": "true"])
+        XCTAssertEqual(prefs.scroll, true)
+    }
+
+    func testFromMapHyphens() {
+        let prefs = EPUBPreferences(fromMap: ["hyphens": "true"])
+        XCTAssertEqual(prefs.hyphens, true)
+    }
+
+    func testFromMapLineHeight() {
+        let prefs = EPUBPreferences(fromMap: ["lineHeight": "1.5"])
+        XCTAssertEqual(prefs.lineHeight, 1.5)
+    }
+
+    func testFromMapPageMargins() {
+        let prefs = EPUBPreferences(fromMap: ["pageMargins": "2.0"])
+        XCTAssertEqual(prefs.pageMargins, 2.0)
+    }
+
+    func testFromMapTextColor() {
+        let prefs = EPUBPreferences(fromMap: ["textColor": "#000000"])
+        XCTAssertNotNil(prefs.textColor)
+    }
+
+    func testFromMapTextNormalization() {
+        let prefs = EPUBPreferences(fromMap: ["textNormalization": "true"])
+        XCTAssertEqual(prefs.textNormalization, true)
+    }
+
+    func testFromMapVerticalText() {
+        let prefs = EPUBPreferences(fromMap: ["verticalText": "true"])
+        XCTAssertEqual(prefs.verticalText, true)
+    }
+
+    func testFromMapWordSpacing() {
+        let prefs = EPUBPreferences(fromMap: ["wordSpacing": "0.25"])
+        XCTAssertEqual(prefs.wordSpacing, 0.25)
+    }
+
+    func testFromMapLetterSpacing() {
+        let prefs = EPUBPreferences(fromMap: ["letterSpacing": "0.1"])
+        XCTAssertEqual(prefs.letterSpacing, 0.1)
+    }
+
+    func testFromMapParagraphIndent() {
+        let prefs = EPUBPreferences(fromMap: ["paragraphIndent": "1.5"])
+        XCTAssertEqual(prefs.paragraphIndent, 1.5)
+    }
+
+    func testFromMapParagraphSpacing() {
+        let prefs = EPUBPreferences(fromMap: ["paragraphSpacing": "0.5"])
+        XCTAssertEqual(prefs.paragraphSpacing, 0.5)
+    }
+
+    func testFromMapFontWeight() {
+        let prefs = EPUBPreferences(fromMap: ["fontWeight": "700.0"])
+        XCTAssertEqual(prefs.fontWeight, 700.0)
+    }
+
+    func testFromMapLigatures() {
+        let prefs = EPUBPreferences(fromMap: ["ligatures": "true"])
+        XCTAssertEqual(prefs.ligatures, true)
+    }
+
+    func testFromMapUnknownKeyIgnored() {
+        let prefs = EPUBPreferences(fromMap: ["nonExistentKey": "value"])
+        XCTAssertNil(prefs.fontSize)
+    }
+
+    func testFromMapEmptyMap() {
+        let prefs = EPUBPreferences(fromMap: [:])
+        XCTAssertNil(prefs.fontSize)
+        XCTAssertNil(prefs.scroll)
+    }
+}
+
+// MARK: - PDFPreferences Extension Tests
+
+final class PDFPreferencesExtensionTests: XCTestCase {
+
+    func testFromMapFitWidth() {
+        let prefs = PDFPreferences(fromMap: ["fit": "width"])
+        XCTAssertEqual(prefs.scroll, true)
+    }
+
+    func testFromMapFitContain() {
+        let prefs = PDFPreferences(fromMap: ["fit": "contain"])
+        XCTAssertEqual(prefs.scroll, false)
+    }
+
+    func testFromMapScrollModeVertical() {
+        let prefs = PDFPreferences(fromMap: ["scrollMode": "vertical"])
+        XCTAssertEqual(prefs.scrollAxis, .vertical)
+    }
+
+    func testFromMapScrollModeHorizontal() {
+        let prefs = PDFPreferences(fromMap: ["scrollMode": "horizontal"])
+        XCTAssertEqual(prefs.scrollAxis, .horizontal)
+    }
+
+    func testFromMapPageLayoutSingle() {
+        let prefs = PDFPreferences(fromMap: ["pageLayout": "single"])
+        XCTAssertEqual(prefs.spread, .never)
+    }
+
+    func testFromMapPageLayoutDouble() {
+        let prefs = PDFPreferences(fromMap: ["pageLayout": "double"])
+        XCTAssertEqual(prefs.spread, .always)
+    }
+
+    func testFromMapPageLayoutAutomatic() {
+        let prefs = PDFPreferences(fromMap: ["pageLayout": "automatic"])
+        XCTAssertEqual(prefs.spread, .auto)
+    }
+
+    func testFromMapOffsetFirstPage() {
+        let prefs = PDFPreferences(fromMap: ["offsetFirstPage": true])
+        XCTAssertEqual(prefs.offsetFirstPage, true)
+    }
+
+    func testFromMapPageSpacing() {
+        let prefs = PDFPreferences(fromMap: ["pageSpacing": 16.0])
+        XCTAssertEqual(prefs.pageSpacing, 16.0)
+    }
+
+    func testFromMapVisibleScrollbar() {
+        let prefs = PDFPreferences(fromMap: ["visibleScrollbar": false])
+        XCTAssertEqual(prefs.visibleScrollbar, false)
+    }
+
+    func testFromMapBackgroundColor() {
+        let prefs = PDFPreferences(fromMap: ["backgroundColor": "#FFFFFF"])
+        XCTAssertNotNil(prefs.backgroundColor)
+    }
+
+    func testFromMapUnknownKeyIgnored() {
+        let prefs = PDFPreferences(fromMap: ["bogusKey": "value"])
+        XCTAssertNil(prefs.scroll)
+    }
+}
+
+// MARK: - TTSVoice.Quality Extension Tests
+
+final class TTSVoiceQualityExtensionTests: XCTestCase {
+
+    func testLowToFlutterString() {
+        XCTAssertEqual(TTSVoice.Quality.low.toFlutterString, "low")
+    }
+
+    func testLowerToFlutterString() {
+        XCTAssertEqual(TTSVoice.Quality.lower.toFlutterString, "low")
+    }
+
+    func testMediumToFlutterString() {
+        XCTAssertEqual(TTSVoice.Quality.medium.toFlutterString, "normal")
+    }
+
+    func testHighToFlutterString() {
+        XCTAssertEqual(TTSVoice.Quality.high.toFlutterString, "high")
+    }
+
+    func testHigherToFlutterString() {
+        XCTAssertEqual(TTSVoice.Quality.higher.toFlutterString, "high")
+    }
+}

--- a/flureadium/example/ios/RunnerTests/RunnerTests.swift
+++ b/flureadium/example/ios/RunnerTests/RunnerTests.swift
@@ -20,6 +20,165 @@ class RunnerTests: XCTestCase {
     wait(for: [expectation], timeout: 1.0)
   }
 
+  // MARK: - Unknown method
+
+  func testUnknownMethodReturnsNotImplemented() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "nonExistentMethod", arguments: nil)
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response)
+      XCTAssertTrue((response as AnyObject) === FlutterMethodNotImplemented,
+                    "Unknown method should return FlutterMethodNotImplemented")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: - setCustomHeaders
+
+  func testSetCustomHeadersValidArgs() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let args: [String: Any] = ["httpHeaders": ["Authorization": "Bearer token123"]]
+    let call = FlutterMethodCall(methodName: "setCustomHeaders", arguments: args)
+    plugin.handle(call) { response in
+      XCTAssertNil(response as? FlutterError,
+                   "Valid setCustomHeaders should not return an error")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testSetCustomHeadersInvalidArgs() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "setCustomHeaders", arguments: nil)
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response as? FlutterError,
+                      "setCustomHeaders with nil args should return FlutterError")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: - TTS methods without navigator
+
+  func testTtsGetAvailableVoicesWithoutNavigator() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "ttsGetAvailableVoices", arguments: nil)
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response as? FlutterError,
+                      "ttsGetAvailableVoices without TTS navigator should return error")
+      let error = response as! FlutterError
+      XCTAssertEqual(error.code, "TTSError")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testTtsSetVoiceWithoutNavigator() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let args: [Any?] = ["com.apple.voice.fake"]
+    let call = FlutterMethodCall(methodName: "ttsSetVoice", arguments: args)
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response as? FlutterError)
+      let error = response as! FlutterError
+      XCTAssertEqual(error.code, "TTSError")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testTtsSetPreferencesWithoutNavigator() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "ttsSetPreferences", arguments: ["speed": 1.5])
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response as? FlutterError)
+      let error = response as! FlutterError
+      XCTAssertEqual(error.code, "TTSError")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: - ttsGetSystemVoices
+
+  func testTtsGetSystemVoicesReturnsArray() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "ttsGetSystemVoices", arguments: nil)
+    plugin.handle(call) { response in
+      XCTAssertTrue(response is [String],
+                    "ttsGetSystemVoices should return array of JSON strings")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: - ttsRequestInstallVoice
+
+  func testTtsRequestInstallVoiceReturnsNil() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "ttsRequestInstallVoice", arguments: nil)
+    plugin.handle(call) { response in
+      XCTAssertNil(response, "ttsRequestInstallVoice should return nil (no-op on iOS)")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: - Audio methods without navigator
+
+  func testAudioSetPreferencesWithoutNavigator() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "audioSetPreferences", arguments: ["speed": 1.5])
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response as? FlutterError)
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 2.0)
+  }
+
+  // MARK: - goToLocator invalid args
+
+  func testGoToLocatorInvalidArgsReturnsError() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "goToLocator", arguments: nil)
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response as? FlutterError,
+                      "goToLocator with nil args should return FlutterError")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 2.0)
+  }
+
   override func tearDown() {
     currentPublication = nil
     super.tearDown()

--- a/flureadium/example/ios/RunnerTests/StateSerializationTests.swift
+++ b/flureadium/example/ios/RunnerTests/StateSerializationTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+import ReadiumShared
+@testable import flureadium
+
+final class ReadiumTimeBasedStateTests: XCTestCase {
+
+    // MARK: - toJson
+
+    func testToJsonMinimal() {
+        let state = ReadiumTimebasedState(state: .playing)
+        let json = state.toJson()
+        XCTAssertEqual(json["state"] as? String, "playing")
+        XCTAssertNil(json["currentOffset"])
+        XCTAssertNil(json["currentBuffered"])
+        XCTAssertNil(json["currentDuration"])
+        XCTAssertNil(json["currentLocator"])
+    }
+
+    func testToJsonFull() {
+        let locator = Locator(href: URL(string: "ch1.xhtml")!, mediaType: .html)
+        let state = ReadiumTimebasedState(
+            state: .paused,
+            currentOffset: 1.5,
+            currentBuffered: 10.0,
+            currentDuration: 60.0,
+            currentLocator: locator
+        )
+        let json = state.toJson()
+        XCTAssertEqual(json["state"] as? String, "paused")
+        XCTAssertEqual(json["currentOffset"] as? Int, 1500)  // seconds → milliseconds
+        XCTAssertEqual(json["currentBuffered"] as? Int, 10000)
+        XCTAssertEqual(json["currentDuration"] as? Int, 60000)
+        XCTAssertNotNil(json["currentLocator"])
+    }
+
+    func testToJsonTimeConversion() {
+        let state = ReadiumTimebasedState(state: .loading, currentOffset: 2.345)
+        let json = state.toJson()
+        XCTAssertEqual(json["currentOffset"] as? Int, 2345)
+    }
+
+    func testToJsonAllStates() {
+        XCTAssertEqual(ReadiumTimebasedState(state: .playing).toJson()["state"] as? String, "playing")
+        XCTAssertEqual(ReadiumTimebasedState(state: .paused).toJson()["state"] as? String, "paused")
+        XCTAssertEqual(ReadiumTimebasedState(state: .loading).toJson()["state"] as? String, "loading")
+        XCTAssertEqual(ReadiumTimebasedState(state: .ended).toJson()["state"] as? String, "ended")
+        XCTAssertEqual(ReadiumTimebasedState(state: .failure).toJson()["state"] as? String, "failure")
+    }
+
+    // MARK: - toJsonString
+
+    func testToJsonStringReturnsValidJson() {
+        let state = ReadiumTimebasedState(state: .playing, currentOffset: 5.0)
+        let jsonString = state.toJsonString()
+        XCTAssertNotNil(jsonString)
+
+        // Parse it back to verify it's valid JSON
+        let data = jsonString!.data(using: .utf8)!
+        let parsed = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(parsed["state"] as? String, "playing")
+        XCTAssertEqual(parsed["currentOffset"] as? Int, 5000)
+    }
+
+    func testToJsonStringPrettyPrinted() {
+        let state = ReadiumTimebasedState(state: .paused)
+        let pretty = state.toJsonString(pretty: true)
+        XCTAssertNotNil(pretty)
+        XCTAssertTrue(pretty!.contains("\n"), "Pretty-printed JSON should contain newlines")
+    }
+
+    // MARK: - Equatable
+
+    func testEqualitySameValues() {
+        let a = ReadiumTimebasedState(state: .playing, currentOffset: 1.0, currentDuration: 60.0)
+        let b = ReadiumTimebasedState(state: .playing, currentOffset: 1.0, currentDuration: 60.0)
+        XCTAssertEqual(a, b)
+    }
+
+    func testInequalityDifferentState() {
+        let a = ReadiumTimebasedState(state: .playing)
+        let b = ReadiumTimebasedState(state: .paused)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testInequalityDifferentOffset() {
+        let a = ReadiumTimebasedState(state: .playing, currentOffset: 1.0)
+        let b = ReadiumTimebasedState(state: .playing, currentOffset: 2.0)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testInequalityNilVsNonNilOffset() {
+        let a = ReadiumTimebasedState(state: .playing, currentOffset: nil)
+        let b = ReadiumTimebasedState(state: .playing, currentOffset: 1.0)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testEqualityBothNilOptionals() {
+        let a = ReadiumTimebasedState(state: .ended)
+        let b = ReadiumTimebasedState(state: .ended)
+        XCTAssertEqual(a, b)
+    }
+}

--- a/flureadium/example/ios/RunnerTests/UtilityTests.swift
+++ b/flureadium/example/ios/RunnerTests/UtilityTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import flureadium
+
+final class UtilityTests: XCTestCase {
+
+    // MARK: - clamp
+
+    func testClampBelowMinimum() {
+        XCTAssertEqual(clamp(1, minValue: 5, maxValue: 10), 5)
+    }
+
+    func testClampAboveMaximum() {
+        XCTAssertEqual(clamp(15, minValue: 5, maxValue: 10), 10)
+    }
+
+    func testClampWithinRange() {
+        XCTAssertEqual(clamp(7, minValue: 5, maxValue: 10), 7)
+    }
+
+    func testClampAtMinBoundary() {
+        XCTAssertEqual(clamp(5, minValue: 5, maxValue: 10), 5)
+    }
+
+    func testClampAtMaxBoundary() {
+        XCTAssertEqual(clamp(10, minValue: 5, maxValue: 10), 10)
+    }
+
+    func testClampWithDoubles() {
+        XCTAssertEqual(clamp(0.3, minValue: 0.5, maxValue: 2.0), 0.5)
+        XCTAssertEqual(clamp(3.0, minValue: 0.5, maxValue: 2.0), 2.0)
+        XCTAssertEqual(clamp(1.0, minValue: 0.5, maxValue: 2.0), 1.0)
+    }
+
+    // MARK: - Collection.firstMap
+
+    func testFirstMapReturnsFirstMatch() {
+        let result = [1, 2, 3].firstMap { $0 > 1 ? "\($0)" : nil }
+        XCTAssertEqual(result, "2")
+    }
+
+    func testFirstMapReturnsNilForNoMatch() {
+        let result = [1, 2, 3].firstMap { _ in nil as String? }
+        XCTAssertNil(result)
+    }
+
+    func testFirstMapOnEmptyCollection() {
+        let result = [Int]().firstMap { "\($0)" }
+        XCTAssertNil(result)
+    }
+
+    func testFirstMapReturnsFirstNotAll() {
+        var callCount = 0
+        let result = [10, 20, 30].firstMap { val -> Int? in
+            callCount += 1
+            return val >= 20 ? val : nil
+        }
+        XCTAssertEqual(result, 20)
+        XCTAssertEqual(callCount, 2, "Should stop after first match")
+    }
+
+    // MARK: - Sequence.asyncCompactMap
+
+    func testAsyncCompactMapFiltersNils() async {
+        let input = [1, 2, 3, 4, 5]
+        let result = await input.asyncCompactMap { val -> String? in
+            val.isMultiple(of: 2) ? "\(val)" : nil
+        }
+        XCTAssertEqual(result, ["2", "4"])
+    }
+
+    func testAsyncCompactMapEmptySequence() async {
+        let result = await [Int]().asyncCompactMap { "\($0)" }
+        XCTAssertEqual(result, [])
+    }
+
+    func testAsyncCompactMapAllNil() async {
+        let result = await [1, 2, 3].asyncCompactMap { _ -> String? in nil }
+        XCTAssertEqual(result, [])
+    }
+
+    func testAsyncCompactMapAllNonNil() async {
+        let result = await [1, 2, 3].asyncCompactMap { "\($0)" }
+        XCTAssertEqual(result, ["1", "2", "3"])
+    }
+}


### PR DESCRIPTION
## Summary

- Add ~130 XCTest unit tests across 10 test classes covering all testable native Swift code in the iOS plugin
- Tests cover model parsing, serialization, extensions, view geometry, navigator lifecycle, and plugin handler dispatch
- Update ios-unit-tests.md with complete test inventory and improved instructions

## Test plan

- [x] All tests pass via `xcodebuild test -only-testing:RunnerTests` (TEST SUCCEEDED)
- [x] No source code changes — test-only work
- [x] Existing 11 tests continue to pass (regression)