### PR TITLE
fix: stabilize Android background TTS playback

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -1,1 +1,0 @@
-{"id":"int-9c507627","kind":"field_change","created_at":"2026-04-12T20:51:29.27407Z","actor":"Mike Mulev","issue_id":"flureadium-voe","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Phase 1 complete: add Copy to iOS EPUB text selection"}}

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.9.1
+
+### Bug Fixes
+
+- **Android / TTS and audiobook background playback**: Start `PluginMediaService` with `startForegroundService()` instead of `startService()` so Android 15 does not kill playback shortly after the app goes to the background.
+- **Android / media session cleanup**: Close the media session if `TTSNavigator.play()` or `AudiobookNavigator.play()` fails while opening the session, preventing a dangling foreground-service start from timing out.
+
+### Testing
+
+- Add Android JVM regression tests for foreground-service startup and `openSession()` failure cleanup in TTS and audiobook navigators.
+
+### Documentation
+
+- Document the Android foreground-service permissions required for background TTS and audiobook playback.
+- Add a troubleshooting note for TTS stopping about a second after the app is backgrounded on Android 15+.
+
 ## 0.9.0
 
 ### New Features

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -4,15 +4,17 @@
 
 - **Android / TTS and audiobook background playback**: Start `PluginMediaService` with `startForegroundService()` instead of `startService()` so Android 15 does not kill playback shortly after the app goes to the background.
 - **Android / media session cleanup**: Close the media session if `TTSNavigator.play()` or `AudiobookNavigator.play()` fails while opening the session, preventing a dangling foreground-service start from timing out.
+- **Android / saved-state background crash**: Persist `FlutterDecorationPreferences` as primitive `Bundle` data instead of Java serialization so pressing Home does not crash activity state saving with `BadParcelableException` on devices where Readium decoration styles are not serializable.
 
 ### Testing
 
 - Add Android JVM regression tests for foreground-service startup and `openSession()` failure cleanup in TTS and audiobook navigators.
+- Add Android JVM regression tests for `FlutterDecorationPreferences` bundle round-tripping and `ReadiumReader.storeState()` parcel-safe saved-state persistence.
 
 ### Documentation
 
 - Document the Android foreground-service permissions required for background TTS and audiobook playback.
-- Add a troubleshooting note for TTS stopping about a second after the app is backgrounded on Android 15+.
+- Update the Android troubleshooting note to cover both the foreground-service startup fix and the saved-state crash fix for playback stopping when the app is backgrounded.
 
 ## 0.9.0
 

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -21,7 +21,7 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.8.0
+  flureadium: ^0.9.1
 ```
 
 ### Platform Setup
@@ -46,6 +46,8 @@ class MainActivity: FlutterFragmentActivity()
 3. If using TTS with `AudioService`, add to `AndroidManifest.xml`:
 ```xml
 <uses-permission android:name="android.permission.WAKE_LOCK" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 ```
 
 </details>

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/FlutterDecorationPreferences.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/FlutterDecorationPreferences.kt
@@ -1,14 +1,20 @@
 package dev.mulev.flureadium
 
 import android.graphics.Color
+import android.os.Bundle
 import org.readium.r2.navigator.Decoration
-import java.io.Serializable
 
 // TODO: Decision on appropriate defaults
 // TODO: Can this be made configurable at built time?
 // TODO: More complex styles? Like bold or italic plus background and text colors?
 private val defaultUtteranceStyle = Decoration.Style.Highlight(tint = Color.YELLOW)
 private val defaultCurrentRangeStyle = Decoration.Style.Underline(tint = Color.RED)
+private const val utteranceStyleKey = "utteranceStyle"
+private const val currentRangeStyleKey = "currentRangeStyle"
+private const val decorationTypeKey = "type"
+private const val decorationTintKey = "tint"
+private const val decorationTypeHighlight = "highlight"
+private const val decorationTypeUnderline = "underline"
 
 /**
  * Decoration preferences used in the Flutter Readium plugin.
@@ -23,8 +29,27 @@ data class FlutterDecorationPreferences(
      * Style for current reading range decoration.
      */
     var currentRangeStyle: Decoration.Style? = defaultCurrentRangeStyle
-) : Serializable {
+) {
+    fun toBundle(): Bundle =
+        Bundle().apply {
+            putBundle(utteranceStyleKey, utteranceStyle.toBundle())
+            putBundle(currentRangeStyleKey, currentRangeStyle.toBundle())
+        }
+
     companion object {
+        fun fromBundle(bundle: Bundle?): FlutterDecorationPreferences {
+            if (bundle == null) {
+                return FlutterDecorationPreferences()
+            }
+
+            return FlutterDecorationPreferences(
+                utteranceStyle = decorationStyleFromBundle(bundle.getBundle(utteranceStyleKey))
+                    ?: defaultUtteranceStyle,
+                currentRangeStyle = decorationStyleFromBundle(bundle.getBundle(currentRangeStyleKey))
+                    ?: defaultCurrentRangeStyle,
+            )
+        }
+
         /**
          * Create Decoration.Style from map.
          */
@@ -39,3 +64,38 @@ data class FlutterDecorationPreferences(
         }
     }
 }
+
+private fun Decoration.Style?.toBundle(): Bundle? {
+    if (this == null) {
+        return null
+    }
+
+    return Bundle().apply {
+        when (this@toBundle) {
+            is Decoration.Style.Highlight -> putString(decorationTypeKey, decorationTypeHighlight)
+            is Decoration.Style.Underline -> putString(decorationTypeKey, decorationTypeUnderline)
+        }
+
+        decorationStyleTint(this@toBundle)?.let { putInt(decorationTintKey, it) }
+    }
+}
+
+private fun decorationStyleFromBundle(bundle: Bundle?): Decoration.Style? {
+    if (bundle == null || !bundle.containsKey(decorationTintKey)) {
+        return null
+    }
+
+    val tint = bundle.getInt(decorationTintKey)
+    return when (bundle.getString(decorationTypeKey)) {
+        decorationTypeUnderline -> Decoration.Style.Underline(tint = tint)
+        decorationTypeHighlight -> Decoration.Style.Highlight(tint = tint)
+        else -> null
+    }
+}
+
+private fun decorationStyleTint(style: Decoration.Style): Int? =
+    when (style) {
+        is Decoration.Style.Highlight -> style.tint
+        is Decoration.Style.Underline -> style.tint
+        else -> null
+    }

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PluginMediaService.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PluginMediaService.kt
@@ -23,6 +23,7 @@ import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
 import androidx.media3.common.ForwardingSimpleBasePlayer
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
@@ -307,7 +308,7 @@ class PluginMediaService : MediaSessionService(), MediaSession.Callback {
 
         fun start(application: Application) {
             val intent = intent(application)
-            application.startService(intent)
+            ContextCompat.startForegroundService(application, intent)
         }
 
         fun stop(application: Application) {

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
@@ -280,7 +280,7 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
             putBundle(audioNavigatorStateKey, audiobookNavigator?.storeState())
             putBoolean(syncAudioEnabledKey, syncAudiobookNavigator != null)
             putBundle(syncAudioNavigatorStateKey, syncAudiobookNavigator?.storeState())
-            putSerializable(decorationStyleKey, decorationStyle)
+            putBundle(decorationStyleKey, decorationStyle.toBundle())
         }
     }
 
@@ -305,7 +305,7 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
                 return@launch
             }
 
-            decorationStyle = bundle.getSerializable(decorationStyleKey) as? FlutterDecorationPreferences ?: FlutterDecorationPreferences()
+            decorationStyle = FlutterDecorationPreferences.fromBundle(bundle.getBundle(decorationStyleKey))
 
             if (bundle.getBoolean(epubEnabledKey)) {
                 Log.d(TAG, ":storeState - restore epub navigator")

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigator.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigator.kt
@@ -123,6 +123,7 @@ open class AudiobookNavigator(
                 mediaServiceFacade?.openSession(audioNavigator!!)
             } catch (e: Exception) {
                 Log.e(TAG, "Error opening MediaSession: ${e.message}")
+                mediaServiceFacade?.closeSession()
                 audioNavigator?.close()
                 return@async
             }
@@ -305,4 +306,3 @@ open class AudiobookNavigator(
         }
     }
 }
-

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/TTSNavigator.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/TTSNavigator.kt
@@ -166,6 +166,7 @@ class TTSNavigator(
                 ttsNavigator?.play()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to open MediaSession: $e")
+                mediaServiceFacade?.closeSession()
                 ttsNavigator?.close()
                 return@async
             }

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/FlutterDecorationPreferencesTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/FlutterDecorationPreferencesTest.kt
@@ -1,0 +1,53 @@
+package dev.mulev.flureadium
+
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import org.junit.runner.RunWith
+import org.readium.r2.navigator.Decoration
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], manifest = Config.NONE)
+internal class FlutterDecorationPreferencesTest {
+
+    @Test
+    fun toBundle_roundTripsCustomStyles() {
+        val original = FlutterDecorationPreferences(
+            utteranceStyle = Decoration.Style.Underline(tint = Color.GREEN),
+            currentRangeStyle = Decoration.Style.Highlight(tint = Color.BLUE)
+        )
+
+        val restored = FlutterDecorationPreferences.fromBundle(original.toBundle())
+
+        val utteranceStyle = assertIs<Decoration.Style.Underline>(restored.utteranceStyle)
+        val currentRangeStyle = assertIs<Decoration.Style.Highlight>(restored.currentRangeStyle)
+        assertEquals(Color.GREEN, utteranceStyle.tint)
+        assertEquals(Color.BLUE, currentRangeStyle.tint)
+    }
+
+    @Test
+    fun toBundle_canBeWrittenToParcel() {
+        val preferences = FlutterDecorationPreferences()
+        val parcel = Parcel.obtain()
+
+        try {
+            parcel.writeBundle(Bundle().apply {
+                putBundle("decorationStyle", preferences.toBundle())
+            })
+            parcel.setDataPosition(0)
+
+            val restored = parcel.readBundle(javaClass.classLoader)?.getBundle("decorationStyle")
+
+            assertNotNull(restored)
+        } finally {
+            parcel.recycle()
+        }
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PluginMediaServiceStartTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PluginMediaServiceStartTest.kt
@@ -1,0 +1,28 @@
+package dev.mulev.flureadium
+
+import android.app.Application
+import android.content.Intent
+import android.os.Build
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+internal class PluginMediaServiceStartTest {
+
+    @Test
+    fun start_callsStartForegroundService_notStartService() {
+        val application = mock(Application::class.java)
+
+        PluginMediaService.start(application)
+
+        verify(application).startForegroundService(any(Intent::class.java))
+        verify(application, never()).startService(any(Intent::class.java))
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/ReadiumReaderSavedStateTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/ReadiumReaderSavedStateTest.kt
@@ -1,0 +1,67 @@
+package dev.mulev.flureadium
+
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import org.junit.runner.RunWith
+import org.readium.r2.navigator.Decoration
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], manifest = Config.NONE)
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ReadiumReaderSavedStateTest {
+
+    @AfterTest
+    fun tearDown() {
+        ReadiumReader.currentPublicationUrl = null
+        ReadiumReader.decorationStyle = FlutterDecorationPreferences()
+    }
+
+    @Test
+    fun storeState_persistsDecorationStyleAsBundle() {
+        ReadiumReader.currentPublicationUrl = "https://example.com/book.epub"
+        ReadiumReader.decorationStyle = FlutterDecorationPreferences(
+            utteranceStyle = Decoration.Style.Underline(tint = Color.GREEN),
+            currentRangeStyle = Decoration.Style.Highlight(tint = Color.BLUE)
+        )
+
+        val parcel = Parcel.obtain()
+
+        try {
+            val savedState = invokeStoreState()
+            parcel.writeBundle(savedState)
+            parcel.setDataPosition(0)
+
+            val restoredState = parcel.readBundle(javaClass.classLoader)
+            val decorationStyleBundle = restoredState?.getBundle("decorationStyle")
+            val restoredPreferences = FlutterDecorationPreferences.fromBundle(decorationStyleBundle)
+
+            assertNotNull(decorationStyleBundle)
+            assertEquals(
+                Color.GREEN,
+                assertIs<Decoration.Style.Underline>(restoredPreferences.utteranceStyle).tint
+            )
+            assertEquals(
+                Color.BLUE,
+                assertIs<Decoration.Style.Highlight>(restoredPreferences.currentRangeStyle).tint
+            )
+        } finally {
+            parcel.recycle()
+        }
+    }
+
+    private fun invokeStoreState(): Bundle {
+        val storeState = ReadiumReader::class.java.getDeclaredMethod("storeState")
+        storeState.isAccessible = true
+        return storeState.invoke(ReadiumReader) as Bundle
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigatorPlayErrorTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigatorPlayErrorTest.kt
@@ -1,0 +1,80 @@
+package dev.mulev.flureadium.navigators
+
+import dev.mulev.flureadium.FlutterAudioPreferences
+import dev.mulev.flureadium.PluginMediaServiceFacade
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.readium.adapter.exoplayer.audio.ExoPlayerPreferences
+import org.readium.adapter.exoplayer.audio.ExoPlayerSettings
+import org.readium.navigator.media.audio.AudioNavigator
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Publication
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalReadiumApi::class, ExperimentalCoroutinesApi::class)
+internal class AudiobookNavigatorPlayErrorTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private class TestableAudiobookNavigator(
+        publication: Publication,
+        listener: TimebasedNavigator.TimebasedListener,
+        preferences: FlutterAudioPreferences
+    ) : AudiobookNavigator(publication, listener, null, preferences) {
+        override suspend fun initNavigator() {
+            // No-op for JVM unit tests.
+        }
+
+        fun setTestAudioNavigator(
+            navigator: AudioNavigator<ExoPlayerSettings, ExoPlayerPreferences>?
+        ) {
+            audioNavigator = navigator
+        }
+
+        fun setTestMediaServiceFacade(facade: PluginMediaServiceFacade?) {
+            mediaServiceFacade = facade
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun play_callsCloseSession_whenOpenSessionThrows() = runTest {
+        val navigator = TestableAudiobookNavigator(
+            mock(Publication::class.java),
+            mock(TimebasedNavigator.TimebasedListener::class.java),
+            FlutterAudioPreferences()
+        )
+        val mockFacade = mock(PluginMediaServiceFacade::class.java)
+        val mockAudioNavigator = mock(AudioNavigator::class.java)
+            as AudioNavigator<ExoPlayerSettings, ExoPlayerPreferences>
+        doThrow(RuntimeException("simulated failure"))
+            .`when`(mockFacade)
+            .openSession(any())
+        navigator.setTestMediaServiceFacade(mockFacade)
+        navigator.setTestAudioNavigator(mockAudioNavigator)
+
+        navigator.play(null)
+
+        verify(mockFacade).closeSession()
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/TTSNavigatorPlayErrorTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/TTSNavigatorPlayErrorTest.kt
@@ -1,0 +1,68 @@
+package dev.mulev.flureadium.navigators
+
+import dev.mulev.flureadium.FlutterTtsPreferences
+import dev.mulev.flureadium.PluginMediaServiceFacade
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.readium.navigator.media.tts.TtsNavigator
+import org.readium.navigator.media.tts.android.AndroidTtsEngine
+import org.readium.navigator.media.tts.android.AndroidTtsPreferences
+import org.readium.navigator.media.tts.android.AndroidTtsSettings
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Publication
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalReadiumApi::class, ExperimentalCoroutinesApi::class)
+internal class TTSNavigatorPlayErrorTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun TTSNavigator.setField(name: String, value: Any?) {
+        val field = TTSNavigator::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(this, value)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun play_callsCloseSession_whenOpenSessionThrows() = runTest {
+        val navigator = TTSNavigator(
+            mock(Publication::class.java),
+            mock(TimebasedNavigator.TimebasedListener::class.java),
+            null,
+            FlutterTtsPreferences()
+        )
+        val mockFacade = mock(PluginMediaServiceFacade::class.java)
+        val mockTtsNavigator = mock(TtsNavigator::class.java)
+            as TtsNavigator<AndroidTtsSettings, AndroidTtsPreferences, AndroidTtsEngine.Error, AndroidTtsEngine.Voice>
+        doThrow(RuntimeException("simulated failure"))
+            .`when`(mockFacade)
+            .openSession(any())
+        navigator.setField("mediaServiceFacade", mockFacade)
+        navigator.setField("ttsNavigator", mockTtsNavigator)
+
+        navigator.play(null)
+
+        verify(mockFacade).closeSession()
+    }
+}

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.1.0
+  flureadium: ^0.9.1
 ```
 
 Run:
@@ -66,13 +66,15 @@ class MainActivity: FlutterFragmentActivity() {
 
 This fixes the error: `MainActivity cannot be cast to androidx.fragment.app.FragmentActivity`
 
-#### 4. Add Wake Lock Permission (Optional)
+#### 4. Add Playback Permissions (Optional)
 
 If using TTS or audiobook features, add to `android/app/src/main/AndroidManifest.xml`:
 
 ```xml
 <manifest>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <!-- ... -->
 </manifest>
 ```

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -59,6 +59,9 @@ For TTS and audiobook features, add to `AndroidManifest.xml`:
 ```xml
 <manifest>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- Required for TTS and audiobook background playback on Android 14+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <!-- For network-based publications -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -264,6 +267,7 @@ android {
 1. Check TTS engine is installed (Settings > Accessibility > TTS)
 2. Download language data if prompted
 3. Test with system TTS settings
+4. If TTS stops about a second after the app goes to the background on Android 15+, update to the latest Flureadium release. That bug came from starting the media service with `startService` instead of `startForegroundService`, and it has been fixed.
 
 ### Edge taps not responding
 

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -267,7 +267,7 @@ android {
 1. Check TTS engine is installed (Settings > Accessibility > TTS)
 2. Download language data if prompted
 3. Test with system TTS settings
-4. If TTS stops about a second after the app goes to the background on Android 15+, update to the latest Flureadium release. That bug came from starting the media service with `startService` instead of `startForegroundService`, and it has been fixed.
+4. If TTS stops when the app goes to the background, update to the latest Flureadium release. Recent Android fixes cover both the media-service startup path (`startForegroundService()` instead of `startService()`) and an activity saved-state crash caused by serializing Readium decoration styles when the app was backgrounded.
 
 ### Edge taps not responding
 

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.3"
+    version: "0.9.1"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.9.0
+version: 0.9.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary
- start Android background playback with `startForegroundService()` and close media sessions on `openSession()` failure
- persist `FlutterDecorationPreferences` via `Bundle` data to prevent the background state-save crash
- bump flureadium to 0.9.1 and update changelog, docs, and Android JVM coverage

## Testing
- Android JVM `testDebugUnitTest`
- `flutter test`

## Manual verification
- Pixel emulator retest confirmed TTS keeps playing after pressing Home