### PR TITLE
Feat/image navigator

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.10.1
+
+### Bug Fixes
+
+- **iOS CBZ navigation crash**: Fix `PlatformException(InvalidArgument, Failed to parse locator)` when navigating CBZ files with special characters in filenames. The Locator href encode/decode boundary in `flureadium_platform_interface` now normalizes hrefs correctly for native platform transport.
+
+### Documentation
+
+- Document href encoding behavior in the Locator API reference.
+
+---
+
 ## 0.10.0
 
 ### New Features

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.10.2
+
+### Bug Fixes
+
+- **iOS CBZ page navigation performance**: Cache images from Readium's local server to eliminate redundant ZIP extraction and HTTP round-trips on every page turn. Adds `ImageCacheURLProtocol`, a URLProtocol subclass that intercepts localhost GET requests and serves cached images from NSCache. Cache is session-scoped and cleared when the reader closes.
+
+### Testing
+
+- iOS XCTest coverage for `ImageCacheURLProtocol`: canInit filtering, cache hit/miss, enable/disable lifecycle, clearCache.
+
+---
+
 ## 0.10.1
 
 ### Bug Fixes

--- a/flureadium/docs/api-reference/locator.md
+++ b/flureadium/docs/api-reference/locator.md
@@ -23,7 +23,7 @@ Locator(
 
 **Type:** `String` (required)
 
-The path to the content document within the publication.
+The path to the content document within the publication. Internally, `href` is always stored in decoded form (e.g. `Happiness v01 [HD].jpg`). When serialized via `toJson()`, the value is percent-encoded for safe transport to native platforms (e.g. `Happiness%20v01%20%5BHD%5D.jpg`). `fromJson()` automatically decodes percent-encoded hrefs on parse.
 
 ```dart
 print(locator.href);  // "chapter1.xhtml"

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -174,6 +174,22 @@ This is a native iOS layer change only. No Dart or Flutter changes are required.
 - `PdfReaderView.swift` - PDF reader using EdgeTapInterceptView
 - `ImageReaderView.swift` - CBZ / DIVINA reader using EdgeTapInterceptView
 
+### CBZ Image Caching
+
+Readium's CBZ navigator creates a new `ImageViewController` for every page turn, each fetching the full image from a local HTTP server via `URLSession.shared`. The server's `ResourceResponse` sets `Cache-Control: no-cache, no-store, must-revalidate` to protect DRM-enabled content, which prevents `URLCache` from storing responses. For CBZ and DiViNa publications (which have no DRM), this causes redundant ZIP extraction and HTTP round-trips on every swipe.
+
+`ImageCacheURLProtocol` is a `URLProtocol` subclass that transparently intercepts these localhost HTTP GET requests and caches image data in `NSCache`. On cache hit, images are served instantly from memory without any network or ZIP extraction overhead.
+
+**Scope:**
+- Intercepts only HTTP GET requests to `localhost` / `127.0.0.1` — EPUB (WKWebView), PDF (PDFKit), and external traffic are unaffected
+- Registered when `ImageReaderView` initializes, unregistered when it disposes
+- Cache is session-scoped: cleared automatically when the publication closes
+- Uses `NSCache` for automatic LRU eviction under memory pressure — no explicit size limit needed
+
+**Files:**
+- `ImageCacheURLProtocol.swift` — URLProtocol subclass with NSCache storage
+- `ImageReaderView.swift` — enable/disable calls in init and dispose
+
 ### Text Selection Copy
 
 When a user long-presses text in an EPUB or PDF reader, iOS shows a native

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -180,15 +180,30 @@ Readium's CBZ navigator creates a new `ImageViewController` for every page turn,
 
 `ImageCacheURLProtocol` is a `URLProtocol` subclass that transparently intercepts these localhost HTTP GET requests and caches image data in `NSCache`. On cache hit, images are served instantly from memory without any network or ZIP extraction overhead.
 
-**Scope:**
+**Primary cache:**
 - Intercepts only HTTP GET requests to `localhost` / `127.0.0.1` — EPUB (WKWebView), PDF (PDFKit), and external traffic are unaffected
 - Registered when `ImageReaderView` initializes, unregistered when it disposes
 - Cache is session-scoped: cleared automatically when the publication closes
-- Uses `NSCache` for automatic LRU eviction under memory pressure — no explicit size limit needed
+- `NSCache` with explicit limits: 100 MB total cost, 30-entry count limit
+
+**Prefetch cache:**
+
+After each page turn, `ImageReaderView` reads adjacent pages (N-1, N+1, N+2) directly from the ZIP container via `Publication.get(link)` and stores them in a secondary prefetch dictionary inside `ImageCacheURLProtocol`. This bypasses the HTTP server entirely — for CBZ files using ZIP STORE (no compression), it's a fast memory copy.
+
+When Readium's `ImageViewController` loads a page, `ImageCacheURLProtocol.startLoading()` checks the prefetch store after a primary cache miss. On hit, the data is served instantly, promoted to the primary `NSCache`, and removed from the prefetch store. This eliminates the visible blank flash during page transitions.
+
+Prefetch skips:
+- Pages already visited (tracked via `visitedIndices` — already in primary cache)
+- Pages already prefetched (checked via `hasPrefetch(href:)`)
+- Out-of-range indices
+
+The prefetch store is a small thread-safe dictionary (typically 3 entries), synchronized with `NSLock`. URL matching uses path suffix comparison with percent-decoding to handle all encoding combinations.
+
+Fast swiping is handled by cancelling the in-flight prefetch task on each new page turn, preventing wasted I/O on pages the user has already passed. All prefetch state (task, visited indices, store) is cleared on dispose.
 
 **Files:**
-- `ImageCacheURLProtocol.swift` — URLProtocol subclass with NSCache storage
-- `ImageReaderView.swift` — enable/disable calls in init and dispose
+- `ImageCacheURLProtocol.swift` — URLProtocol subclass with primary NSCache + secondary prefetch store
+- `ImageReaderView.swift` — enable/disable calls in init and dispose, prefetch logic in `locationDidChange`
 
 ### Text Selection Copy
 

--- a/flureadium/example/integration_test/cbz_test.dart
+++ b/flureadium/example/integration_test/cbz_test.dart
@@ -39,5 +39,31 @@ void main() {
 
       expect(find.byType(ReadiumReaderWidget), findsOneWidget);
     });
+
+    testWidgets('revisiting pages loads from cache without errors', (
+      tester,
+    ) async {
+      app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
+      for (var i = 0; i < 15; i++) {
+        await tester.pump(const Duration(seconds: 1));
+        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
+      }
+
+      expect(find.byType(ReadiumReaderWidget), findsOneWidget);
+
+      // Navigate forward two pages
+      await tester.tap(find.text('→'));
+      await tester.pump(const Duration(seconds: 2));
+      await tester.tap(find.text('→'));
+      await tester.pump(const Duration(seconds: 2));
+
+      // Navigate back to previously visited pages (cache hit path on iOS)
+      await tester.tap(find.text('←'));
+      await tester.pump(const Duration(seconds: 2));
+      await tester.tap(find.text('←'));
+      await tester.pump(const Duration(seconds: 2));
+
+      expect(find.byType(ReadiumReaderWidget), findsOneWidget);
+    });
   });
 }

--- a/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		D1E2F3A4B5C6D7E800007002 /* EdgeTapInterceptViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */; };
 		D1E2F3A4B5C6D7E800008002 /* NowPlayingInfoUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */; };
 		E1F2A3B4C5D6E7F800008002 /* EpubEditingActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */; };
+		F1A2B3C4D5E6F7A800009002 /* ImageCacheURLProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -69,6 +70,7 @@
 		D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeTapInterceptViewTests.swift; sourceTree = "<group>"; };
 		D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoUpdaterTests.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpubEditingActionsTests.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheURLProtocolTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5BDBF082C9CC180601979FB5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 				D1E2F3A4B5C6D7E800007001 /* EdgeTapInterceptViewTests.swift */,
 				D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */,
 				E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */,
+				F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -417,6 +420,7 @@
 				D1E2F3A4B5C6D7E800007002 /* EdgeTapInterceptViewTests.swift in Sources */,
 				D1E2F3A4B5C6D7E800008002 /* NowPlayingInfoUpdaterTests.swift in Sources */,
 				E1F2A3B4C5D6E7F800008002 /* EpubEditingActionsTests.swift in Sources */,
+				F1A2B3C4D5E6F7A800009002 /* ImageCacheURLProtocolTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/flureadium/example/ios/RunnerTests/ImageCacheURLProtocolTests.swift
+++ b/flureadium/example/ios/RunnerTests/ImageCacheURLProtocolTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import flureadium
+
+final class ImageCacheURLProtocolTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        ImageCacheURLProtocol.disable()
+    }
+
+    override func tearDown() {
+        ImageCacheURLProtocol.disable()
+        super.tearDown()
+    }
+
+    // MARK: - canInit
+
+    func testCanInitReturnsTrueForLocalhostGET() {
+        let request = URLRequest(url: URL(string: "http://localhost:8080/image.jpg")!)
+        XCTAssertTrue(ImageCacheURLProtocol.canInit(with: request))
+    }
+
+    func testCanInitReturnsTrueFor127001GET() {
+        let request = URLRequest(url: URL(string: "http://127.0.0.1:8080/image.jpg")!)
+        XCTAssertTrue(ImageCacheURLProtocol.canInit(with: request))
+    }
+
+    func testCanInitReturnsFalseForNonLocalhost() {
+        let request = URLRequest(url: URL(string: "https://example.com/image.jpg")!)
+        XCTAssertFalse(ImageCacheURLProtocol.canInit(with: request))
+    }
+
+    func testCanInitReturnsFalseForPOST() {
+        var request = URLRequest(url: URL(string: "http://localhost:8080/image.jpg")!)
+        request.httpMethod = "POST"
+        XCTAssertFalse(ImageCacheURLProtocol.canInit(with: request))
+    }
+
+    func testCanInitReturnsFalseForAlreadyHandledRequest() {
+        let url = URL(string: "http://localhost:8080/image.jpg")!
+        let mutable = NSMutableURLRequest(url: url)
+        URLProtocol.setProperty(true, forKey: "ImageCacheURLProtocol.handled", in: mutable)
+        XCTAssertFalse(ImageCacheURLProtocol.canInit(with: mutable as URLRequest))
+    }
+
+    // MARK: - Cache hit
+
+    func testCacheHitReturnsCachedDataWithoutNetwork() {
+        let expectation = self.expectation(description: "Cache hit")
+        let url = URL(string: "http://localhost:19876/cached-image.jpg")!
+
+        ImageCacheURLProtocol.seedCache(url: url, data: Data([0xFF, 0xD8, 0xFF, 0xE0]), mimeType: "image/jpeg")
+
+        ImageCacheURLProtocol.enable()
+
+        let task = URLSession.shared.dataTask(with: url) { data, _, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(data, Data([0xFF, 0xD8, 0xFF, 0xE0]))
+            expectation.fulfill()
+        }
+        task.resume()
+
+        waitForExpectations(timeout: 5)
+    }
+
+    // MARK: - clearCache
+
+    func testClearCacheRemovesAllEntries() {
+        let url = URL(string: "http://localhost:19876/test-image.jpg")!
+        ImageCacheURLProtocol.seedCache(url: url, data: Data([0x01, 0x02]), mimeType: "image/png")
+        XCTAssertTrue(ImageCacheURLProtocol.hasCachedResponse(for: url))
+
+        ImageCacheURLProtocol.clearCache()
+
+        XCTAssertFalse(ImageCacheURLProtocol.hasCachedResponse(for: url))
+    }
+
+    // MARK: - enable / disable
+
+    func testEnableRegistersProtocol() {
+        ImageCacheURLProtocol.enable()
+        // After enable, canInit should still work (protocol is registered).
+        let request = URLRequest(url: URL(string: "http://localhost:8080/image.jpg")!)
+        XCTAssertTrue(ImageCacheURLProtocol.canInit(with: request))
+    }
+
+    func testDisableUnregistersAndClearsCache() {
+        let url = URL(string: "http://localhost:19876/disable-test.jpg")!
+        ImageCacheURLProtocol.seedCache(url: url, data: Data([0x01]), mimeType: "image/jpeg")
+        XCTAssertTrue(ImageCacheURLProtocol.hasCachedResponse(for: url))
+
+        ImageCacheURLProtocol.disable()
+
+        XCTAssertFalse(ImageCacheURLProtocol.hasCachedResponse(for: url))
+    }
+
+    // MARK: - Cache miss with real network
+
+    func testCacheMissForwardsRequestAndCachesResponse() {
+        let expectation = self.expectation(description: "Cache miss forwards")
+        let url = URL(string: "http://localhost:19999/nonexistent.jpg")!
+
+        ImageCacheURLProtocol.enable()
+
+        // Connection refused is expected — no server on port 19999.
+        // Verifies the protocol forwarded the request instead of looping.
+        let task = URLSession.shared.dataTask(with: url) { _, _, error in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        task.resume()
+
+        waitForExpectations(timeout: 5)
+    }
+}

--- a/flureadium/example/ios/RunnerTests/ImageCacheURLProtocolTests.swift
+++ b/flureadium/example/ios/RunnerTests/ImageCacheURLProtocolTests.swift
@@ -112,4 +112,99 @@ final class ImageCacheURLProtocolTests: XCTestCase {
 
         waitForExpectations(timeout: 5)
     }
+
+    // MARK: - Prefetch store
+
+    func testSeedPrefetchStoresData() {
+        ImageCacheURLProtocol.seedPrefetch(href: "page.jpg", data: Data([0x01, 0x02]), mimeType: "image/jpeg")
+        XCTAssertTrue(ImageCacheURLProtocol.hasPrefetch(href: "page.jpg"))
+    }
+
+    func testHasPrefetchReturnsFalseForUnknown() {
+        XCTAssertFalse(ImageCacheURLProtocol.hasPrefetch(href: "unknown.jpg"))
+    }
+
+    func testClearPrefetchCacheRemovesAll() {
+        ImageCacheURLProtocol.seedPrefetch(href: "a.jpg", data: Data([0x01]), mimeType: "image/jpeg")
+        ImageCacheURLProtocol.seedPrefetch(href: "b.jpg", data: Data([0x02]), mimeType: "image/jpeg")
+        XCTAssertTrue(ImageCacheURLProtocol.hasPrefetch(href: "a.jpg"))
+        XCTAssertTrue(ImageCacheURLProtocol.hasPrefetch(href: "b.jpg"))
+
+        ImageCacheURLProtocol.clearPrefetchCache()
+
+        XCTAssertFalse(ImageCacheURLProtocol.hasPrefetch(href: "a.jpg"))
+        XCTAssertFalse(ImageCacheURLProtocol.hasPrefetch(href: "b.jpg"))
+    }
+
+    func testFindPrefetchMatchReturnsCachedDataForSuffixMatch() {
+        ImageCacheURLProtocol.seedPrefetch(href: "page.jpg", data: Data([0xAA]), mimeType: "image/jpeg")
+
+        let match = ImageCacheURLProtocol.findPrefetchMatchData(forPath: "/some-uuid/page.jpg")
+
+        XCTAssertNotNil(match)
+        XCTAssertEqual(match, Data([0xAA]))
+    }
+
+    func testFindPrefetchMatchReturnsCachedDataForSubdirectoryHref() {
+        ImageCacheURLProtocol.seedPrefetch(href: "images/page.jpg", data: Data([0xBB]), mimeType: "image/jpeg")
+
+        let match = ImageCacheURLProtocol.findPrefetchMatchData(forPath: "/some-uuid/images/page.jpg")
+
+        XCTAssertNotNil(match)
+        XCTAssertEqual(match, Data([0xBB]))
+    }
+
+    func testFindPrefetchMatchReturnsNilForNoMatch() {
+        ImageCacheURLProtocol.seedPrefetch(href: "page1.jpg", data: Data([0x01]), mimeType: "image/jpeg")
+
+        let match = ImageCacheURLProtocol.findPrefetchMatchData(forPath: "/some-uuid/page2.jpg")
+
+        XCTAssertNil(match)
+    }
+
+    func testFindPrefetchMatchHandlesPercentEncodedHrefs() {
+        ImageCacheURLProtocol.seedPrefetch(href: "My%20Image.jpg", data: Data([0xCC]), mimeType: "image/jpeg")
+
+        let match = ImageCacheURLProtocol.findPrefetchMatchData(forPath: "/some-uuid/My Image.jpg")
+
+        XCTAssertNotNil(match)
+        XCTAssertEqual(match, Data([0xCC]))
+    }
+
+    func testDisableClearsBothCaches() {
+        let url = URL(string: "http://localhost:19876/primary.jpg")!
+        ImageCacheURLProtocol.seedCache(url: url, data: Data([0x01]), mimeType: "image/jpeg")
+        ImageCacheURLProtocol.seedPrefetch(href: "prefetched.jpg", data: Data([0x02]), mimeType: "image/jpeg")
+        XCTAssertTrue(ImageCacheURLProtocol.hasCachedResponse(for: url))
+        XCTAssertTrue(ImageCacheURLProtocol.hasPrefetch(href: "prefetched.jpg"))
+
+        ImageCacheURLProtocol.disable()
+
+        XCTAssertFalse(ImageCacheURLProtocol.hasCachedResponse(for: url))
+        XCTAssertFalse(ImageCacheURLProtocol.hasPrefetch(href: "prefetched.jpg"))
+    }
+
+    func testPrefetchHitPromotesToPrimaryCache() {
+        let expectation = self.expectation(description: "Prefetch hit promotes")
+        let url = URL(string: "http://localhost:19876/prefetch-promote.jpg")!
+        let imageData = Data([0xFF, 0xD8, 0xFF, 0xE0])
+
+        ImageCacheURLProtocol.seedPrefetch(href: "prefetch-promote.jpg", data: imageData, mimeType: "image/jpeg")
+        ImageCacheURLProtocol.enable()
+
+        let task = URLSession.shared.dataTask(with: url) { data, _, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(data, imageData)
+
+            // Promoted to primary cache
+            XCTAssertTrue(ImageCacheURLProtocol.hasCachedResponse(for: url))
+            // Removed from prefetch store
+            XCTAssertFalse(ImageCacheURLProtocol.hasPrefetch(href: "prefetch-promote.jpg"))
+
+            expectation.fulfill()
+        }
+        task.resume()
+
+        waitForExpectations(timeout: 5)
+    }
 }

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,14 +191,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.4"
+    version: "0.10.1"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../../flureadium_platform_interface"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.6.1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.1"
+    version: "0.10.2"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/ios/flureadium/Sources/flureadium/ImageCacheURLProtocol.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ImageCacheURLProtocol.swift
@@ -7,7 +7,12 @@ import Foundation
 /// on every page turn.
 final class ImageCacheURLProtocol: URLProtocol {
     private static let handledKey = "ImageCacheURLProtocol.handled"
-    private static let cache = NSCache<NSURL, CachedResponse>()
+    private static let cache: NSCache<NSURL, CachedResponse> = {
+        let c = NSCache<NSURL, CachedResponse>()
+        c.totalCostLimit = 100 * 1024 * 1024 // 100 MB
+        c.countLimit = 30
+        return c
+    }()
 
     override class func canInit(with request: URLRequest) -> Bool {
         guard
@@ -29,16 +34,12 @@ final class ImageCacheURLProtocol: URLProtocol {
     override func startLoading() {
         let url = request.url! as NSURL
         if let cached = Self.cache.object(forKey: url) {
-            let response = URLResponse(
-                url: url as URL,
-                mimeType: cached.mimeType,
-                expectedContentLength: cached.data.count,
-                textEncodingName: nil
-            )
-            client?.urlProtocol(self, didReceive: response,
-                                cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: cached.data)
-            client?.urlProtocolDidFinishLoading(self)
+            serveCachedResponse(cached, for: url as URL)
+            return
+        }
+
+        if let prefetched = Self.promotePrefetchToCache(forPath: request.url?.path ?? "", url: url) {
+            serveCachedResponse(prefetched, for: url as URL)
             return
         }
 
@@ -69,6 +70,19 @@ final class ImageCacheURLProtocol: URLProtocol {
         task.resume()
     }
 
+    private func serveCachedResponse(_ cached: CachedResponse, for url: URL) {
+        let response = URLResponse(
+            url: url,
+            mimeType: cached.mimeType,
+            expectedContentLength: cached.data.count,
+            textEncodingName: nil
+        )
+        client?.urlProtocol(self, didReceive: response,
+                            cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: cached.data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
     override func stopLoading() {}
 
     // MARK: - Public API
@@ -80,10 +94,58 @@ final class ImageCacheURLProtocol: URLProtocol {
     static func disable() {
         URLProtocol.unregisterClass(ImageCacheURLProtocol.self)
         cache.removeAllObjects()
+        clearPrefetchCache()
     }
 
     static func clearCache() {
         cache.removeAllObjects()
+    }
+
+    // MARK: - Prefetch Store
+
+    private static var prefetchStore: [String: CachedResponse] = [:]
+    private static let prefetchLock = NSLock()
+
+    static func seedPrefetch(href: String, data: Data, mimeType: String?) {
+        let entry = CachedResponse(data: data, mimeType: mimeType)
+        prefetchLock.lock()
+        defer { prefetchLock.unlock() }
+        prefetchStore[href] = entry
+    }
+
+    static func hasPrefetch(href: String) -> Bool {
+        prefetchLock.lock()
+        defer { prefetchLock.unlock() }
+        return prefetchStore[href] != nil
+    }
+
+    static func clearPrefetchCache() {
+        prefetchLock.lock()
+        defer { prefetchLock.unlock() }
+        prefetchStore.removeAll()
+    }
+
+    /// Finds a prefetch entry matching the given URL path, promotes it to the
+    /// primary cache, and removes it from the prefetch store -- all atomically
+    /// under a single lock.
+    private static func promotePrefetchToCache(forPath decodedPath: String, url: NSURL) -> CachedResponse? {
+        prefetchLock.lock()
+        defer { prefetchLock.unlock() }
+        guard let (href, cached) = prefetchEntry(matchingPath: decodedPath) else { return nil }
+        cache.setObject(cached, forKey: url, cost: cached.data.count)
+        prefetchStore.removeValue(forKey: href)
+        return cached
+    }
+
+    /// Caller must hold `prefetchLock`.
+    private static func prefetchEntry(matchingPath decodedPath: String) -> (String, CachedResponse)? {
+        for (href, cached) in prefetchStore {
+            let decodedHref = href.removingPercentEncoding ?? href
+            if decodedPath.hasSuffix("/\(decodedHref)") {
+                return (href, cached)
+            }
+        }
+        return nil
     }
 
     // MARK: - Test Helpers
@@ -95,6 +157,12 @@ final class ImageCacheURLProtocol: URLProtocol {
 
     static func hasCachedResponse(for url: URL) -> Bool {
         cache.object(forKey: url as NSURL) != nil
+    }
+
+    static func findPrefetchMatchData(forPath decodedPath: String) -> Data? {
+        prefetchLock.lock()
+        defer { prefetchLock.unlock() }
+        return prefetchEntry(matchingPath: decodedPath)?.1.data
     }
 }
 

--- a/flureadium/ios/flureadium/Sources/flureadium/ImageCacheURLProtocol.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ImageCacheURLProtocol.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Caches HTTP responses from Readium's local server for image-based
+/// publications (CBZ, DiViNa). Readium's ResourceResponse disables
+/// HTTP caching for DRM safety, but CBZ/DiViNa have no DRM — caching
+/// is safe and eliminates redundant ZIP extraction + HTTP round-trips
+/// on every page turn.
+final class ImageCacheURLProtocol: URLProtocol {
+    private static let handledKey = "ImageCacheURLProtocol.handled"
+    private static let cache = NSCache<NSURL, CachedResponse>()
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        guard
+            let url = request.url,
+            let host = url.host,
+            (host == "localhost" || host == "127.0.0.1"),
+            request.httpMethod == "GET",
+            URLProtocol.property(
+                forKey: handledKey, in: request
+            ) == nil
+        else { return false }
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let url = request.url! as NSURL
+        if let cached = Self.cache.object(forKey: url) {
+            let response = URLResponse(
+                url: url as URL,
+                mimeType: cached.mimeType,
+                expectedContentLength: cached.data.count,
+                textEncodingName: nil
+            )
+            client?.urlProtocol(self, didReceive: response,
+                                cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: cached.data)
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        let mutable = (request as NSURLRequest).mutableCopy()
+            as! NSMutableURLRequest
+        URLProtocol.setProperty(true, forKey: Self.handledKey, in: mutable)
+
+        let task = URLSession.shared.dataTask(with: mutable as URLRequest) {
+            [weak self] data, response, error in
+            guard let self else { return }
+            if let error {
+                self.client?.urlProtocol(self, didFailWithError: error)
+                return
+            }
+            if let data, let response {
+                let entry = CachedResponse(
+                    data: data,
+                    mimeType: response.mimeType
+                )
+                Self.cache.setObject(entry, forKey: url, cost: data.count)
+
+                self.client?.urlProtocol(self, didReceive: response,
+                                         cacheStoragePolicy: .notAllowed)
+                self.client?.urlProtocol(self, didLoad: data)
+            }
+            self.client?.urlProtocolDidFinishLoading(self)
+        }
+        task.resume()
+    }
+
+    override func stopLoading() {}
+
+    // MARK: - Public API
+
+    static func enable() {
+        URLProtocol.registerClass(ImageCacheURLProtocol.self)
+    }
+
+    static func disable() {
+        URLProtocol.unregisterClass(ImageCacheURLProtocol.self)
+        cache.removeAllObjects()
+    }
+
+    static func clearCache() {
+        cache.removeAllObjects()
+    }
+
+    // MARK: - Test Helpers
+
+    static func seedCache(url: URL, data: Data, mimeType: String?) {
+        let entry = CachedResponse(data: data, mimeType: mimeType)
+        cache.setObject(entry, forKey: url as NSURL, cost: data.count)
+    }
+
+    static func hasCachedResponse(for url: URL) -> Bool {
+        cache.object(forKey: url as NSURL) != nil
+    }
+}
+
+// NSCache requires AnyObject values, so this must be a class.
+private final class CachedResponse {
+    let data: Data
+    let mimeType: String?
+
+    init(data: Data, mimeType: String?) {
+        self.data = data
+        self.mimeType = mimeType
+    }
+}

--- a/flureadium/ios/flureadium/Sources/flureadium/ImageReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ImageReaderView.swift
@@ -59,6 +59,8 @@ class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, Visu
     viewContainer = EdgeTapInterceptView()
     super.init()
 
+    ImageCacheURLProtocol.enable()
+
     channel.setMethodCallHandler(onMethodCall)
     imageViewController.delegate = self
 
@@ -192,6 +194,7 @@ class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, Visu
     case "isReaderReady":
       result(hasSentReady)
     case "dispose":
+      ImageCacheURLProtocol.disable()
       imageViewController.view.removeFromSuperview()
       imageViewController.delegate = nil
       readerStatusStreamHandler?.sendEvent(ImageReaderStatusClosed)

--- a/flureadium/ios/flureadium/Sources/flureadium/ImageReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ImageReaderView.swift
@@ -18,6 +18,8 @@ class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, Visu
   private let imageViewController: CBZNavigatorViewController
   private var hasSentReady = false
   private var navigationState = ImageReaderNavigationState()
+  private var visitedIndices = Set<Int>()
+  private var prefetchTask: Task<Void, Never>?
 
   func view() -> UIView {
     print(TAG, "::getView")
@@ -105,6 +107,12 @@ class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, Visu
       hasSentReady = true
     }
     emitOnPageChanged(locator: locator)
+
+    let readingOrder = imageViewController.publication.readingOrder
+    if let currentIndex = readingOrder.firstIndexWithHREF(locator.href) {
+      visitedIndices.insert(currentIndex)
+      prefetchAdjacentPages(around: currentIndex)
+    }
   }
 
   func getCurrentLocation() -> Locator? {
@@ -144,6 +152,35 @@ class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, Visu
         }
       }
     )
+  }
+
+  private func prefetchAdjacentPages(around currentIndex: Int) {
+    prefetchTask?.cancel()
+    let publication = imageViewController.publication
+    let readingOrder = publication.readingOrder
+    let adjacentIndices = [currentIndex - 1, currentIndex + 1, currentIndex + 2]
+    let visited = visitedIndices
+
+    prefetchTask = Task {
+      for index in adjacentIndices {
+        guard !Task.isCancelled else { return }
+        guard readingOrder.indices.contains(index) else { continue }
+        guard !visited.contains(index) else { continue }
+
+        let link = readingOrder[index]
+        guard !ImageCacheURLProtocol.hasPrefetch(href: link.href) else { continue }
+        guard let resource = publication.get(link) else { continue }
+
+        let result = await resource.read()
+        if let data = try? result.get() {
+          ImageCacheURLProtocol.seedPrefetch(
+            href: link.href,
+            data: data,
+            mimeType: link.mediaType?.string
+          )
+        }
+      }
+    }
   }
 
   private func emitOnPageChanged(locator: Locator) {
@@ -194,6 +231,9 @@ class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, Visu
     case "isReaderReady":
       result(hasSentReady)
     case "dispose":
+      prefetchTask?.cancel()
+      prefetchTask = nil
+      visitedIndices.removeAll()
       ImageCacheURLProtocol.disable()
       imageViewController.view.removeFromSuperview()
       imageViewController.delegate = nil

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.10.1
+version: 0.10.2
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.10.0
+version: 0.10.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium_platform_interface/CHANGELOG.md
+++ b/flureadium_platform_interface/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.6.1
+
+### Bug Fixes
+
+- **Locator href encoding**: `Locator.fromJson` now decodes percent-encoded hrefs so the internal representation is always in decoded form. `Locator.toJson` encodes hrefs for safe transport to native platforms. Fixes `PlatformException(InvalidArgument, Failed to parse locator)` on iOS when navigating CBZ files with special characters (spaces, brackets) in filenames.
+
+### Testing
+
+- Add 8 unit tests for href encoding: fromJson decoding, toJson encoding, roundtrip idempotency, and edge cases (spaces-only, brackets-only, mixed special characters).
+
+---
+
 ## 0.6.0
 
 ### New Features

--- a/flureadium_platform_interface/lib/src/shared/publication/locator.dart
+++ b/flureadium_platform_interface/lib/src/shared/publication/locator.dart
@@ -81,7 +81,7 @@ class Locator extends AdditionalProperties
     final text = LocatorText.fromJson(json.optJsonObject('text'));
 
     return Locator(
-      href: href,
+      href: Uri.decodeFull(href),
       type: type,
       title: title,
       locations: locations,
@@ -93,10 +93,11 @@ class Locator extends AdditionalProperties
   String get json => JsonCodec().encode(toJson());
 
   @override
-  Map<String, dynamic> toJson() => {'href': href, 'type': type}
-    ..putOpt('title', title)
-    ..putJSONableIfNotEmpty('locations', locations)
-    ..putJSONableIfNotEmpty('text', text);
+  Map<String, dynamic> toJson() =>
+      {'href': Uri.encodeFull(Uri.decodeFull(href)), 'type': type}
+        ..putOpt('title', title)
+        ..putJSONableIfNotEmpty('locations', locations)
+        ..putJSONableIfNotEmpty('text', text);
 
   Locator copyWith({
     String? href,

--- a/flureadium_platform_interface/pubspec.yaml
+++ b/flureadium_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium_platform_interface
 description: "Platform interface for Flureadium, providing shared models, exceptions, and the abstract FlureadiumPlatform class for EPUB, PDF, and audiobook reading."
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium_platform_interface/test/models/locator_test.dart
+++ b/flureadium_platform_interface/test/models/locator_test.dart
@@ -284,6 +284,96 @@ void main() {
       });
     });
 
+    group('href encoding', () {
+      test('fromJson decodes percent-encoded href', () {
+        final json = {
+          'href': 'Happiness%20v01%20%5BHD%5D.jpg',
+          'type': 'image/jpeg',
+        };
+
+        final locator = Locator.fromJson(json);
+
+        expect(locator, isNotNull);
+        expect(locator!.href, equals('Happiness v01 [HD].jpg'));
+      });
+
+      test('fromJson decodes href with spaces only', () {
+        final json = {'href': 'my%20chapter.xhtml', 'type': 'text/html'};
+
+        final locator = Locator.fromJson(json);
+
+        expect(locator, isNotNull);
+        expect(locator!.href, equals('my chapter.xhtml'));
+      });
+
+      test('fromJson preserves already-decoded href', () {
+        final json = {'href': 'chapter1.xhtml', 'type': 'text/html'};
+
+        final locator = Locator.fromJson(json);
+
+        expect(locator, isNotNull);
+        expect(locator!.href, equals('chapter1.xhtml'));
+      });
+
+      test('toJson encodes decoded href with special characters', () {
+        final locator = Locator(
+          href: '/Happiness - c001 [HD].jpg',
+          type: 'image/jpeg',
+        );
+
+        final json = locator.toJson();
+
+        expect(json['href'], equals('/Happiness%20-%20c001%20%5BHD%5D.jpg'));
+      });
+
+      test('toJson encodes brackets in href', () {
+        final locator = Locator(href: 'page[1].jpg', type: 'image/jpeg');
+
+        final json = locator.toJson();
+
+        expect(json['href'], equals('page%5B1%5D.jpg'));
+      });
+
+      test('toJson preserves simple href unchanged', () {
+        final locator = Locator(href: 'chapter1.xhtml', type: 'text/html');
+
+        final json = locator.toJson();
+
+        expect(json['href'], equals('chapter1.xhtml'));
+      });
+
+      test(
+        'roundtrip: encoded JSON → fromJson → toJson → same encoded JSON',
+        () {
+          final originalJson = {
+            'href': 'file%20name%20%5Btag%5D.jpg',
+            'type': 'image/jpeg',
+          };
+
+          final locator = Locator.fromJson(originalJson);
+          final reserialized = locator!.toJson();
+
+          expect(reserialized['href'], equals('file%20name%20%5Btag%5D.jpg'));
+        },
+      );
+
+      test(
+        'roundtrip: decoded constructor → toJson → fromJson → same decoded internal',
+        () {
+          final original = Locator(
+            href: 'file name [tag].jpg',
+            type: 'image/jpeg',
+          );
+
+          final json = original.toJson();
+          final restored = Locator.fromJson(json);
+
+          expect(restored, isNotNull);
+          expect(restored!.href, equals('file name [tag].jpg'));
+        },
+      );
+    });
+
     group('equality', () {
       test('equal locators have same hashCode', () {
         final locator1 = Locator(


### PR DESCRIPTION
## Summary

- Normalize Locator href encoding: decode in `fromJson`, encode in `toJson`. Fixes `PlatformException` on iOS when navigating CBZ files with special characters in filenames
- Cache iOS CBZ images via a custom `URLProtocol` that intercepts localhost GET requests and stores responses in `NSCache`. Readium disables HTTP caching for DRM reasons, but CBZ has no DRM, so the re-fetching on every page turn was unnecessary
- Prefetch adjacent CBZ pages (N-1, N+1, N+2) after each page turn to avoid blank flashes during fast swiping. Primary cache limited to 100 MB / 30 entries
- Add CBZ page-revisit integration test: navigate forward two pages, then back, verifying the cache hit path

## Changed packages

- `flureadium_platform_interface` 0.6.1 — Locator href encoding fix
- `flureadium` 0.10.1 → 0.10.2 — iOS CBZ caching + prefetch

## Test plan

- [x] Unit test: Locator round-trip encoding
- [x] Swift test: `ImageCacheURLProtocol` cache behavior
- [x] Integration test: CBZ page-revisit flow
- [ ] Manual: open a CBZ with special characters in filenames on iOS, navigate pages