### PR TITLE
Add Copy to the iOS EPUB text selection menu

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -1,0 +1,1 @@
+{"id":"int-9c507627","kind":"field_change","created_at":"2026-04-12T20:51:29.27407Z","actor":"Mike Mulev","issue_id":"flureadium-voe","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Phase 1 complete: add Copy to iOS EPUB text selection"}}

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.9.0
+
+### New Features
+
+- **iOS / EPUB**: Add `Copy` to the long-press text selection menu. EPUB selection actions now use `EditingAction.copy`, `EditingAction.lookup`, and `EditingAction.translate`, replacing the old placeholder custom action.
+
+### Testing
+
+- Add iOS XCTest coverage for EPUB editing actions in `EpubEditingActionsTests`.
+- Add an EPUB integration smoke test that long-presses the reader surface and verifies the reader remains mounted.
+
+### Documentation
+
+- Document text-selection copy behavior on iOS and Android, including the existing PDF behavior and the Android PDF limitation.
+
 ## 0.8.3
 
 ### Bug Fixes

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -231,6 +231,16 @@ PDF is always paginated; scroll mode does not apply.
 that lands in an edge zone (claiming the gesture sequence), and `false` for centre touches
 (passing them straight to the Readium WebView / PDF view).
 
+### Text Selection Copy
+
+**EPUB:** Copy is available through Android's native WebView text-selection
+action mode. When the user long-presses EPUB content, the system selection UI
+handles Copy without any plugin-specific override.
+
+**PDF:** Text selection and copy are not supported on this path. The Pdfium
+adapter renders PDF pages as bitmap content, so there is no text layer for the
+system action mode to act on.
+
 ## Troubleshooting
 
 ### "MainActivity cannot be cast to FragmentActivity"

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -172,6 +172,26 @@ This is a native iOS layer change only. No Dart or Flutter changes are required.
 - `ReadiumReaderView.swift` - EPUB reader using EdgeTapInterceptView
 - `PdfReaderView.swift` - PDF reader using EdgeTapInterceptView
 
+### Text Selection Copy
+
+When a user long-presses text in an EPUB or PDF reader, iOS shows a native
+selection menu.
+
+**EPUB:** The menu shows Copy, Look Up, and Translate. This is configured via
+Readium's `EditingAction` support with
+`config.editingActions = [.copy, .lookup, .translate]` in
+`EPUBNavigatorViewController.Configuration`. The `.copy` action uses the native
+`copy:` responder selector and copies the current selection to
+`UIPasteboard.general`.
+
+**PDF:** Copy is available through Readium's default editing actions
+(`EditingAction.defaultActions = [.copy, .share, .lookup, .translate]`). The
+`PDFNavigatorViewController` path keeps those defaults.
+
+> Note: Copy still respects DRM rights. For protected publications, Readium
+> checks `UserRights.copy(text:)` before writing to the pasteboard and silently
+> blocks copy when the license denies it.
+
 ### Stream and View Lifecycle
 
 Flureadium iOS uses `EventStreamHandler` to manage Flutter EventChannel streams (text locator, reader status, errors). The `"dispose"` method call from Dart is the single comprehensive cleanup point. `deinit` is a minimal safety net.

--- a/flureadium/example/integration_test/epub_test.dart
+++ b/flureadium/example/integration_test/epub_test.dart
@@ -24,6 +24,22 @@ void main() {
       expect(find.byType(ReadiumReaderWidget), findsOneWidget);
     });
 
+    testWidgets('long press on reader does not crash', (tester) async {
+      app.main();
+      for (var i = 0; i < 15; i++) {
+        await tester.pump(const Duration(seconds: 1));
+        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
+      }
+
+      final reader = find.byType(ReadiumReaderWidget);
+      expect(reader, findsOneWidget);
+
+      await tester.longPressAt(tester.getCenter(reader));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(reader, findsOneWidget);
+    });
+
     testWidgets('navigate left and right', (tester) async {
       app.main();
       for (var i = 0; i < 15; i++) {

--- a/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C1D2E3F4A5B6C7D800006002 /* ReadiumErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */; };
 		D1E2F3A4B5C6D7E800007002 /* EdgeTapInterceptViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */; };
 		D1E2F3A4B5C6D7E800008002 /* NowPlayingInfoUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */; };
+		E1F2A3B4C5D6E7F800008002 /* EpubEditingActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -67,6 +68,7 @@
 		C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumErrorTests.swift; sourceTree = "<group>"; };
 		D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeTapInterceptViewTests.swift; sourceTree = "<group>"; };
 		D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoUpdaterTests.swift; sourceTree = "<group>"; };
+		E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpubEditingActionsTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5BDBF082C9CC180601979FB5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				C1D2E3F4A5B6C7D800006001 /* ReadiumErrorTests.swift */,
 				D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */,
 				D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */,
+				E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -413,6 +416,7 @@
 				C1D2E3F4A5B6C7D800006002 /* ReadiumErrorTests.swift in Sources */,
 				D1E2F3A4B5C6D7E800007002 /* EdgeTapInterceptViewTests.swift in Sources */,
 				D1E2F3A4B5C6D7E800008002 /* NowPlayingInfoUpdaterTests.swift in Sources */,
+				E1F2A3B4C5D6E7F800008002 /* EpubEditingActionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/flureadium/example/ios/RunnerTests/EpubEditingActionsTests.swift
+++ b/flureadium/example/ios/RunnerTests/EpubEditingActionsTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import flureadium
+
+final class EpubEditingActionsTests: XCTestCase {
+
+    func testEpubEditingActionsContainsCopy() {
+        XCTAssertTrue(
+            ReadiumReaderView.epubEditingActions.contains(.copy),
+            "editingActions must include .copy so users can copy selected text"
+        )
+    }
+
+    func testEpubEditingActionsContainsLookup() {
+        XCTAssertTrue(
+            ReadiumReaderView.epubEditingActions.contains(.lookup),
+            "editingActions must retain .lookup (regression)"
+        )
+    }
+
+    func testEpubEditingActionsContainsTranslate() {
+        XCTAssertTrue(
+            ReadiumReaderView.epubEditingActions.contains(.translate),
+            "editingActions must retain .translate (regression)"
+        )
+    }
+
+    func testEpubEditingActionsCountIsThree() {
+        XCTAssertEqual(
+            ReadiumReaderView.epubEditingActions.count,
+            3,
+            "editingActions must have exactly 3 items: copy, lookup, translate"
+        )
+    }
+}

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -47,6 +47,10 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
 
   var publicationIdentifier: String?
 
+  /// The editing actions shown in the EPUB long-press selection menu.
+  /// Keeping this as a static constant makes the native action set testable.
+  static let epubEditingActions: [EditingAction] = [.copy, .lookup, .translate]
+
   func view() -> UIView {
     print(TAG, "::getView")
     return _view
@@ -104,7 +108,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     config.preloadNextPositionCount = 4
     config.debugState = true
     config.decorationTemplates = HTMLDecorationTemplate.defaultTemplates(alpha: 1.0, experimentalPositioning: true)
-    config.editingActions = [.lookup, .translate, EditingAction(title: "Custom Action", action: #selector(onCustomEditingAction))]
+    config.editingActions = ReadiumReaderView.epubEditingActions
 
     if (defaultPreferences != nil) {
       config.preferences = defaultPreferences!

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.8.3
+version: 0.9.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
Summary
- Add Copy to the iOS EPUB long-press text selection menu.
- Add iOS XCTest coverage and an EPUB long-press integration smoke test.
- Update platform docs and bump flureadium to 0.9.0.

Testing
- flutter test
- flutter build ios --simulator --debug
- User-verified iOS unit tests and manual copy behavior.

Notes
- Beads task flureadium-voe is closed in this branch.