### PR TITLE
Wire onExternalLinkActivated through widget to channel

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.9.4
+
+### Bug Fixes
+
+- **Reader external-link callbacks**: Forward `ReadiumReaderWidget.onExternalLinkActivated` into `ReadiumReaderChannel` so Dart hosts actually receive external-link activations reported by the native reader.
+- **Analyzer/test export mismatch**: Expose the widget-test channel-construction helper consistently across the conditional `reader_widget_*` exports so `dart analyze` and `flutter test` resolve the same public surface.
+
+### Testing
+
+- Add Dart regressions for the native `onExternalLinkActivated` method-call path and the widget/channel construction seam.
+- Verify `dart analyze`, `flureadium/flutter test`, `flureadium_platform_interface/flutter test`, and the example EPUB integration smoke test pass.
+
+### Documentation
+
+- Document `onExternalLinkActivated` as a delivered integration callback and clarify that host apps can hand external links off to the OS browser for restricted-content flows.
+
 ## 0.9.3
 
 ### Bug Fixes

--- a/flureadium/docs/api-reference/reader-widget.md
+++ b/flureadium/docs/api-reference/reader-widget.md
@@ -142,19 +142,29 @@ Called on swipe gestures.
 
 **Type:** `Function(String)?`
 
-Called when the user taps an external link (URLs outside the publication).
+Called when the native reader reports that the user activated an external link
+(a URL outside the publication). The callback is delivered to the host app, so
+the host decides whether to block, confirm, or launch the URL.
 
 ```dart
 ReadiumReaderWidget(
   publication: pub,
   onExternalLinkActivated: (url) async {
-    // Open in browser
+    // Host app controls external-link policy.
     if (await canLaunchUrl(Uri.parse(url))) {
-      await launchUrl(Uri.parse(url));
+      await launchUrl(
+        Uri.parse(url),
+        mode: LaunchMode.externalApplication,
+      );
     }
   },
 )
 ```
+
+Use this seam to keep reader-originated links consistent with the rest of your
+app's external URL policy. For example, apps that must avoid in-app browser
+surfaces during restricted-content flows can always hand the URL off to the OS
+browser instead.
 
 ### onLocatorChanged
 

--- a/flureadium/docs/guides/epub-reading.md
+++ b/flureadium/docs/guides/epub-reading.md
@@ -506,11 +506,23 @@ ReadiumReaderWidget(
     );
 
     if (confirmed == true) {
-      await launchUrl(Uri.parse(url));
+      await launchUrl(
+        Uri.parse(url),
+        mode: LaunchMode.externalApplication,
+      );
     }
   },
 )
 ```
+
+`onExternalLinkActivated` is the handoff point from the native reader back into
+your Flutter app. Treat it as policy, not just telemetry: your app decides
+whether to block the URL, show a confirmation step, or hand it to the OS.
+
+For restricted-content or parental-controls scenarios, prefer
+`LaunchMode.externalApplication` so the OS browser owns the transition instead
+of an in-app browser surface. That keeps reader-originated links aligned with
+the same external launch policy you use elsewhere in the app.
 
 ## Complete Example
 

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.2"
+    version: "0.9.4"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/lib/reader_widget.dart
+++ b/flureadium/lib/reader_widget.dart
@@ -18,6 +18,19 @@ import 'src/utils/toc_matcher.dart';
 
 const _viewType = 'dev.mulev.flureadium/ReadiumReaderWidget';
 
+@visibleForTesting
+ReadiumReaderChannel createReadiumReaderChannel(
+  int id, {
+  required ValueChanged<Locator> onPageChanged,
+  ValueChanged<String>? onExternalLinkActivated,
+}) {
+  return ReadiumReaderChannel(
+    '$_viewType:$id',
+    onPageChanged: onPageChanged,
+    onExternalLinkActivated: onExternalLinkActivated,
+  );
+}
+
 /// A ReadiumReaderWidget wraps a native Kotlin/Swift Readium navigator widget.
 class ReadiumReaderWidget extends StatefulWidget {
   const ReadiumReaderWidget({
@@ -407,8 +420,8 @@ class _ReadiumReaderWidgetState extends State<ReadiumReaderWidget>
   int? _lastNavigatedTocIndex;
 
   void _onPlatformViewCreated(final int id) {
-    _channel = ReadiumReaderChannel(
-      '$_viewType:$id',
+    _channel = createReadiumReaderChannel(
+      id,
       onPageChanged: (final locator) {
         debugPrint('onPageChanged: ${locator.toJson()}');
         _currentLocator = locator;
@@ -425,6 +438,7 @@ class _ReadiumReaderWidgetState extends State<ReadiumReaderWidget>
           }
         }
       },
+      onExternalLinkActivated: widget.onExternalLinkActivated,
     );
 
     // Register as current widget only after _channel is assigned.

--- a/flureadium/lib/reader_widget_unsupported.dart
+++ b/flureadium/lib/reader_widget_unsupported.dart
@@ -1,6 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flureadium/flureadium.dart';
 
+import 'reader_channel.dart';
+
+const _viewType = 'dev.mulev.flureadium/ReadiumReaderWidget';
+
+@visibleForTesting
+ReadiumReaderChannel createReadiumReaderChannel(
+  int id, {
+  required ValueChanged<Locator> onPageChanged,
+  ValueChanged<String>? onExternalLinkActivated,
+}) {
+  return ReadiumReaderChannel(
+    '$_viewType:$id',
+    onPageChanged: onPageChanged,
+    onExternalLinkActivated: onExternalLinkActivated,
+  );
+}
+
 class ReadiumReaderWidget extends StatelessWidget {
   const ReadiumReaderWidget({
     required this.publication,

--- a/flureadium/lib/reader_widget_web.dart
+++ b/flureadium/lib/reader_widget_web.dart
@@ -1,7 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flureadium/flureadium.dart';
+
+import 'reader_channel.dart';
 import 'src/index.dart';
+
+const _viewType = 'dev.mulev.flureadium/ReadiumReaderWidget';
+
+@visibleForTesting
+ReadiumReaderChannel createReadiumReaderChannel(
+  int id, {
+  required ValueChanged<Locator> onPageChanged,
+  ValueChanged<String>? onExternalLinkActivated,
+}) {
+  return ReadiumReaderChannel(
+    '$_viewType:$id',
+    onPageChanged: onPageChanged,
+    onExternalLinkActivated: onExternalLinkActivated,
+  );
+}
 
 class ReadiumReaderWidget extends StatefulWidget {
   const ReadiumReaderWidget({
@@ -12,6 +29,8 @@ class ReadiumReaderWidget extends StatefulWidget {
     this.onGoLeft,
     this.onGoRight,
     this.onSwipe,
+    this.onExternalLinkActivated,
+    this.onLocatorChanged,
     this.onReady,
     super.key,
   });
@@ -23,6 +42,8 @@ class ReadiumReaderWidget extends StatefulWidget {
   final VoidCallback? onGoLeft;
   final VoidCallback? onGoRight;
   final VoidCallback? onSwipe;
+  final Function(String)? onExternalLinkActivated;
+  final void Function(Locator)? onLocatorChanged;
 
   /// Called once when the widget is ready to accept stream subscriptions.
   /// On web, event channels are registered eagerly, so this fires from initState.

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.9.3
+version: 0.9.4
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium/test/reader/reader_channel_test.dart
+++ b/flureadium/test/reader/reader_channel_test.dart
@@ -119,4 +119,21 @@ void main() {
       expect(decoMap['style'], isA<Map>());
     });
   });
+
+  group('native callbacks', () {
+    test('forwards external link callback from native method call', () async {
+      String? seen;
+      channel = ReadiumReaderChannel(
+        channelName,
+        onPageChanged: (_) {},
+        onExternalLinkActivated: (url) => seen = url,
+      );
+
+      await channel.onMethodCall(
+        const MethodCall('onExternalLinkActivated', 'https://example.com'),
+      );
+
+      expect(seen, 'https://example.com');
+    });
+  });
 }

--- a/flureadium/test/widget/reader_widget_test.dart
+++ b/flureadium/test/widget/reader_widget_test.dart
@@ -217,6 +217,18 @@ void main() {
         widget.onGoRight!();
         expect(wentRight, isTrue);
       });
+
+      test('createReadiumReaderChannel carries onExternalLinkActivated', () {
+        void onExternalLink(String _) {}
+
+        final channel = createReadiumReaderChannel(
+          42,
+          onPageChanged: (_) {},
+          onExternalLinkActivated: onExternalLink,
+        );
+
+        expect(channel.onExternalLinkActivated, same(onExternalLink));
+      });
     });
 
     group('publication data', () {


### PR DESCRIPTION
## Summary

- Forward `onExternalLinkActivated` from `ReadiumReaderWidget` into `ReadiumReaderChannel` so Dart hosts receive external-link activations reported by the native reader.
- Extract `createReadiumReaderChannel` factory for testability and consistent export surface across platform conditional files (`reader_widget.dart`, `reader_widget_unsupported.dart`, `reader_widget_web.dart`).
- Add regression tests for the native `onExternalLinkActivated` method-call path and the widget/channel construction seam.
- Update docs and changelog, bump version to 0.9.4.

## Test plan

- [x] `flutter test` in `flureadium/flureadium/` passes
- [x] `dart analyze` clean
- [x] New unit tests cover native callback forwarding and factory wiring