### PR TITLE
Fix PDF navigator NPE on init

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -49,3 +49,4 @@ bd.db
 # since no pattern above ignores them.
 
 .beads-credential-key
+interactions.jsonl

--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -47,3 +47,5 @@ bd.db
 # They would override fork protection in .git/info/exclude.
 # Config files (metadata.json, config.yaml) are tracked by git by default
 # since no pattern above ignores them.
+
+.beads-credential-key

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.3
+
+### Bug Fixes
+
+- **Android**: Fix NullPointerException crash when opening PDF files. Inside `PdfNavigator.initNavigator()`, a Kotlin scope resolution bug caused `engineProvider` to resolve to the uninitialized `PdfReaderViewModel` property instead of the outer `PdfNavigator` property.
+
 ## 0.8.2
 
 ### Bug Fixes

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/PdfNavigator.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/PdfNavigator.kt
@@ -119,7 +119,7 @@ class PdfNavigator : BaseNavigator, PdfReaderFragment.Listener {
             vm = PdfReaderViewModel().apply {
                 navigatorFactory = PdfNavigatorFactory(
                     publication,
-                    pdfEngineProvider = engineProvider!!
+                    pdfEngineProvider = this@PdfNavigator.engineProvider!!
                 )
                 locator = this@PdfNavigator.initialLocator
                 fit = this@PdfNavigator.flutterPreferences.toReadiumFit()

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/PdfNavigatorInitTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/PdfNavigatorInitTest.kt
@@ -1,0 +1,87 @@
+package dev.mulev.flureadium.navigators
+
+import dev.mulev.flureadium.FlutterPdfPreferences
+import dev.mulev.flureadium.fragments.PdfReaderFragment
+import dev.mulev.flureadium.models.PdfReaderViewModel
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockConstruction
+import org.readium.adapter.pdfium.navigator.PdfiumEngineProvider
+import org.readium.r2.navigator.pdf.PdfNavigatorFactory
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Publication
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression test for PdfNavigator.initNavigator() scope resolution.
+ *
+ * Bare `engineProvider!!` inside `PdfReaderViewModel.apply {}` resolved to
+ * PdfReaderViewModel.engineProvider (null) instead of PdfNavigator.engineProvider.
+ * The fix qualifies it as `this@PdfNavigator.engineProvider!!`.
+ */
+@OptIn(ExperimentalReadiumApi::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], manifest = Config.NONE)
+internal class PdfNavigatorInitTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createNavigator(): PdfNavigator {
+        return PdfNavigator(
+            mock(Publication::class.java),
+            null,
+            mock(PdfNavigator.VisualListener::class.java),
+            FlutterPdfPreferences()
+        )
+    }
+
+    private fun PdfNavigator.getField(name: String): Any? {
+        val field = PdfNavigator::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(this)
+    }
+
+    /**
+     * Without the fix, initNavigator() throws NPE because PdfReaderViewModel.engineProvider
+     * is null at construction time. With the fix, the outer PdfNavigator.engineProvider is
+     * used instead.
+     */
+    @Test
+    fun initNavigator_resolves_engineProvider_from_outer_scope() = runTest {
+        val navigator = createNavigator()
+
+        mockConstruction(PdfiumEngineProvider::class.java).use {
+            mockConstruction(PdfNavigatorFactory::class.java).use {
+                navigator.initNavigator()
+            }
+        }
+
+        val fragment = navigator.getField("pdfNavigator") as PdfReaderFragment
+        assertNotNull(fragment, "pdfNavigator fragment should be initialized")
+
+        val vm = fragment.vm as PdfReaderViewModel
+        assertNotNull(vm.navigatorFactory, "navigatorFactory must be set")
+        assertNotNull(vm.engineProvider, "VM engineProvider must be set from outer PdfNavigator scope")
+    }
+}

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.1"
+    version: "0.8.3"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.8.2
+version: 0.8.3
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- Fix NullPointerException when opening PDFs on Android — bare `engineProvider!!` inside `PdfReaderViewModel.apply {}` resolved to the ViewModel's null property instead of the outer `PdfNavigator`'s initialized property. Qualified with `this@PdfNavigator`.
- Add regression test (`PdfNavigatorInitTest`) that catches the NPE with the old code and passes with the fix.
- Bump version to 0.8.3.

## Test plan

- [x] New regression test passes (red without fix, green with fix)
- [x] Full Android unit test suite passes
- [x] Manual verification: PDF opens without crash on Android device