### PR TITLE
Fix iOS reader crash in getLocatorFragments

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.9.3
+
+### Bug Fixes
+
+- **iOS / EPUB reader locator crash**: Replace the force-unwrapped `getLocatorFragments()` parse path with safe optional handling so `null` JavaScript results no longer crash the reader.
+- **iOS / reader disposal race**: Guard async page-change callbacks with a disposal flag and `MainActor` state reads so page-change work does not outlive a torn-down reader view.
+
+### Testing
+
+- Add iOS regression coverage for locator-fragment result parsing in `ReadiumExtensionsTests`.
+- Verify Flutter tests, native iOS `RunnerTests`, and example integration tests pass for the fix.
+
+### Documentation
+
+- Add a troubleshooting entry covering the locator-fragment crash symptoms, cause, and remediation.
+
 ## 0.9.2
 
 ### Bug Fixes

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -21,7 +21,7 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.9.2
+  flureadium: ^0.9.3
 ```
 
 ### Platform Setup

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.9.2
+  flureadium: ^0.9.3
 ```
 
 Run:

--- a/flureadium/docs/troubleshooting.md
+++ b/flureadium/docs/troubleshooting.md
@@ -94,6 +94,20 @@ cd ios
 pod install --repo-update
 ```
 
+### iOS: Reader crash while turning pages or closing the reader
+
+**Symptoms:**
+- Crash in `ReadiumReaderView.getLocatorFragments`
+- More likely while a page-change callback is in flight and the reader is closed immediately after
+
+**Cause:**
+Older versions force-unwrapped the JavaScript locator-fragments result. Readium returns `()` when the JavaScript side yields `null`, and a detached page-change task could also race with `dispose`.
+
+**Solution:**
+Upgrade to a version containing the fix, or backport both changes:
+1. Replace the force-unwrap in `getLocatorFragments` with safe dictionary parsing and `try? Locator(...)`.
+2. Guard asynchronous page-change work with a disposal flag and a weak `self` capture before evaluating JavaScript or sending Flutter events.
+
 ### Web: JavaScript File Not Found
 
 **Error:**

--- a/flureadium/example/ios/RunnerTests/ReadiumExtensionsTests.swift
+++ b/flureadium/example/ios/RunnerTests/ReadiumExtensionsTests.swift
@@ -54,6 +54,37 @@ final class LocatorExtensionTests: XCTestCase {
     }
 }
 
+final class LocatorParsingTests: XCTestCase {
+
+    func testParseLocatorFragmentsResultReturnsLocatorForValidJson() {
+        let result: [String: Any?] = [
+            "href": "https://example.com/ch1.xhtml",
+            "type": MediaType.html.string,
+            "locations": [
+                "fragments": ["#page-1"],
+            ],
+        ]
+
+        let locator = parseLocatorFragmentsResult(result)
+
+        XCTAssertEqual(locator?.href.string, "https://example.com/ch1.xhtml")
+        XCTAssertEqual(locator?.mediaType, .html)
+        XCTAssertEqual(locator?.locations.fragments, ["#page-1"])
+    }
+
+    func testParseLocatorFragmentsResultReturnsNilForNullJavascriptValue() {
+        XCTAssertNil(parseLocatorFragmentsResult(()))
+    }
+
+    func testParseLocatorFragmentsResultReturnsNilForMalformedJson() {
+        let result: [String: Any?] = [
+            "href": "https://example.com/ch1.xhtml",
+        ]
+
+        XCTAssertNil(parseLocatorFragmentsResult(result))
+    }
+}
+
 // MARK: - State Mapping Tests
 
 final class StateMappingTests: XCTestCase {

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -380,7 +380,9 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
     print(TAG, "emitOnPageChanged:locator=\(String(describing: locator))")
 
     Task.detached(priority: .high) { [isVerticalScroll, weak self] in
-      guard let self, !self.isDisposed else { return }
+      guard let self else { return }
+      let isDisposed = await MainActor.run { self.isDisposed }
+      guard !isDisposed else { return }
       guard let locatorWithFragments = await self.getLocatorFragments(json, isVerticalScroll) else {
         print(TAG, "emitOnPageChanged failed!")
         return

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -22,6 +22,14 @@ class ReadiumBugLogger: ReadiumShared.WarningLogger {
 private let readiumBugLogger = ReadiumBugLogger()
 private var userScripts: [WKUserScript] = []
 
+func parseLocatorFragmentsResult(_ result: Any?) -> Locator? {
+  guard let json = result as? Dictionary<String, Any?> else {
+    return nil
+  }
+
+  return try? Locator(json: json, warnings: readiumBugLogger)
+}
+
 class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, VisualNavigatorDelegate {
 
   private let channel: ReadiumReaderChannel
@@ -32,6 +40,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   private let readiumViewController: EPUBNavigatorViewController
   private var isVerticalScroll = false
   private var hasSentReady = false
+  private var isDisposed = false
   private var enableEdgeTapNavigation: Bool
   private var enableSwipeNavigation: Bool
   private var edgeTapAreaPoints: CGFloat?
@@ -370,12 +379,14 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
 
     print(TAG, "emitOnPageChanged:locator=\(String(describing: locator))")
 
-    Task.detached(priority: .high) { [isVerticalScroll] in
+    Task.detached(priority: .high) { [isVerticalScroll, weak self] in
+      guard let self, !self.isDisposed else { return }
       guard let locatorWithFragments = await self.getLocatorFragments(json, isVerticalScroll) else {
         print(TAG, "emitOnPageChanged failed!")
         return
       }
-      await MainActor.run() {
+      await MainActor.run {
+        guard !self.isDisposed else { return }
         self.channel.onPageChanged(locator: locatorWithFragments)
         guard let textLocatorStreamHandler = self.textLocatorStreamHandler else {
           print(TAG, "emitOnPageChanged: textLocatorStreamHandler is nil!")
@@ -397,9 +408,16 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
   }
 
   internal func getLocatorFragments(_ locatorJson: String, _ isVerticalScroll: Bool) async -> Locator? {
+    guard !isDisposed else {
+      return nil
+    }
+
     switch await self.evaluateJavascript("window.epubPage.getLocatorFragments(\(locatorJson), \(isVerticalScroll));") {
       case .success(let jresult):
-        let locatorWithFragments = try! Locator(json: jresult as? Dictionary<String, Any?>, warnings: readiumBugLogger)!
+        guard let locatorWithFragments = parseLocatorFragmentsResult(jresult) else {
+          print(TAG, "getLocatorFragments: failed to parse locator from JS result")
+          return nil
+        }
         return locatorWithFragments
       case .failure(let err):
         print(TAG, "getLocatorFragments failed! \(err)")
@@ -591,6 +609,7 @@ class ReadiumReaderView: NSObject, FlutterPlatformView, EPUBNavigatorDelegate, V
       break
     case "dispose":
       print(TAG, "Disposing readiumViewController")
+      isDisposed = true
       readiumViewController.view.removeFromSuperview()
       readiumViewController.delegate = nil
       self.readerStatusStreamHandler?.sendEvent(ReadiumReaderStatusClosed)

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.9.2
+version: 0.9.3
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Summary

- Replace force-unwrap in `getLocatorFragments` with safe optional parsing so `null` JavaScript results no longer crash the reader
- Guard async page-change callbacks with a disposal flag and weak self capture to prevent race conditions when the reader is torn down mid-navigation
- Add iOS regression tests covering valid, null, and malformed locator fragment parsing

## Test plan

- [x] Flutter tests pass
- [x] iOS `RunnerTests` pass (includes new `LocatorParsingTests`)
- [x] Example integration tests pass
- [x] Manual: open an EPUB, turn pages rapidly, close reader mid-navigation — no crash