### PR TITLE
fix(ios): route goToLocator to CBZ and PDF readers

### DIFF
--- a/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		D1E2F3A4B5C6D7E800008002 /* NowPlayingInfoUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */; };
 		E1F2A3B4C5D6E7F800008002 /* EpubEditingActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */; };
 		F1A2B3C4D5E6F7A800009002 /* ImageCacheURLProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */; };
+		A2B3C4D5E6F7A8B900010002 /* FlureadiumPluginGoToLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B900010001 /* FlureadiumPluginGoToLocatorTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -71,6 +72,7 @@
 		D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoUpdaterTests.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpubEditingActionsTests.swift; sourceTree = "<group>"; };
 		F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheURLProtocolTests.swift; sourceTree = "<group>"; };
+		A2B3C4D5E6F7A8B900010001 /* FlureadiumPluginGoToLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlureadiumPluginGoToLocatorTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5BDBF082C9CC180601979FB5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 				D1E2F3A4B5C6D7E800008001 /* NowPlayingInfoUpdaterTests.swift */,
 				E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */,
 				F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */,
+				A2B3C4D5E6F7A8B900010001 /* FlureadiumPluginGoToLocatorTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -421,6 +424,7 @@
 				D1E2F3A4B5C6D7E800008002 /* NowPlayingInfoUpdaterTests.swift in Sources */,
 				E1F2A3B4C5D6E7F800008002 /* EpubEditingActionsTests.swift in Sources */,
 				F1A2B3C4D5E6F7A800009002 /* ImageCacheURLProtocolTests.swift in Sources */,
+				A2B3C4D5E6F7A8B900010002 /* FlureadiumPluginGoToLocatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/flureadium/example/ios/RunnerTests/FlureadiumPluginGoToLocatorTests.swift
+++ b/flureadium/example/ios/RunnerTests/FlureadiumPluginGoToLocatorTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import Flutter
+import ReadiumShared
+@testable import flureadium
+
+final class FlureadiumPluginGoToLocatorTests: XCTestCase {
+
+  override func setUp() {
+    super.setUp()
+    currentPublication = nil
+    currentReaderView = nil
+    currentImageReaderView = nil
+    currentPdfReaderView = nil
+  }
+
+  override func tearDown() {
+    currentPublication = nil
+    currentReaderView = nil
+    currentImageReaderView = nil
+    currentPdfReaderView = nil
+    super.tearDown()
+  }
+
+  func testGoToLocatorReturnsErrorWhenArgsNil() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let call = FlutterMethodCall(methodName: "goToLocator", arguments: nil)
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response as? FlutterError,
+                      "goToLocator with nil args should return FlutterError")
+      let error = response as! FlutterError
+      XCTAssertEqual(error.code, "InvalidArgument")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 2.0)
+  }
+
+  func testGoToLocatorReturnsErrorWhenLocatorJsonInvalid() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let badArgs: [Any?] = [["this": "is not a valid locator"]]
+    let call = FlutterMethodCall(methodName: "goToLocator", arguments: badArgs)
+    plugin.handle(call) { response in
+      XCTAssertNotNil(response as? FlutterError,
+                      "goToLocator with malformed locator JSON should return FlutterError")
+      let error = response as! FlutterError
+      XCTAssertEqual(error.code, "InvalidArgument")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 2.0)
+  }
+
+  func testGoToLocatorReturnsFalseWhenNoNavigatorOrViewRegistered() {
+    let plugin = FlureadiumPlugin()
+    let expectation = expectation(description: "result called")
+
+    let locatorJson: [String: Any] = [
+      "href": "page1.jpg",
+      "type": "image/jpeg",
+    ]
+    let call = FlutterMethodCall(methodName: "goToLocator", arguments: [locatorJson])
+    plugin.handle(call) { response in
+      XCTAssertEqual(response as? Bool, false,
+                     "goToLocator should return false when nothing is registered")
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 5.0)
+  }
+}

--- a/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
@@ -373,9 +373,19 @@ public class FlureadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.WarningLog
         if (self.timebasedNavigator != nil) {
           navigated = await self.timebasedNavigator?.seek(toLocator: locator) ?? false
         }
-        // ReaderView goTo
+        // ReaderView goTo (EPUB)
         else if (currentReaderView != nil) {
           await currentReaderView?.goToLocator(locator: locator, animated: false)
+          navigated = true
+        }
+        // ImageReaderView goTo (CBZ / DiViNa)
+        else if (currentImageReaderView != nil) {
+          await currentImageReaderView?.goToLocator(locator: locator, animated: false)
+          navigated = true
+        }
+        // PdfReaderView goTo
+        else if (currentPdfReaderView != nil) {
+          await currentPdfReaderView?.goToLocator(locator: locator, animated: false)
           navigated = true
         }
         await MainActor.run { [navigated] in


### PR DESCRIPTION
## Summary

Plugin-level `Flureadium.goToLocator` and `Flureadium.goByLink` silently no-op for CBZ and PDF on iOS. Only `ReadiumReaderView` (EPUB) registered itself as `currentReaderView`, so the plugin handler's dispatch fell through both branches and returned `navigated=false` with no error and no log. The per-widget `currentReaderWidget?.go(...)` path was unaffected.

## Fix

Extend the iOS plugin's `goToLocator` dispatch to image and PDF readers — mirrors the Android `ReadiumReader.kt` pattern (image → pdf → epub → audio) and reuses the existing weak-var lifecycle.

## Changes

- `FlureadiumPlugin.swift` — added image and PDF branches to `goToLocator` handler.
- `FlureadiumPluginGoToLocatorTests.swift` — XCTest cases for argument handling and no-target fallthrough (74 lines).
- `Runner.xcodeproj/project.pbxproj` — registered the new test source.

Android is unaffected — already routes through all navigators in sequence.

## Test plan

- [x] `xcodebuild test` passes against booted simulator
- [ ] Manual: tap a CBZ TOC entry from the fablum dock — reader navigates to the page
- [ ] Manual: same flow for PDF
- [ ] Manual: EPUB navigation regression — still works as before