### PR TITLE
Fix Android sync audiobook saved-state crash

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.2
+
+### Bug Fixes
+
+- **Android / sync audiobook saved-state crash**: `SyncAudiobookNavigator.storeState()` put `FlutterMediaOverlay` objects into the Bundle via `putSerializable`, but those objects contain non-serializable Readium types (`Url`, `MediaType`). Android's activity state save hit `BadParcelableException` → `NotSerializableException` during synchronized audiobook playback. The data was never actually read back — `restoreState()` re-derives overlays from the publication — so the fix drops the dead `putSerializable` call and removes `Serializable` from both model classes.
+
 ## 0.9.1
 
 ### Bug Fixes

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -21,7 +21,7 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.9.1
+  flureadium: ^0.9.2
 ```
 
 ### Platform Setup

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/models/FlutterMediaOverlay.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/models/FlutterMediaOverlay.kt
@@ -8,14 +8,12 @@ import org.json.JSONObject
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.Url
 import org.readium.r2.shared.util.mediatype.MediaType
-import java.io.Serializable
-
 private const val TAG = "FlutterMediaOverlay"
 
 /**
  * Simple media overlay mapping.
  */
-data class FlutterMediaOverlay(val items: List<FlutterMediaOverlayItem>) : Serializable {
+data class FlutterMediaOverlay(val items: List<FlutterMediaOverlayItem>) {
     /**
      * The audio file name (without fragment).
      */

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/models/FlutterMediaOverlayItem.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/models/FlutterMediaOverlayItem.kt
@@ -4,7 +4,6 @@ import org.json.JSONObject
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.Url
 import org.readium.r2.shared.util.mediatype.MediaType
-import java.io.Serializable
 
 /**
  * A single media overlay item mapping audio to text.
@@ -29,7 +28,7 @@ data class FlutterMediaOverlayItem(
      * The title of the chapter or section this item belongs to
      */
     val title: String
-) : Serializable {
+) {
     /**
      * The audio file without the fragment (e.g. "chapter1.mp3")
      */

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/SyncAudiobookNavigator.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/SyncAudiobookNavigator.kt
@@ -19,8 +19,6 @@ import org.readium.r2.shared.publication.Publication
 
 private const val TAG = "SyncAudiobookNavigator"
 
-private const val mediaOverlaysKey = "MediaOverlays"
-
 private const val SYNC_AUDIO_DECORATION_ID_UTTERANCE = "synced-utterance"
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalReadiumApi::class)
@@ -106,12 +104,6 @@ class SyncAudiobookNavigator(
         }
 
         super.onCurrentLocatorChanges(audioLocator)
-    }
-
-    override fun storeState(): Bundle {
-        return super.storeState().apply {
-            putSerializable(mediaOverlaysKey, ArrayList(mediaOverlays))
-        }
     }
 
     override suspend fun play(fromLocator: Locator?) {

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.9.1
+  flureadium: ^0.9.2
 ```
 
 Run:

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.1"
+    version: "0.9.2"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.9.1
+version: 0.9.2
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- Fix `BadParcelableException` crash on Android when activity state is saved during synchronized audiobook playback
- `SyncAudiobookNavigator.storeState()` was putting `FlutterMediaOverlay` objects into the Bundle via `putSerializable`, but they contain non-serializable Readium types (`Url`, `MediaType`)
- The serialized data was never read back — `restoreState()` re-derives overlays from the publication — so the dead write is removed along with the misleading `Serializable` interface on both model classes
- Bump version to 0.9.2

## Test plan

- [x] Android JVM unit tests pass
- [x] Flutter unit tests pass
- [ ] Manual: open a book with media overlays, start sync audio playback, press Home — app should not crash