### PR TITLE
Fix iOS SIGABRT on hot reload with active reader

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.8.2
+
+### Bug Fixes
+
+- **iOS**: Fix SIGABRT crash on hot reload with an active EPUB or PDF reader. The crash was a Swift runtime exclusivity violation — `deinit` wrote to a global variable that was already mid-write during ARC deallocation triggered by the new view's `init`. Global reader view references are now `weak var` (matching Android's `WeakReference` pattern), and `deinit` no longer touches them.
+- **iOS**: Make PdfReaderView dispose handler comprehensive — stream disposal and channel cleanup were previously only in `deinit`, meaning they never ran when the Dart `dispose` call arrived while the engine was still alive.
+
 ## 0.8.1
 
 ### Bug Fixes

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -181,9 +181,33 @@ Flureadium iOS uses `EventStreamHandler` to manage Flutter EventChannel streams 
 
 This separation prevents crashes during app termination, where `FlutterEngine.destroyContext` triggers deallocation of native views after the message channels are already torn down.
 
+### Global Reference Lifecycle
+
+The plugin tracks the active reader view via two module-level globals in `FlureadiumPlugin.swift`:
+
+```swift
+internal weak var currentReaderView: ReadiumReaderView?
+internal weak var currentPdfReaderView: PdfReaderView?
+```
+
+Both are `weak var` — they do not own the view. This mirrors Android's `WeakReference<ReadiumReaderWidget>` pattern in `ReadiumReader.kt`. The weak reference prevents a Swift runtime exclusivity violation that would otherwise occur during hot reload: when a new view's `init` assigns itself to the global, ARC releases the old value, triggering the old view's `deinit` — if `deinit` also writes to the same global, Swift detects overlapping exclusive writes and aborts.
+
+Cleanup responsibilities:
+
+| Event | What happens |
+|-------|-------------|
+| `init` | View assigns itself to the global (`currentReaderView = self`) |
+| `"dispose"` method call | Identity-guarded cleanup (`if currentReaderView === self { currentReaderView = nil }`) — prevents clearing a newer view that replaced this one during hot reload |
+| `closePublication()` | Nils both globals before closing the publication — correct teardown order since views reference the publication |
+| `deinit` | Does not touch globals — handles only the view's own resource cleanup |
+
+The identity guard in the dispose handler matches Android's pattern at `ReadiumReaderWidget.kt:79`.
+
 **Files:**
 - `EventStreamHandler.swift` - Stream handler with `dispose()` that sends `FlutterEndOfEventStream`
-- `ReadiumReaderView.swift` - Calls stream `dispose()` in method call handler, not in `deinit`
+- `FlureadiumPlugin.swift` - Global weak references and `closePublication()` cleanup
+- `ReadiumReaderView.swift` - EPUB reader: init assigns global, dispose handler clears it
+- `PdfReaderView.swift` - PDF reader: same pattern as EPUB
 
 ## Troubleshooting
 

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -174,12 +174,21 @@ This is a native iOS layer change only. No Dart or Flutter changes are required.
 
 ### Stream and View Lifecycle
 
-Flureadium iOS uses `EventStreamHandler` to manage Flutter EventChannel streams (text locator, reader status, errors). Proper lifecycle management is critical:
+Flureadium iOS uses `EventStreamHandler` to manage Flutter EventChannel streams (text locator, reader status, errors). The `"dispose"` method call from Dart is the single comprehensive cleanup point. `deinit` is a minimal safety net.
 
-- **Stream disposal** (sending `FlutterEndOfEventStream` and clearing handlers) must happen in the `"dispose"` method call from Dart, while the Flutter engine is still alive
-- **`deinit`** only nils out references as a safety net — it must NOT send messages on Flutter channels, as `deinit` may be triggered during engine teardown when channels are no longer valid
+**dispose handler** owns all cleanup that needs a live Flutter engine:
 
-This separation prevents crashes during app termination, where `FlutterEngine.destroyContext` triggers deallocation of native views after the message channels are already torn down.
+| Responsibility | Why in dispose |
+|----------------|----------------|
+| Send "closed" status event | Needs live Flutter engine |
+| Stream `.dispose()` (sends `FlutterEndOfEventStream`) | Needs live Flutter engine |
+| Nil stream handler references | Part of explicit teardown |
+| Nil channel method call handler | Prevents calls after dispose |
+| Remove subview | Idempotent, safe in both |
+| Nil delegate | Part of explicit teardown |
+| Nil global reference (identity-guarded) | Explicit lifecycle event |
+
+**deinit** retains only `removeFromSuperview()` — it handles the edge case where the native view is deallocated without the Dart `dispose` call being received (engine teardown, hot restart). All property nilling is removed because ARC handles it automatically when the object deallocates. `deinit` must not send messages on Flutter channels, as it may run during engine teardown when channels are already torn down.
 
 ### Global Reference Lifecycle
 

--- a/flureadium/docs/troubleshooting.md
+++ b/flureadium/docs/troubleshooting.md
@@ -267,6 +267,14 @@ settles as soon as the reader is ready in integration tests.
 
 **Fix:** Ensure all stream handler `.dispose()` calls happen in the platform view's `"dispose"` method call handler (called from Dart while the engine is alive), not in `deinit`. The `deinit` should only nil out references without sending any messages. See [iOS Platform - Stream and View Lifecycle](platform-specific/ios.md#stream-and-view-lifecycle).
 
+### iOS: Crash on Hot Reload with Active Reader (SIGABRT)
+
+**Symptom:** `SIGABRT` with "Fatal access conflict detected" or "Simultaneous accesses to..." when hot-reloading while a reader view is open. The crash trace points to `ReadiumReaderView.deinit` or `PdfReaderView.deinit`.
+
+**Cause:** The old reader view's `deinit` was writing to a module-level global (`currentReaderView`) at the same time the new view's `init` was writing to it. Swift's runtime exclusivity enforcement detects overlapping writes and aborts. This happens because assigning the new view to the global triggers ARC release of the old value, which triggers `deinit` — all within a single write operation.
+
+**Fix (applied):** The globals are now `weak var`, so ARC zeroing doesn't trigger user code in `deinit`. The `deinit` no longer touches global state at all. Explicit cleanup happens in the `"dispose"` method call handler (identity-guarded) and in `closePublication()`. See [iOS Platform - Global Reference Lifecycle](platform-specific/ios.md#global-reference-lifecycle).
+
 ### iOS: Crash on ttsSetPreferences with Null voiceIdentifier
 
 **Symptom:**

--- a/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
@@ -10,19 +10,11 @@ private let TAG = "ReadiumReaderPlugin"
 
 internal var currentPublicationUrlStr: String?
 internal var currentPublication: Publication?
-internal var currentReaderView: ReadiumReaderView?
-internal var currentPdfReaderView: PdfReaderView?
+internal weak var currentReaderView: ReadiumReaderView?
+internal weak var currentPdfReaderView: PdfReaderView?
 
 func getCurrentPublication() -> Publication? {
   return currentPublication
-}
-
-func setCurrentReadiumReaderView(_ readerView: ReadiumReaderView?) {
-  currentReaderView = readerView
-}
-
-func setCurrentPdfReaderView(_ readerView: PdfReaderView?) {
-  currentPdfReaderView = readerView
 }
 
 public class FlureadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.WarningLogger, TimebasedListener {
@@ -589,6 +581,8 @@ extension FlureadiumPlugin {
     await MainActor.run {
       self.timebasedNavigator?.dispose()
       self.timebasedNavigator = nil
+      currentReaderView = nil
+      currentPdfReaderView = nil
       currentPublication?.close()
       currentPublication = nil
       currentPublicationUrlStr = nil

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -44,16 +44,8 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
   }
 
   deinit {
-    print(TAG, "::dispose")
+    print(TAG, "::deinit")
     pdfViewController.view.removeFromSuperview()
-    pdfViewController.delegate = nil
-    textLocatorStreamHandler?.dispose()
-    textLocatorStreamHandler = nil
-    readerStatusStreamHandler?.dispose()
-    readerStatusStreamHandler = nil
-    errorStreamHandler?.dispose()
-    errorStreamHandler = nil
-    channel.setMethodCallHandler(nil)
   }
 
   init(
@@ -517,6 +509,13 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
       pdfViewController.view.removeFromSuperview()
       pdfViewController.delegate = nil
       self.readerStatusStreamHandler?.sendEvent(PdfReaderStatusClosed)
+      textLocatorStreamHandler?.dispose()
+      textLocatorStreamHandler = nil
+      readerStatusStreamHandler?.dispose()
+      readerStatusStreamHandler = nil
+      errorStreamHandler?.dispose()
+      errorStreamHandler = nil
+      channel.setMethodCallHandler(nil)
       if currentPdfReaderView === self { currentPdfReaderView = nil }
       result(nil)
     default:

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -54,7 +54,6 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
     errorStreamHandler?.dispose()
     errorStreamHandler = nil
     channel.setMethodCallHandler(nil)
-    setCurrentPdfReaderView(nil)
   }
 
   init(
@@ -126,7 +125,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
       ]
     )
 
-    setCurrentPdfReaderView(self)
+    currentPdfReaderView = self
     publicationIdentifier = publication.metadata.identifier
 
     // Configure edge tap handlers for page navigation
@@ -518,6 +517,7 @@ class PdfReaderView: NSObject, FlutterPlatformView, PDFNavigatorDelegate, Visual
       pdfViewController.view.removeFromSuperview()
       pdfViewController.delegate = nil
       self.readerStatusStreamHandler?.sendEvent(PdfReaderStatusClosed)
+      if currentPdfReaderView === self { currentPdfReaderView = nil }
       result(nil)
     default:
       print(TAG, "Unhandled call \(call.method)")

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -55,11 +55,6 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   deinit {
     print(TAG, "::deinit")
     readiumViewController.view.removeFromSuperview()
-    readiumViewController.delegate = nil
-    textLocatorStreamHandler = nil
-    readerStatusStreamHandler = nil
-    errorStreamHandler = nil
-    channel.setMethodCallHandler(nil)
   }
 
   init(
@@ -601,6 +596,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
       readerStatusStreamHandler = nil
       errorStreamHandler?.dispose()
       errorStreamHandler = nil
+      channel.setMethodCallHandler(nil)
       if currentReaderView === self { currentReaderView = nil }
       result(nil)
       break

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -60,7 +60,6 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     readerStatusStreamHandler = nil
     errorStreamHandler = nil
     channel.setMethodCallHandler(nil)
-    setCurrentReadiumReaderView(nil)
   }
 
   init(
@@ -152,7 +151,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
       ]
     )
 
-    setCurrentReadiumReaderView(self)
+    currentReaderView = self
     publicationIdentifier = publication.metadata.identifier
 
     /// This adapter will automatically turn pages when the user taps the
@@ -602,6 +601,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
       readerStatusStreamHandler = nil
       errorStreamHandler?.dispose()
       errorStreamHandler = nil
+      if currentReaderView === self { currentReaderView = nil }
       result(nil)
       break
     default:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- Make `currentReaderView` / `currentPdfReaderView` globals `weak var` and remove setter wrappers — prevents overlapping exclusive writes when deinit fires during a new view's init
- Consolidate cleanup so the dispose handler is the single comprehensive teardown point; deinit keeps only `removeFromSuperview()` as a safety net
- Add identity-guarded global cleanup and nil both reader globals in `closePublication()`
- Fix PdfReaderView's missing stream disposal in dispose handler and wrong print tag in deinit

## Test plan

- [x] iOS unit tests pass (all RunnerTests)
- [x] iOS simulator build succeeds
- [ ] Manual: hot reload with active EPUB reader — no crash
- [ ] Manual: hot reload with active PDF reader — no crash
- [ ] Manual: close publication and reopen — streams clean up properly