### PR TITLE
Add CBZ navigation and thumbnail API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ This project is a fork of [Notalib/flutter_readium](https://github.com/Notalib/f
 - **EPUB 2 & 3 reading** — paginated and scrolling modes with customizable typography
 - **WebPub support** — web publication format alongside EPUB
 - **PDF support** — native rendering on Android (Pdfium) and iOS
+- **CBZ and DIVINA support** — native image-based publication rendering on Android and iOS
 - **Text-to-Speech** — platform-native TTS with voice selection, speed, and pitch control
 - **Audiobook playback** — pre-recorded audio with track navigation, seeking, and variable speed
 - **Media Overlays** — synchronized audio with text highlighting (read-along)
 - **Highlights and annotations** — visual decorations with custom colors and styles
 - **Reader preferences** — fonts, font sizes, colors, margins, themes (night/sepia), scroll modes
 - **Progress saving** — position persistence and restoration via Locators
+- **Page thumbnails** — downscaled JPEG thumbnails for image resources in open publications
 - **Table of contents** — hierarchical navigation through publication structure
 - **Real-time event streams** — position changes, playback state, reader status, and errors
 
@@ -28,6 +30,8 @@ This project is a fork of [Notalib/flutter_readium](https://github.com/Notalib/f
 | EPUB 3 | Yes | Yes | Yes | Yes |
 | WebPub | Yes | Yes | Yes | Yes |
 | PDF | Android, iOS | — | — | — |
+| CBZ | Android, iOS | — | — | — |
+| DIVINA | Android, iOS | — | — | — |
 
 ## Minimum Requirements
 
@@ -45,7 +49,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^x.y.z
+  flureadium: ^0.11.0
 ```
 
 Then follow the platform-specific setup below. For full details, see the [Installation Guide](flureadium/docs/getting-started/installation.md).
@@ -54,10 +58,12 @@ Then follow the platform-specific setup below. For full details, see the [Instal
 
 - Set `minSdkVersion` to 24 or higher in `android/app/build.gradle`.
 - Change your main activity to extend `FlutterFragmentActivity` instead of `FlutterActivity`.
-- If using TTS, add to your `AndroidManifest.xml`:
+- If using TTS or audiobook background playback, add to your `AndroidManifest.xml`:
 
 ```xml
 <uses-permission android:name="android.permission.WAKE_LOCK" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 ```
 
 ### iOS
@@ -137,6 +143,8 @@ What Flureadium supports on each platform:
 |---------|---------|-----|-------|-----|
 | EPUB Visual Reading | Yes | Yes | Yes | Yes |
 | PDF | Yes | Yes | Yes | No |
+| CBZ / DIVINA | Yes | Yes | No | No |
+| Page Thumbnails | Yes | Yes | No | No |
 | Text-to-Speech | Yes | Yes | Yes | Limited&sup1; |
 | Audiobook Playback | Yes | Yes | Yes | Partial&sup2; |
 | Media Overlays | Yes | Yes | Yes | No |
@@ -177,8 +185,6 @@ Native Readium features that exist in the underlying toolkits but are not yet su
 | LCP DRM | Kotlin, Swift | Not integrated (infrastructure exists, can be enabled) |
 | OPDS Catalog Browsing | Kotlin, Swift | Not exposed in API |
 | Content Search | Kotlin, Swift | Not exposed in API |
-| CBZ Comics | Kotlin, Swift | Not implemented |
-| Divina (Visual Narratives) | Kotlin, Swift | Not implemented |
 
 ## Architecture
 

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,36 @@
+## 0.11.0
+
+### New Features
+
+- Add `Flureadium.extractPageThumbnail(href, maxHeight, quality)` for downscaled JPEG thumbnails from image resources in the currently open publication.
+- Add native thumbnail extraction on Android and iOS. Android uses `BitmapFactory` downsampling and JPEG compression; iOS uses ImageIO thumbnail decoding and JPEG compression.
+- Add the `extractPageThumbnail` web override, returning `null` until a web decoder is wired up.
+
+### Bug Fixes
+
+- **iOS / CBZ and PDF navigation**: Route `goToLocator` to image-based readers and PDF readers, not just EPUB and time-based navigators.
+- **iOS / early CBZ navigation**: Wait for the image navigator to become ready before programmatic `goToLocator`, returning `false` instead of hanging indefinitely when readiness never arrives.
+- **Android / CBZ and PDF navigation**: Dispatch `goToLocator` to image and PDF navigators and return the native navigation result to Dart.
+- **Android / thumbnail href lookup**: Resolve thumbnail hrefs through Readium legacy-href URL normalization so manifest hrefs with leading slashes or encoded characters resolve consistently.
+- **Android / TTS service startup**: Enter the foreground immediately with a startup media notification so background playback startup is not killed before the real media notification is ready.
+
+### Testing
+
+- Add Dart facade tests and platform-interface method-channel tests for `extractPageThumbnail`.
+- Add Android JVM tests for `PageThumbnailExtractor` and foreground-service startup behavior.
+- Add iOS XCTest coverage for `PageThumbnailExtractor` and image-reader `goToLocator` readiness/routing.
+- Extend CBZ integration coverage for `goToLocator`, successful thumbnail extraction, missing hrefs, and closed-publication behavior.
+
+### Documentation
+
+- Document `extractPageThumbnail` in the Flureadium API reference, concepts, platform docs, READMEs, and example README.
+- Update README and docs format matrices for CBZ/DIVINA support and remove stale "not implemented" claims.
+- Document Android and iOS thumbnail implementation details and the web `null` behavior.
+
+### Dependencies
+
+- Requires `flureadium_platform_interface` ^0.7.0.
+
 ## 0.10.0
 
 ### New Features

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -9,10 +9,12 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 - **EPUB Reading**: Full EPUB 2/3 support with customizable typography
 - **PDF Reading**: PDF support via Readium's PDF adapters (Android via Pdfium, iOS via PDFKit)
+- **CBZ and DIVINA Reading**: Image-based comics and visual narratives on Android and iOS
 - **Audiobook Playback**: Native audio with background playback support
 - **Text-to-Speech**: Platform TTS with voice selection, rate control, availability detection, and position restore
 - **Synchronized Audio**: Media overlay support for read-along experiences
 - **Highlighting**: Decoration API for bookmarks, highlights, and annotations
+- **Page Thumbnails**: Downscaled JPEG thumbnails for image resources in the open publication
 - **Cross-Platform**: Android, iOS, macOS, and Web (web support is work in progress — see [Web Platform](docs/platform-specific/web.md))
 
 ## Quick Start
@@ -21,7 +23,7 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.9.3
+  flureadium: ^0.11.0
 ```
 
 ### Platform Setup
@@ -113,15 +115,19 @@ final flureadium = Flureadium();
 final publication = await flureadium.openPublication('file:///path/to/book.epub');
 
 // Display in your widget tree
-ReaderWidget(
-  onReaderCreated: (controller) {
-    // Reader is ready
+ReadiumReaderWidget(
+  publication: publication,
+  onReady: () {
+    // Native reader is ready
   },
 )
 
 // Navigate
 await flureadium.goRight();
 await flureadium.goToLocator(savedPosition);
+
+// Extract a small thumbnail for an image resource in an open CBZ/DIVINA
+final bytes = await flureadium.extractPageThumbnail('001.jpg', 80, 70);
 
 // Listen for position changes
 flureadium.onTextLocatorChanged.listen((locator) {

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PageThumbnailExtractor.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PageThumbnailExtractor.kt
@@ -1,0 +1,56 @@
+package dev.mulev.flureadium
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.ByteArrayOutputStream
+
+/**
+ * Decodes raw image bytes into a downscaled JPEG using BitmapFactory's
+ * inSampleSize-based downsampling. The first pass measures source dimensions;
+ * the second pass decodes at the largest power-of-two scale that keeps the
+ * longest side ≥ maxHeight, then a final scale-to-fit if needed.
+ */
+internal object PageThumbnailExtractor {
+    fun extract(bytes: ByteArray, maxHeight: Int, quality: Int): ByteArray? {
+        if (bytes.isEmpty() || maxHeight <= 0) return null
+
+        val measureOpts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, measureOpts)
+        if (measureOpts.outWidth <= 0 || measureOpts.outHeight <= 0) return null
+
+        val decodeOpts = BitmapFactory.Options().apply {
+            inSampleSize = computeInSampleSize(
+                srcWidth = measureOpts.outWidth,
+                srcHeight = measureOpts.outHeight,
+                target = maxHeight,
+            )
+        }
+        val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decodeOpts) ?: return null
+        val scaled = scaleToFit(decoded, maxHeight)
+
+        val output = ByteArrayOutputStream()
+        val q = quality.coerceIn(0, 100)
+        val ok = scaled.compress(Bitmap.CompressFormat.JPEG, q, output)
+        if (scaled !== decoded) decoded.recycle()
+        scaled.recycle()
+        return if (ok) output.toByteArray() else null
+    }
+
+    private fun computeInSampleSize(srcWidth: Int, srcHeight: Int, target: Int): Int {
+        val largest = maxOf(srcWidth, srcHeight)
+        var sample = 1
+        while (largest / (sample * 2) >= target) {
+            sample *= 2
+        }
+        return sample
+    }
+
+    private fun scaleToFit(src: Bitmap, maxHeight: Int): Bitmap {
+        val largest = maxOf(src.width, src.height)
+        if (largest <= maxHeight) return src
+        val ratio = maxHeight.toFloat() / largest
+        val w = (src.width * ratio).toInt().coerceAtLeast(1)
+        val h = (src.height * ratio).toInt().coerceAtLeast(1)
+        return Bitmap.createScaledBitmap(src, w, h, true)
+    }
+}

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PluginMediaService.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PluginMediaService.kt
@@ -13,14 +13,18 @@ package dev.mulev.flureadium
  */
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
@@ -29,6 +33,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.CommandButton
+import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import androidx.media3.session.SessionCommand
@@ -60,6 +65,9 @@ private const val TAG = "Flutter_Readium.MediaService"
 
 private const val CUSTOM_COMMAND_REWIND_ACTION_ID = "REWIND_CUSTOM"
 private const val CUSTOM_COMMAND_FORWARD_ACTION_ID = "FORWARD_CUSTOM"
+private const val STARTUP_NOTIFICATION_CHANNEL_NAME = "Media playback"
+private const val STARTUP_NOTIFICATION_TITLE = "Flureadium playback"
+private const val STARTUP_NOTIFICATION_TEXT = "Preparing playback"
 
 @UnstableApi
 enum class NotificationPlayerCustomCommandButton(
@@ -253,6 +261,7 @@ class PluginMediaService : MediaSessionService(), MediaSession.Callback {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        enterForegroundForStartup()
         super.onStartCommand(intent, flags, startId)
 
         // TODO: Handle restoration properly when activated from a stale notification.
@@ -279,6 +288,42 @@ class PluginMediaService : MediaSessionService(), MediaSession.Callback {
 
         // Prevents the service from being automatically restarted after being killed;
         return START_NOT_STICKY
+    }
+
+    private fun enterForegroundForStartup() {
+        ensureStartupNotificationChannel()
+
+        val notification = NotificationCompat.Builder(
+            this,
+            DefaultMediaNotificationProvider.DEFAULT_CHANNEL_ID
+        )
+            .setSmallIcon(androidx.media3.session.R.drawable.media3_icon_play)
+            .setContentTitle(STARTUP_NOTIFICATION_TITLE)
+            .setContentText(STARTUP_NOTIFICATION_TEXT)
+            .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setSilent(true)
+            .build()
+
+        ServiceCompat.startForeground(
+            this,
+            DefaultMediaNotificationProvider.DEFAULT_NOTIFICATION_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+        )
+    }
+
+    private fun ensureStartupNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val notificationManager = getSystemService(NotificationManager::class.java)
+        val channel = NotificationChannel(
+            DefaultMediaNotificationProvider.DEFAULT_CHANNEL_ID,
+            STARTUP_NOTIFICATION_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_LOW
+        )
+        notificationManager.createNotificationChannel(channel)
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
@@ -19,6 +19,7 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.fromLegacyHref
 import org.readium.r2.shared.util.getOrElse
 import kotlin.time.Duration
 
@@ -204,9 +205,9 @@ internal class PublicationMethodCallHandler() :
                     throw Exception("goToLocator: failed to go to locator. Missing locator: ${args[0]} ")
                 }
 
-                ReadiumReader.goToLocator(locator)
+                val navigated = ReadiumReader.goToLocator(locator)
 
-                return Try.success(null)
+                return Try.success(navigated)
             }
 
             "getLinkContent" -> {
@@ -460,7 +461,10 @@ internal class PublicationMethodCallHandler() :
     ): Try<ByteArray?, PublicationError> {
         val publication = ReadiumReader.currentPublication
             ?: return Try.success(null)
-        val url = Url.invoke(href) ?: return Try.success(null)
+        // Use fromLegacyHref to match iOS AnyURL(legacyHREF:) — strips a
+        // leading '/' the Dart Publication.fromJson normalizer adds and
+        // percent-encodes the path before container lookup.
+        val url = Url.fromLegacyHref(href) ?: return Try.success(null)
         val resource = publication.get(url) ?: return Try.success(null)
         val resourceBytes = resource.read().getOrElse { return Try.success(null) }
         return Try.success(PageThumbnailExtractor.extract(resourceBytes, maxHeight, quality))

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
@@ -461,7 +461,7 @@ internal class PublicationMethodCallHandler() :
         val publication = ReadiumReader.currentPublication
             ?: return Try.success(null)
         val url = Url.invoke(href) ?: return Try.success(null)
-        val resource = publication.get(Link(url)) ?: return Try.success(null)
+        val resource = publication.get(url) ?: return Try.success(null)
         val resourceBytes = resource.read().getOrElse { return Try.success(null) }
         return Try.success(PageThumbnailExtractor.extract(resourceBytes, maxHeight, quality))
     }

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationChannel.kt
@@ -18,6 +18,7 @@ import org.readium.r2.shared.InternalReadiumApi
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.Url
 import org.readium.r2.shared.util.getOrElse
 import kotlin.time.Duration
 
@@ -261,6 +262,14 @@ internal class PublicationMethodCallHandler() :
                 return renderFirstPage(pubUrlStr, maxWidth, maxHeight)
             }
 
+            "extractPageThumbnail" -> {
+                val args = arguments as List<Any?>
+                val href = args[0] as String
+                val maxHeight = args[1] as Int
+                val quality = args[2] as Int
+                return extractPageThumbnail(href, maxHeight, quality)
+            }
+
             else -> {
                 throw NotImplementedError()
             }
@@ -438,6 +447,23 @@ internal class PublicationMethodCallHandler() :
 
         ReadiumReader.audioEnable(locator, preferences)
         return Try.success(null)
+    }
+
+    /**
+     * Extract a downscaled JPEG thumbnail from the resource at [href] in the open publication.
+     * Returns null if no publication is open, the resource is missing/unreadable, or decode fails.
+     */
+    private suspend fun extractPageThumbnail(
+        href: String,
+        maxHeight: Int,
+        quality: Int,
+    ): Try<ByteArray?, PublicationError> {
+        val publication = ReadiumReader.currentPublication
+            ?: return Try.success(null)
+        val url = Url.invoke(href) ?: return Try.success(null)
+        val resource = publication.get(Link(url)) ?: return Try.success(null)
+        val resourceBytes = resource.read().getOrElse { return Try.success(null) }
+        return Try.success(PageThumbnailExtractor.extract(resourceBytes, maxHeight, quality))
     }
 
     /**

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
@@ -1047,14 +1047,23 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
     }
 
     /**
-     * Go to a specific locator.
+     * Go to a specific locator. Returns true if at least one navigator was
+     * available to dispatch to, false otherwise.
      */
-    suspend fun goToLocator(locator: Locator) {
+    suspend fun goToLocator(locator: Locator): Boolean {
+        val handled = audiobookNavigator != null
+            || syncAudiobookNavigator != null
+            || ttsNavigator != null
+            || imageNavigator != null
+            || pdfNavigator != null
+            || epubNavigator != null
         audiobookNavigator?.goToLocator(locator)
         syncAudiobookNavigator?.goToLocator(locator)
         ttsNavigator?.goToLocator(locator)
         imageGoToLocator(locator, true)
+        pdfGoToLocator(locator, true)
         epubGoToLocator(locator, true)
+        return handled
     }
 
     suspend fun audioSeek(offsetSeconds: Double) {

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PageThumbnailExtractorTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PageThumbnailExtractorTest.kt
@@ -1,0 +1,68 @@
+package dev.mulev.flureadium
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.ByteArrayOutputStream
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [33])
+internal class PageThumbnailExtractorTest {
+
+    @Test
+    fun extract_validJpeg_returnsSmallerJpeg() {
+        val src = fixtureJpeg(width = 200, height = 300)
+        val result = PageThumbnailExtractor.extract(src, maxHeight = 80, quality = 70)
+        assertNotNull(result)
+        assertTrue(
+            "expected output (${result!!.size}) < input (${src.size})",
+            result.size < src.size,
+        )
+    }
+
+    @Test
+    fun extract_capsLongestSideAtMaxHeight() {
+        val src = fixtureJpeg(width = 200, height = 300)
+        val result = PageThumbnailExtractor.extract(src, maxHeight = 80, quality = 70)
+        val out = BitmapFactory.decodeByteArray(result!!, 0, result.size)
+        assertTrue(
+            "longest side must be ≤ 80, was ${maxOf(out.width, out.height)}",
+            maxOf(out.width, out.height) <= 80,
+        )
+    }
+
+    @Test
+    fun extract_returnsNullForInvalidBytes() {
+        assertNull(
+            PageThumbnailExtractor.extract(byteArrayOf(0, 1, 2, 3), maxHeight = 80, quality = 70),
+        )
+    }
+
+    @Test
+    fun extract_returnsNullForEmptyBytes() {
+        assertNull(PageThumbnailExtractor.extract(ByteArray(0), maxHeight = 80, quality = 70))
+    }
+
+    @Test
+    fun extract_returnsNullForZeroMaxHeight() {
+        val src = fixtureJpeg(width = 200, height = 300)
+        assertNull(PageThumbnailExtractor.extract(src, maxHeight = 0, quality = 70))
+    }
+
+    private fun fixtureJpeg(width: Int, height: Int): ByteArray {
+        val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        bmp.eraseColor(android.graphics.Color.GRAY)
+        val baos = ByteArrayOutputStream()
+        bmp.compress(Bitmap.CompressFormat.JPEG, 90, baos)
+        bmp.recycle()
+        return baos.toByteArray()
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PluginMediaServiceStartTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PluginMediaServiceStartTest.kt
@@ -3,17 +3,24 @@ package dev.mulev.flureadium
 import android.app.Application
 import android.content.Intent
 import android.os.Build
+import androidx.media3.session.DefaultMediaNotificationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.P])
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class PluginMediaServiceStartTest {
 
     @Test
@@ -24,5 +31,21 @@ internal class PluginMediaServiceStartTest {
 
         verify(application).startForegroundService(any(Intent::class.java))
         verify(application, never()).startService(any(Intent::class.java))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun onStartCommand_entersForegroundImmediately() {
+        val controller = Robolectric.buildService(PluginMediaService::class.java).create()
+        val service = controller.get()
+
+        service.onStartCommand(Intent(service, PluginMediaService::class.java), 0, 1)
+
+        val shadowService = shadowOf(service)
+        assertEquals(
+            DefaultMediaNotificationProvider.DEFAULT_NOTIFICATION_ID,
+            shadowService.lastForegroundNotificationId
+        )
+        assertNotNull(shadowService.lastForegroundNotification)
     }
 }

--- a/flureadium/docs/05-testing/integration-tests.md
+++ b/flureadium/docs/05-testing/integration-tests.md
@@ -12,7 +12,7 @@ Integration tests run the example app on a real device or simulator and assert w
 | `launch_test.dart` | All | App starts, MaterialApp renders |
 | `epub_test.dart` | Android, iOS | EPUB auto-opens, navigation/prefs/highlight don't crash, TTS sentence nav buttons appear, close removes widget |
 | `audiobook_test.dart` | Android, iOS (`@Tags(['native'])`) | Audiobook opens, play changes button label, seek doesn't crash, pause/resume button labels cycle correctly |
-| `cbz_test.dart` | Android, iOS | CBZ auto-opens, `ReadiumReaderWidget` present, left/right navigation works |
+| `cbz_test.dart` | Android, iOS | CBZ auto-opens, navigation works, `goToLocator` reaches an image page, `extractPageThumbnail` returns JPEG bytes/null as appropriate |
 | `divina_test.dart` | Android, iOS | DIVINA auto-opens, `ReadiumReaderWidget` present, left/right navigation works |
 | `webpub_test.dart` | Android, iOS | Remote WebPub manifest opens, `ReadiumReaderWidget` present |
 

--- a/flureadium/docs/README.md
+++ b/flureadium/docs/README.md
@@ -42,8 +42,6 @@ Flureadium is a Flutter plugin that wraps the Readium toolkits for reading EPUB 
 ## Architecture
 
 - **[Overview](architecture/overview.md)** - High-level architecture
-- **[Platform Channels](architecture/platform-channels.md)** - Native communication
-- **[Readium Integration](architecture/readium-integration.md)** - How we wrap Readium
 
 ## Platform Setup
 
@@ -60,10 +58,10 @@ Flureadium is a Flutter plugin that wraps the Readium toolkits for reading EPUB 
 | EPUB 3 | Yes | Yes | Yes | Yes |
 | WebPub | Yes | Yes | Yes | Yes |
 | PDF | Android, iOS | - | - | - |
+| CBZ | Android, iOS | - | - | - |
+| DIVINA | Android, iOS | - | - | - |
 
-> **Note:** PDF support status:
-> - **Completed:** Format detection, preferences API, Android native navigator, iOS native navigator, Flutter widget layer integration, Epist migration
-> - **In Progress:** Manual testing on both platforms
+PDF, CBZ, and DIVINA are native-reader features on Android and iOS. Web support is work in progress and currently focuses on EPUB/WebPub infrastructure and Web Speech API TTS.
 
 ## Minimum Requirements
 
@@ -81,4 +79,4 @@ Flureadium is a Flutter plugin that wraps the Readium toolkits for reading EPUB 
 
 ---
 
-*Last updated: 2026-02-08*
+*Last updated: 2026-04-29*

--- a/flureadium/docs/api-reference/flureadium-class.md
+++ b/flureadium/docs/api-reference/flureadium-class.md
@@ -140,7 +140,7 @@ Future<bool> goToLocator(Locator locator)
 **Parameters:**
 - `locator` - The [Locator](locator.md) to navigate to
 
-**Returns:** `true` if navigation succeeded
+**Returns:** `true` when an active navigator accepted the locator. Returns `false` if no reader is active or, on image-based readers, the native navigator is not ready before its bounded wait expires.
 
 **Example:**
 ```dart
@@ -466,7 +466,7 @@ if (coverBytes != null) {
 
 ### extractPageThumbnail
 
-Returns a downscaled JPEG thumbnail of a resource in the currently open publication.
+Returns a downscaled JPEG thumbnail of an image resource in the currently open publication.
 
 ```dart
 Future<Uint8List?> extractPageThumbnail(
@@ -481,16 +481,16 @@ Future<Uint8List?> extractPageThumbnail(
 - `maxHeight` - Caps the longer side of the output image, in pixels
 - `quality` - JPEG quality, 0-100
 
-**Returns:** JPEG bytes, or `null` if the publication is closed, the href is unknown, or the resource fails to decode.
+**Returns:** JPEG bytes, or `null` if the publication is closed, the href is unknown, the platform does not implement thumbnail extraction, or the resource fails to decode as an image.
 
-The decode runs on a background queue (`DispatchQueue.global(.userInitiated)` on iOS, `Dispatchers.IO` on Android), so concurrent calls do not block the main thread. The native side reuses the already-mounted publication, so LCP-decryption and streaming work without extra setup.
+The native side reuses the already-mounted publication, so LCP-decryption and streaming work without extra setup. Android handles the method call on a `Dispatchers.IO` coroutine. iOS reads and decodes in a detached user-initiated task and returns the result on the main actor.
 
 Use this for TOC thumbnails or any UI that needs a small bitmap for an arbitrary page. Avoid `ui.instantiateImageCodec` inside `Isolate.spawn` workers: the image decoder registry is not initialised there, even with `BackgroundIsolateBinaryMessenger.ensureInitialized`.
 
 **Platform notes:**
 - iOS: `CGImageSourceCreateThumbnailAtIndex` with `kCGImageSourceThumbnailMaxPixelSize`. The thumbnail is decoded directly from the JPEG without loading the full image.
 - Android: `BitmapFactory` with `inJustDecodeBounds` for the bounds pass, `inSampleSize` for the decode pass, then `Bitmap.compress(JPEG, quality, ...)`.
-- Web: returns `null`. No decoder is wired up.
+- Web and macOS: returns `null` or is not implemented by the current platform plugin. No decoder is wired up.
 
 If the publication is closed while the call is in flight, the future resolves to `null` instead of throwing.
 

--- a/flureadium/docs/api-reference/flureadium-class.md
+++ b/flureadium/docs/api-reference/flureadium-class.md
@@ -464,6 +464,45 @@ if (coverBytes != null) {
 }
 ```
 
+### extractPageThumbnail
+
+Returns a downscaled JPEG thumbnail of a resource in the currently open publication.
+
+```dart
+Future<Uint8List?> extractPageThumbnail(
+  String href,
+  int maxHeight,
+  int quality,
+)
+```
+
+**Parameters:**
+- `href` - Resource href from `Publication.readingOrder` or `Publication.tableOfContents`
+- `maxHeight` - Caps the longer side of the output image, in pixels
+- `quality` - JPEG quality, 0-100
+
+**Returns:** JPEG bytes, or `null` if the publication is closed, the href is unknown, or the resource fails to decode.
+
+The decode runs on a background queue (`DispatchQueue.global(.userInitiated)` on iOS, `Dispatchers.IO` on Android), so concurrent calls do not block the main thread. The native side reuses the already-mounted publication, so LCP-decryption and streaming work without extra setup.
+
+Use this for TOC thumbnails or any UI that needs a small bitmap for an arbitrary page. Avoid `ui.instantiateImageCodec` inside `Isolate.spawn` workers: the image decoder registry is not initialised there, even with `BackgroundIsolateBinaryMessenger.ensureInitialized`.
+
+**Platform notes:**
+- iOS: `CGImageSourceCreateThumbnailAtIndex` with `kCGImageSourceThumbnailMaxPixelSize`. The thumbnail is decoded directly from the JPEG without loading the full image.
+- Android: `BitmapFactory` with `inJustDecodeBounds` for the bounds pass, `inSampleSize` for the decode pass, then `Bitmap.compress(JPEG, quality, ...)`.
+- Web: returns `null`. No decoder is wired up.
+
+If the publication is closed while the call is in flight, the future resolves to `null` instead of throwing.
+
+**Example:**
+```dart
+final href = pub.readingOrder.first.href;
+final bytes = await flureadium.extractPageThumbnail(href, 80, 70);
+if (bytes != null) {
+  // render via Image.memory(bytes) or cache to disk
+}
+```
+
 ---
 
 ## Audiobook

--- a/flureadium/docs/architecture/overview.md
+++ b/flureadium/docs/architecture/overview.md
@@ -80,6 +80,7 @@ lib/
 The main API entry point. Provides:
 - Publication lifecycle (open, close)
 - Navigation (goLeft, goRight, goToLocator)
+- Page and cover thumbnails
 - Playback (TTS, audiobook)
 - Preferences and decorations
 
@@ -129,6 +130,7 @@ abstract class FlureadiumPlatform extends PlatformInterface {
   Future<void> goLeft();
   Future<void> goRight();
   Future<bool> goToLocator(Locator locator);
+  Future<Uint8List?> extractPageThumbnail(String href, int maxHeight, int quality);
   // ... more methods
 }
 ```
@@ -146,8 +148,12 @@ Default implementation using Flutter platform channels:
 ```
 android/src/main/kotlin/dev/mulev/flureadium/
 ├── FlureadiumPlugin.kt        # Flutter plugin registration
-├── ReadiumReaderView.kt       # Native reader view
-├── NavigatorWrapper.kt        # Readium navigator wrapper
+├── ReadiumReaderWidget.kt     # Native reader platform view
+├── ReadiumReader.kt           # Reader and navigator orchestration
+├── PublicationChannel.kt      # Main method-channel handler
+├── PageThumbnailExtractor.kt  # Image-resource thumbnail extraction
+├── fragments/                 # EPUB/PDF/image reader fragments
+├── navigators/                # EPUB/PDF/image/audio/TTS navigators
 └── ...
 ```
 
@@ -161,8 +167,10 @@ Uses:
 ```
 ios/Sources/flureadium/
 ├── FlureadiumPlugin.swift     # Flutter plugin registration
-├── ReadiumReaderView.swift    # Native reader view
-├── NavigatorController.swift  # Navigation handling
+├── ReadiumReaderView.swift    # EPUB reader view
+├── PdfReaderView.swift        # PDF reader view
+├── ImageReaderView.swift      # CBZ / DIVINA reader view
+├── PageThumbnailExtractor.swift # Image-resource thumbnail extraction
 └── ...
 ```
 
@@ -275,7 +283,7 @@ Follows Flutter plugin platform interface pattern:
 
 ### Navigator Disposal: `release()` vs `dispose()`
 
-Android navigators (`AudiobookNavigator`, `TTSNavigator`, `EpubNavigator`, `PdfNavigator`) have two disposal methods:
+Android navigators (`AudiobookNavigator`, `TTSNavigator`, `EpubNavigator`, `PdfNavigator`, `ImageNavigator`) have two disposal methods:
 
 - **`dispose()`** — fire-and-forget. Launches cleanup in a detached coroutine and returns immediately. Safe for places where the caller doesn't need to wait for resources to be freed (e.g., widget teardown where the UI is already gone).
 
@@ -309,6 +317,4 @@ All models serialize to/from JSON:
 
 ## See Also
 
-- [Platform Channels](platform-channels.md) - Detailed channel documentation
-- [Readium Integration](readium-integration.md) - How we wrap Readium
 - [Platform-Specific Docs](../platform-specific/) - Platform implementation details

--- a/flureadium/docs/getting-started/concepts.md
+++ b/flureadium/docs/getting-started/concepts.md
@@ -249,7 +249,12 @@ ReadiumReaderWidget(publication: comic);
 await flureadium.goLeft();
 await flureadium.goRight();
 await flureadium.goToLocator(locator);
+
+// Build a thumbnail strip from image resources in the open publication
+final thumbBytes = await flureadium.extractPageThumbnail('001.jpg', 80, 70);
 ```
+
+`extractPageThumbnail` returns downscaled JPEG bytes on Android and iOS, or `null` when the publication is closed, the href cannot be resolved, the resource is not an image, or the current platform does not implement thumbnail extraction.
 
 ## Decorations
 

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.9.3
+  flureadium: ^0.11.0
 ```
 
 Run:

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -93,6 +93,7 @@ android/src/main/kotlin/dev/mulev/flureadium/
 ├── ReadiumReaderViewFactory.kt  # Platform view factory
 ├── ReadiumReaderView.kt         # Native reader view (EPUB)
 ├── ReadiumReaderWidget.kt       # Widget wrapper
+├── PageThumbnailExtractor.kt    # Downscaled JPEG thumbnails for image resources
 ├── FlutterPdfPreferences.kt     # PDF preferences mapping
 ├── fragments/
 │   └── PdfReaderFragment.kt     # PDF reader fragment
@@ -169,6 +170,20 @@ await flureadium.setPDFPreferences(PDFPreferences(
 - `PdfNavigator.kt` - Main PDF navigation controller
 - `PdfReaderFragment.kt` - Android Fragment hosting the PDF view
 - `FlutterPdfPreferences.kt` - Maps Flutter preferences to Readium
+
+### Page Thumbnails
+
+`extractPageThumbnail(href, maxHeight, quality)` resolves `href` against the currently open publication and returns a downscaled JPEG for image resources. It is intended for CBZ/DIVINA page previews, TOC thumbnails, and similar UI.
+
+The Android implementation:
+- Normalizes the incoming href with Readium's legacy-href URL conversion, matching the iOS `AnyURL(legacyHREF:)` path.
+- Reads the resource from the active `Publication`, so mounted publications, streaming resources, and protected resources use the same Readium access path as the reader.
+- Uses `BitmapFactory` with a bounds pass plus `inSampleSize`, then scales to the requested maximum pixel size and compresses to JPEG.
+- Returns `null` when no publication is open, the href is missing, `maxHeight <= 0`, or the image cannot be decoded.
+
+**Files:**
+- `PageThumbnailExtractor.kt` - Decode/downscale/compress helper
+- `PublicationChannel.kt` - `extractPageThumbnail` method-channel handler
 
 ## Edge Tap and Swipe Navigation
 
@@ -268,7 +283,7 @@ android {
 1. Check TTS engine is installed (Settings > Accessibility > TTS)
 2. Download language data if prompted
 3. Test with system TTS settings
-4. If TTS stops when the app goes to the background, update to the latest Flureadium release. Recent Android fixes cover both the media-service startup path (`startForegroundService()` instead of `startService()`) and an activity saved-state crash caused by serializing Readium decoration styles when the app was backgrounded.
+4. If TTS stops when the app goes to the background, update to the latest Flureadium release. Recent Android fixes cover the media-service startup path by entering the foreground immediately with a startup media notification, and also cover an activity saved-state crash caused by serializing Readium decoration styles when the app was backgrounded.
 
 ### Edge taps not responding
 

--- a/flureadium/docs/platform-specific/ios.md
+++ b/flureadium/docs/platform-specific/ios.md
@@ -75,11 +75,12 @@ For audiobook background playback, add to `Info.plist`:
 ```
 ios/Sources/flureadium/
 ├── FlureadiumPlugin.swift       # Plugin registration
-├── MethodCallHandler.swift      # Method channel handler
-├── ReadiumManager.swift         # Readium lifecycle
 ├── ReadiumReaderViewFactory.swift # Platform view factory
-├── ReadiumReaderView.swift      # Native reader view
-└── NavigatorController.swift    # Navigation handling
+├── ReadiumReaderView.swift      # EPUB reader view
+├── PdfReaderView.swift          # PDF reader view
+├── ImageReaderView.swift        # CBZ / DIVINA reader view
+├── EdgeTapInterceptView.swift   # Edge tap and swipe overlay
+└── PageThumbnailExtractor.swift # Downscaled JPEG thumbnails for image resources
 ```
 
 ### Platform View
@@ -174,6 +175,8 @@ This is a native iOS layer change only. No Dart or Flutter changes are required.
 - `PdfReaderView.swift` - PDF reader using EdgeTapInterceptView
 - `ImageReaderView.swift` - CBZ / DIVINA reader using EdgeTapInterceptView
 
+Programmatic `goToLocator` calls route to the active EPUB, PDF, image, or time-based navigator. For CBZ/DIVINA, `ImageReaderView` waits briefly for the Readium image navigator to report readiness before calling `go(to:)`; it returns `false` instead of hanging indefinitely if readiness never arrives.
+
 ### CBZ Image Caching
 
 Readium's CBZ navigator creates a new `ImageViewController` for every page turn, each fetching the full image from a local HTTP server via `URLSession.shared`. The server's `ResourceResponse` sets `Cache-Control: no-cache, no-store, must-revalidate` to protect DRM-enabled content, which prevents `URLCache` from storing responses. For CBZ and DiViNa publications (which have no DRM), this causes redundant ZIP extraction and HTTP round-trips on every swipe.
@@ -204,6 +207,21 @@ Fast swiping is handled by cancelling the in-flight prefetch task on each new pa
 **Files:**
 - `ImageCacheURLProtocol.swift` — URLProtocol subclass with primary NSCache + secondary prefetch store
 - `ImageReaderView.swift` — enable/disable calls in init and dispose, prefetch logic in `locationDidChange`
+
+### Page Thumbnails
+
+`extractPageThumbnail(href, maxHeight, quality)` reads an image resource from the currently open publication and returns a downscaled JPEG. This is primarily useful for CBZ/DIVINA page previews and TOC thumbnail UI.
+
+The iOS implementation:
+- Resolves the incoming href with `AnyURL(legacyHREF:)`, matching Readium's manifest href handling.
+- Reads the resource from the active `Publication`, so the same mounted publication and Readium access path are reused.
+- Uses ImageIO's thumbnail creation path (`CGImageSourceCreateThumbnailAtIndex`) with `kCGImageSourceThumbnailMaxPixelSize`, avoiding a full-size bitmap decode.
+- Compresses to JPEG with the requested 0-100 quality value.
+- Returns `nil` when no publication is open, the href cannot be resolved, `maxHeight <= 0`, or ImageIO cannot decode the resource.
+
+**Files:**
+- `PageThumbnailExtractor.swift` — ImageIO thumbnail decode and JPEG encode helper
+- `FlureadiumPlugin.swift` — `extractPageThumbnail` method-channel handler
 
 ### Text Selection Copy
 

--- a/flureadium/docs/platform-specific/web.md
+++ b/flureadium/docs/platform-specific/web.md
@@ -120,6 +120,7 @@ For advanced CSS options, see [Readium CSS Types](https://github.com/readium/ts-
 | WebPub from remote URL | Broken | `loadPublication` / `getPublication` call fails before `ReadiumWebView` container is mounted |
 | TTS | Supported | Uses Web Speech API — see Text-to-Speech section below |
 | Audiobook playback | Not implemented | Throws `UnimplementedError` |
+| Page thumbnails | Not implemented | `extractPageThumbnail` returns `null` |
 | Custom HTTP headers | No-op | `setCustomHeaders` logs a warning and does nothing on web |
 | Background Audio | No | Browser limitation |
 | Lock Screen | No | Browser limitation |

--- a/flureadium/example/README.md
+++ b/flureadium/example/README.md
@@ -13,6 +13,8 @@ integration_test/
 ├── epub_tts_test.dart      # TTS enable/disable, voice cycling, position restore
 ├── epub_tts_web_test.dart  # Web Speech API TTS tests
 ├── audiobook_test.dart     # Open audiobook, play/pause (native only)
+├── cbz_test.dart           # Open CBZ, navigate, goToLocator, extract thumbnails
+├── divina_test.dart        # Open DIVINA and navigate image-based pages
 └── webpub_test.dart        # Open remote WebPub manifest
 test/
 └── widget_test.dart    # Widget smoke test
@@ -70,6 +72,23 @@ await flureadium.goToLocator(savedLocator);
 
 // Jump to TOC entry
 await flureadium.goByLink(tocLink, publication);
+```
+
+### Image-Based Publications
+
+```dart
+// Open a bundled CBZ or DIVINA file
+final comic = await flureadium.openPublication('file:///path/to/comic.cbz');
+
+// Same widget and navigation API as EPUB/PDF
+ReadiumReaderWidget(publication: comic);
+await flureadium.goRight();
+await flureadium.goToLocator(
+  const Locator(href: '003.jpg', type: 'image/jpeg'),
+);
+
+// Build page preview UI from an image resource in the open publication
+final thumbnail = await flureadium.extractPageThumbnail('001.jpg', 80, 70);
 ```
 
 ### Text-to-Speech
@@ -176,6 +195,8 @@ if (savedJson != null) {
 | Button | API method | Notes |
 |---|---|---|
 | Open EPUB | `openPublication` | Extracts bundled asset to temp; auto-opens on launch |
+| Open CBZ | `openPublication` | Bundled `.cbz` image-based comic |
+| Open DIVINA | `openPublication` | Bundled `.divina` visual narrative |
 | Open AudioBook | `openPublication` | Bundled `.audiobook` file |
 | Open WebPub | `openPublication` + `setCustomHeaders` | Remote manifest; sets `X-Example` header first |
 | Load Only | `loadPublication` | Loads metadata without showing in reader; prints title to debug |
@@ -209,6 +230,7 @@ The following public API methods are not given dedicated buttons because they ar
 | `setDefaultPreferences` | App-level config set before opening; not interactive |
 | `setDefaultPdfPreferences` | PDF-specific; no PDF asset bundled |
 | `renderFirstPage` | PDF-specific; no PDF asset bundled |
+| `extractPageThumbnail` | Covered by CBZ integration tests; no dedicated UI control |
 
 ## Platform-Specific Setup
 

--- a/flureadium/example/integration_test/cbz_test.dart
+++ b/flureadium/example/integration_test/cbz_test.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flureadium/flureadium.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -65,5 +68,113 @@ void main() {
 
       expect(find.byType(ReadiumReaderWidget), findsOneWidget);
     });
+
+    testWidgets(
+      'Flureadium.goToLocator navigates CBZ reader (Bug 1 regression)',
+      (tester) async {
+        app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
+        Publication? pub;
+        for (var i = 0; i < 15; i++) {
+          await tester.pump(const Duration(seconds: 1));
+          if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) {
+            pub = await Flureadium().loadPublication(
+              await _resolveAsset('assets/pubs/sample_comic.cbz'),
+            );
+            break;
+          }
+        }
+
+        expect(find.byType(ReadiumReaderWidget), findsOneWidget);
+        expect(pub, isNotNull);
+        expect(pub!.readingOrder.length, greaterThan(2));
+
+        final targetLink = pub.readingOrder[2];
+        final locator = pub.locatorFromLink(targetLink);
+        expect(locator, isNotNull);
+
+        final navigated = await Flureadium().goToLocator(locator!);
+        await tester.pump(const Duration(seconds: 1));
+
+        expect(navigated, isTrue);
+      },
+    );
+
+    testWidgets(
+      'extractPageThumbnail returns JPEG bytes for a valid CBZ page',
+      (tester) async {
+        app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
+        Publication? pub;
+        for (var i = 0; i < 15; i++) {
+          await tester.pump(const Duration(seconds: 1));
+          if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) {
+            pub = await Flureadium().loadPublication(
+              await _resolveAsset('assets/pubs/sample_comic.cbz'),
+            );
+            break;
+          }
+        }
+        expect(pub, isNotNull);
+
+        final href = pub!.readingOrder.first.href;
+        final bytes = await Flureadium().extractPageThumbnail(href, 80, 70);
+
+        expect(bytes, isNotNull);
+        expect(bytes!.length, greaterThan(2));
+        // JPEG magic bytes (SOI marker)
+        expect(bytes[0], 0xFF);
+        expect(bytes[1], 0xD8);
+      },
+    );
+
+    testWidgets('extractPageThumbnail returns null for bogus href', (
+      tester,
+    ) async {
+      app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
+      for (var i = 0; i < 15; i++) {
+        await tester.pump(const Duration(seconds: 1));
+        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
+      }
+
+      final bytes = await Flureadium().extractPageThumbnail(
+        '/does/not/exist.jpg',
+        80,
+        70,
+      );
+
+      expect(bytes, isNull);
+    });
+
+    testWidgets('extractPageThumbnail returns null after closePublication', (
+      tester,
+    ) async {
+      app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
+      Publication? pub;
+      for (var i = 0; i < 15; i++) {
+        await tester.pump(const Duration(seconds: 1));
+        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) {
+          pub = await Flureadium().loadPublication(
+            await _resolveAsset('assets/pubs/sample_comic.cbz'),
+          );
+          break;
+        }
+      }
+      expect(pub, isNotNull);
+      final href = pub!.readingOrder.first.href;
+
+      await Flureadium().closePublication();
+      final bytes = await Flureadium().extractPageThumbnail(href, 80, 70);
+
+      expect(bytes, isNull);
+    });
   });
+}
+
+Future<String> _resolveAsset(String assetPath) async {
+  final bytes = await rootBundle.load(assetPath);
+  final filename = assetPath.split('/').last;
+  final tmp = File(
+    '${Directory.systemTemp.path}/${DateTime.now().millisecondsSinceEpoch}_$filename',
+  );
+  await tmp.writeAsBytes(bytes.buffer.asUint8List());
+  return tmp.path;
 }

--- a/flureadium/example/integration_test/cbz_test.dart
+++ b/flureadium/example/integration_test/cbz_test.dart
@@ -15,20 +15,14 @@ void main() {
 
     testWidgets('app auto-opens CBZ and shows reader widget', (tester) async {
       app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-      for (var i = 0; i < 15; i++) {
-        await tester.pump(const Duration(seconds: 1));
-        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
-      }
+      await _waitForCbzReaderReady(tester);
 
       expect(find.byType(ReadiumReaderWidget), findsOneWidget);
     });
 
     testWidgets('navigate left and right in CBZ reader', (tester) async {
       app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-      for (var i = 0; i < 15; i++) {
-        await tester.pump(const Duration(seconds: 1));
-        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
-      }
+      await _waitForCbzReaderReady(tester);
 
       expect(find.byType(ReadiumReaderWidget), findsOneWidget);
 
@@ -44,10 +38,7 @@ void main() {
       tester,
     ) async {
       app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-      for (var i = 0; i < 15; i++) {
-        await tester.pump(const Duration(seconds: 1));
-        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
-      }
+      await _waitForCbzReaderReady(tester);
 
       expect(find.byType(ReadiumReaderWidget), findsOneWidget);
 
@@ -70,10 +61,7 @@ void main() {
       'Flureadium.goToLocator navigates CBZ reader (Bug 1 regression)',
       (tester) async {
         app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-        for (var i = 0; i < 15; i++) {
-          await tester.pump(const Duration(seconds: 1));
-          if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
-        }
+        await _waitForCbzReaderReady(tester);
 
         expect(find.byType(ReadiumReaderWidget), findsOneWidget);
 
@@ -86,6 +74,10 @@ void main() {
         await tester.pump(const Duration(seconds: 1));
 
         expect(navigated, isTrue);
+        expect(
+          (await _waitForCbzReaderReady(tester, href: '003.jpg')).href,
+          '003.jpg',
+        );
       },
     );
 
@@ -93,10 +85,7 @@ void main() {
       'extractPageThumbnail returns JPEG bytes for a valid CBZ page',
       (tester) async {
         app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-        for (var i = 0; i < 15; i++) {
-          await tester.pump(const Duration(seconds: 1));
-          if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
-        }
+        await _waitForCbzReaderReady(tester);
 
         final bytes = await Flureadium().extractPageThumbnail(
           '001.jpg',
@@ -116,10 +105,7 @@ void main() {
       tester,
     ) async {
       app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-      for (var i = 0; i < 15; i++) {
-        await tester.pump(const Duration(seconds: 1));
-        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
-      }
+      await _waitForCbzReaderReady(tester);
 
       final bytes = await Flureadium().extractPageThumbnail(
         '/does/not/exist.jpg',
@@ -134,10 +120,7 @@ void main() {
       tester,
     ) async {
       app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-      for (var i = 0; i < 15; i++) {
-        await tester.pump(const Duration(seconds: 1));
-        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
-      }
+      await _waitForCbzReaderReady(tester);
 
       await Flureadium().closePublication();
       final bytes = await Flureadium().extractPageThumbnail('001.jpg', 80, 70);
@@ -145,4 +128,29 @@ void main() {
       expect(bytes, isNull);
     });
   });
+}
+
+Future<Locator> _waitForCbzReaderReady(
+  WidgetTester tester, {
+  String? href,
+}) async {
+  for (var i = 0; i < 30; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+
+    if (find.byType(ReadiumReaderWidget).evaluate().isEmpty) {
+      continue;
+    }
+
+    final reader = FlureadiumPlatform.instance.currentReaderWidget;
+    final locator = reader == null ? null : await reader.getCurrentLocator();
+    if (locator != null && (href == null || locator.href == href)) {
+      return locator;
+    }
+  }
+
+  fail(
+    href == null
+        ? 'CBZ reader did not report an initial locator.'
+        : 'CBZ reader did not navigate to $href.',
+  );
 }

--- a/flureadium/example/integration_test/cbz_test.dart
+++ b/flureadium/example/integration_test/cbz_test.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:flureadium/flureadium.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -73,26 +70,19 @@ void main() {
       'Flureadium.goToLocator navigates CBZ reader (Bug 1 regression)',
       (tester) async {
         app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-        Publication? pub;
         for (var i = 0; i < 15; i++) {
           await tester.pump(const Duration(seconds: 1));
-          if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) {
-            pub = await Flureadium().loadPublication(
-              await _resolveAsset('assets/pubs/sample_comic.cbz'),
-            );
-            break;
-          }
+          if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
         }
 
         expect(find.byType(ReadiumReaderWidget), findsOneWidget);
-        expect(pub, isNotNull);
-        expect(pub!.readingOrder.length, greaterThan(2));
 
-        final targetLink = pub.readingOrder[2];
-        final locator = pub.locatorFromLink(targetLink);
-        expect(locator, isNotNull);
-
-        final navigated = await Flureadium().goToLocator(locator!);
+        const locator = Locator(
+          href: '003.jpg',
+          type: 'image/jpeg',
+          locations: Locations(position: 3, progression: 0.4),
+        );
+        final navigated = await Flureadium().goToLocator(locator);
         await tester.pump(const Duration(seconds: 1));
 
         expect(navigated, isTrue);
@@ -103,20 +93,16 @@ void main() {
       'extractPageThumbnail returns JPEG bytes for a valid CBZ page',
       (tester) async {
         app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-        Publication? pub;
         for (var i = 0; i < 15; i++) {
           await tester.pump(const Duration(seconds: 1));
-          if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) {
-            pub = await Flureadium().loadPublication(
-              await _resolveAsset('assets/pubs/sample_comic.cbz'),
-            );
-            break;
-          }
+          if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
         }
-        expect(pub, isNotNull);
 
-        final href = pub!.readingOrder.first.href;
-        final bytes = await Flureadium().extractPageThumbnail(href, 80, 70);
+        final bytes = await Flureadium().extractPageThumbnail(
+          '001.jpg',
+          80,
+          70,
+        );
 
         expect(bytes, isNotNull);
         expect(bytes!.length, greaterThan(2));
@@ -148,33 +134,15 @@ void main() {
       tester,
     ) async {
       app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
-      Publication? pub;
       for (var i = 0; i < 15; i++) {
         await tester.pump(const Duration(seconds: 1));
-        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) {
-          pub = await Flureadium().loadPublication(
-            await _resolveAsset('assets/pubs/sample_comic.cbz'),
-          );
-          break;
-        }
+        if (find.byType(ReadiumReaderWidget).evaluate().isNotEmpty) break;
       }
-      expect(pub, isNotNull);
-      final href = pub!.readingOrder.first.href;
 
       await Flureadium().closePublication();
-      final bytes = await Flureadium().extractPageThumbnail(href, 80, 70);
+      final bytes = await Flureadium().extractPageThumbnail('001.jpg', 80, 70);
 
       expect(bytes, isNull);
     });
   });
-}
-
-Future<String> _resolveAsset(String assetPath) async {
-  final bytes = await rootBundle.load(assetPath);
-  final filename = assetPath.split('/').last;
-  final tmp = File(
-    '${Directory.systemTemp.path}/${DateTime.now().millisecondsSinceEpoch}_$filename',
-  );
-  await tmp.writeAsBytes(bytes.buffer.asUint8List());
-  return tmp.path;
 }

--- a/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flureadium/example/ios/Runner.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		E1F2A3B4C5D6E7F800008002 /* EpubEditingActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */; };
 		F1A2B3C4D5E6F7A800009002 /* ImageCacheURLProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */; };
 		A2B3C4D5E6F7A8B900010002 /* FlureadiumPluginGoToLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B900010001 /* FlureadiumPluginGoToLocatorTests.swift */; };
+		B3C4D5E6F7A8B9CA00010002 /* PageThumbnailExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C4D5E6F7A8B9CA00010001 /* PageThumbnailExtractorTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -73,6 +74,7 @@
 		E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpubEditingActionsTests.swift; sourceTree = "<group>"; };
 		F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheURLProtocolTests.swift; sourceTree = "<group>"; };
 		A2B3C4D5E6F7A8B900010001 /* FlureadiumPluginGoToLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlureadiumPluginGoToLocatorTests.swift; sourceTree = "<group>"; };
+		B3C4D5E6F7A8B9CA00010001 /* PageThumbnailExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageThumbnailExtractorTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5BDBF082C9CC180601979FB5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 				E1F2A3B4C5D6E7F800008001 /* EpubEditingActionsTests.swift */,
 				F1A2B3C4D5E6F7A800009001 /* ImageCacheURLProtocolTests.swift */,
 				A2B3C4D5E6F7A8B900010001 /* FlureadiumPluginGoToLocatorTests.swift */,
+				B3C4D5E6F7A8B9CA00010001 /* PageThumbnailExtractorTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -425,6 +428,7 @@
 				E1F2A3B4C5D6E7F800008002 /* EpubEditingActionsTests.swift in Sources */,
 				F1A2B3C4D5E6F7A800009002 /* ImageCacheURLProtocolTests.swift in Sources */,
 				A2B3C4D5E6F7A8B900010002 /* FlureadiumPluginGoToLocatorTests.swift in Sources */,
+				B3C4D5E6F7A8B9CA00010002 /* PageThumbnailExtractorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/flureadium/example/ios/RunnerTests/PageThumbnailExtractorTests.swift
+++ b/flureadium/example/ios/RunnerTests/PageThumbnailExtractorTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import ImageIO
+import UIKit
+@testable import flureadium
+
+final class PageThumbnailExtractorTests: XCTestCase {
+  func test_extract_validJpeg_returnsSmallerJpeg() throws {
+    let data = try fixtureJpeg(width: 200, height: 300)
+    let result = PageThumbnailExtractor.extract(data: data, maxHeight: 80, quality: 70)
+    XCTAssertNotNil(result)
+    XCTAssertLessThan(result!.count, data.count)
+  }
+
+  func test_extract_maxHeight80_producesImageWithLongestSideAtMost80() throws {
+    let data = try fixtureJpeg(width: 200, height: 300)
+    let result = PageThumbnailExtractor.extract(data: data, maxHeight: 80, quality: 70)
+    let outputSize = try imageSize(from: XCTUnwrap(result))
+    XCTAssertLessThanOrEqual(max(outputSize.width, outputSize.height), 80)
+  }
+
+  func test_extract_invalidBytes_returnsNil() {
+    let data = Data([0x00, 0x01, 0x02, 0x03])
+    XCTAssertNil(PageThumbnailExtractor.extract(data: data, maxHeight: 80, quality: 70))
+  }
+
+  func test_extract_emptyData_returnsNil() {
+    XCTAssertNil(PageThumbnailExtractor.extract(data: Data(), maxHeight: 80, quality: 70))
+  }
+
+  func test_extract_zeroMaxHeight_returnsNil() throws {
+    let data = try fixtureJpeg(width: 200, height: 300)
+    XCTAssertNil(PageThumbnailExtractor.extract(data: data, maxHeight: 0, quality: 70))
+  }
+
+  // MARK: - Helpers
+
+  private func fixtureJpeg(width: Int, height: Int) throws -> Data {
+    let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
+    let image = renderer.image { ctx in
+      UIColor.red.setFill()
+      ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    }
+    return try XCTUnwrap(image.jpegData(compressionQuality: 0.9))
+  }
+
+  private func imageSize(from data: Data) throws -> CGSize {
+    let source = try XCTUnwrap(CGImageSourceCreateWithData(data as CFData, nil))
+    let cgImage = try XCTUnwrap(CGImageSourceCreateImageAtIndex(source, 0, nil))
+    return CGSize(width: cgImage.width, height: cgImage.height)
+  }
+}

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,14 +191,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../../flureadium_platform_interface"
       relative: true
     source: path
-    version: "0.6.1"
+    version: "0.7.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
@@ -184,12 +184,12 @@ public class FlureadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.WarningLog
           message: "extractPageThumbnail requires [href: String, maxHeight: Int, quality: Int]",
           details: nil))
       }
-      guard let publication = currentPublication else {
+      guard let publication = currentPublication,
+            let url = AnyURL(legacyHREF: href) else {
         return result(nil)
       }
-      let link = Link(href: href)
       Task.detached(priority: .userInitiated) {
-        let resource = publication.get(link)
+        let resource = publication.get(url)
         guard let data = try? await resource?.read().get() else {
           await MainActor.run { result(nil) }
           return

--- a/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
@@ -173,6 +173,38 @@ public class FlureadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.WarningLog
           }
         }
       }
+    case "extractPageThumbnail":
+      guard let args = call.arguments as? [Any?],
+            args.count >= 3,
+            let href = args[0] as? String,
+            let maxHeight = args[1] as? Int,
+            let quality = args[2] as? Int else {
+        return result(FlutterError.init(
+          code: "InvalidArgument",
+          message: "extractPageThumbnail requires [href: String, maxHeight: Int, quality: Int]",
+          details: nil))
+      }
+      guard let publication = currentPublication else {
+        return result(nil)
+      }
+      let link = Link(href: href)
+      Task.detached(priority: .userInitiated) {
+        let resource = publication.get(link)
+        guard let data = try? await resource?.read().get() else {
+          await MainActor.run { result(nil) }
+          return
+        }
+        let jpeg = PageThumbnailExtractor.extract(
+          data: data, maxHeight: maxHeight, quality: quality
+        )
+        await MainActor.run {
+          if let jpeg = jpeg {
+            result(FlutterStandardTypedData(bytes: jpeg))
+          } else {
+            result(nil)
+          }
+        }
+      }
 
     case "ttsEnable":
       guard let args = call.arguments as? [Any?] else {

--- a/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
@@ -412,8 +412,7 @@ public class FlureadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.WarningLog
         }
         // ImageReaderView goTo (CBZ / DiViNa)
         else if (currentImageReaderView != nil) {
-          await currentImageReaderView?.goToLocator(locator: locator, animated: false)
-          navigated = true
+          navigated = await currentImageReaderView?.goToLocator(locator: locator, animated: false) ?? false
         }
         // PdfReaderView goTo
         else if (currentPdfReaderView != nil) {

--- a/flureadium/ios/flureadium/Sources/flureadium/ImageReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ImageReaderView.swift
@@ -8,6 +8,8 @@ private let ImageReaderStatusReady = "ready"
 private let ImageReaderStatusLoading = "loading"
 private let ImageReaderStatusClosed = "closed"
 private let ImageReaderStatusError = "error"
+private let ImageReaderNavigationReadyTimeoutNanoseconds: UInt64 = 10_000_000_000
+private let ImageReaderNavigationReadyPollNanoseconds: UInt64 = 50_000_000
 
 class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, VisualNavigatorDelegate {
   private let channel: ReadiumReaderChannel
@@ -119,8 +121,41 @@ class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, Visu
     imageViewController.currentLocation
   }
 
-  func goToLocator(locator: Locator, animated: Bool) async {
-    let _ = await imageViewController.go(to: locator, options: NavigatorGoOptions(animated: animated))
+  @MainActor
+  func goToLocator(locator: Locator, animated: Bool) async -> Bool {
+    guard await waitUntilReadyForProgrammaticNavigation() else {
+      print(TAG, "goToLocator: reader not ready for \(locator.href)")
+      return false
+    }
+
+    return await imageViewController.go(to: locator, options: NavigatorGoOptions(animated: animated))
+  }
+
+  @MainActor
+  private func waitUntilReadyForProgrammaticNavigation() async -> Bool {
+    if isReadyForProgrammaticNavigation {
+      return true
+    }
+
+    let deadline = DispatchTime.now().uptimeNanoseconds + ImageReaderNavigationReadyTimeoutNanoseconds
+    while DispatchTime.now().uptimeNanoseconds < deadline {
+      if Task.isCancelled {
+        return false
+      }
+
+      try? await Task.sleep(nanoseconds: ImageReaderNavigationReadyPollNanoseconds)
+
+      if isReadyForProgrammaticNavigation {
+        return true
+      }
+    }
+
+    return isReadyForProgrammaticNavigation
+  }
+
+  @MainActor
+  private var isReadyForProgrammaticNavigation: Bool {
+    hasSentReady || imageViewController.currentLocation != nil
   }
 
   private func configureEdgeTapHandlers() {
@@ -199,8 +234,8 @@ class ImageReaderView: NSObject, FlutterPlatformView, CBZNavigatorDelegate, Visu
       let animated = args[1] as! Bool
 
       Task { @MainActor in
-        await self.goToLocator(locator: locator, animated: animated)
-        result(true)
+        let success = await self.goToLocator(locator: locator, animated: animated)
+        result(success)
       }
     case "goLeft":
       let animated = call.arguments as! Bool

--- a/flureadium/ios/flureadium/Sources/flureadium/PageThumbnailExtractor.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PageThumbnailExtractor.swift
@@ -1,0 +1,48 @@
+import Foundation
+import ImageIO
+import CoreGraphics
+import MobileCoreServices
+import UniformTypeIdentifiers
+
+/// Decodes raw image bytes into a downscaled JPEG via ImageIO's thumbnail-direct path.
+/// DCT-domain downscale during decode — never materializes the full-resolution bitmap.
+enum PageThumbnailExtractor {
+  static func extract(data: Data, maxHeight: Int, quality: Int) -> Data? {
+    guard !data.isEmpty, maxHeight > 0 else { return nil }
+
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+      return nil
+    }
+
+    let options: [CFString: Any] = [
+      kCGImageSourceCreateThumbnailFromImageAlways: true,
+      kCGImageSourceThumbnailMaxPixelSize: maxHeight,
+      kCGImageSourceCreateThumbnailWithTransform: true,
+    ]
+
+    guard let cgImage = CGImageSourceCreateThumbnailAtIndex(
+      source, 0, options as CFDictionary
+    ) else {
+      return nil
+    }
+
+    let outputData = NSMutableData()
+    let utType: CFString
+    if #available(iOS 14.0, *) {
+      utType = UTType.jpeg.identifier as CFString
+    } else {
+      utType = kUTTypeJPEG
+    }
+    guard let dest = CGImageDestinationCreateWithData(outputData, utType, 1, nil) else {
+      return nil
+    }
+    let q = max(0.0, min(1.0, Double(quality) / 100.0))
+    let destOptions: [CFString: Any] = [
+      kCGImageDestinationLossyCompressionQuality: q,
+    ]
+    CGImageDestinationAddImage(dest, cgImage, destOptions as CFDictionary)
+    guard CGImageDestinationFinalize(dest) else { return nil }
+
+    return outputData as Data
+  }
+}

--- a/flureadium/lib/flureadium.dart
+++ b/flureadium/lib/flureadium.dart
@@ -319,6 +319,20 @@ class Flureadium {
     );
   }
 
+  /// Extracts a downscaled JPEG thumbnail of a publication resource.
+  ///
+  /// [href] is the resource href as it appears in [Publication.readingOrder]
+  /// or [Publication.tableOfContents]. [maxHeight] caps the longest side of
+  /// the output image in pixels. [quality] is the JPEG quality (0-100).
+  ///
+  /// Returns null if the publication is closed, the href cannot be resolved,
+  /// or the resource cannot be decoded. Web always returns null.
+  Future<Uint8List?> extractPageThumbnail(
+    String href,
+    int maxHeight,
+    int quality,
+  ) => _platform.extractPageThumbnail(href, maxHeight, quality);
+
   /// Navigates to a link within the publication.
   ///
   /// Converts the [link] to a [Locator] and navigates to it.

--- a/flureadium/lib/src/flureadium_web.dart
+++ b/flureadium/lib/src/flureadium_web.dart
@@ -210,6 +210,13 @@ class FlureadiumWebPlugin extends FlureadiumPlatform {
       );
     }
   }
+
+  @override
+  Future<Uint8List?> extractPageThumbnail(
+    String href,
+    int maxHeight,
+    int quality,
+  ) async => null;
   // COMMON PLAYBACK API - END
 
   // TTS API - BEGIN

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.10.0
+version: 0.11.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flureadium_platform_interface: ^0.6.0
+  flureadium_platform_interface: ^0.7.0
   rxdart: ^0.28.0
   wakelock_plus: ^1.2.8
   web: ^1.1.1

--- a/flureadium/test/flureadium_test.dart
+++ b/flureadium/test/flureadium_test.dart
@@ -374,6 +374,57 @@ void main() {
       });
     });
 
+    group('Extract Page Thumbnail', () {
+      test(
+        'extractPageThumbnail forwards args and returns platform bytes',
+        () async {
+          mockPlatform.mockExtractPageThumbnailResult = Uint8List.fromList([
+            0xFF,
+            0xD8,
+            0xAA,
+          ]);
+
+          final result = await flureadium.extractPageThumbnail(
+            'OEBPS/page-3.jpg',
+            80,
+            70,
+          );
+
+          expect(mockPlatform.wasCalled('extractPageThumbnail'), isTrue);
+          expect(
+            mockPlatform.lastCallArgs('extractPageThumbnail')?['href'],
+            equals('OEBPS/page-3.jpg'),
+          );
+          expect(
+            mockPlatform.lastCallArgs('extractPageThumbnail')?['maxHeight'],
+            equals(80),
+          );
+          expect(
+            mockPlatform.lastCallArgs('extractPageThumbnail')?['quality'],
+            equals(70),
+          );
+          expect(result, isNotNull);
+          expect(result!.length, equals(3));
+          expect(result[0], equals(0xFF));
+        },
+      );
+
+      test(
+        'extractPageThumbnail returns null when platform returns null',
+        () async {
+          mockPlatform.mockExtractPageThumbnailResult = null;
+
+          final result = await flureadium.extractPageThumbnail(
+            'OEBPS/missing.jpg',
+            80,
+            70,
+          );
+
+          expect(result, isNull);
+        },
+      );
+    });
+
     group('Render First Page', () {
       test(
         'renderFirstPage calls platform method with correct arguments',

--- a/flureadium/test/mocks/mock_platform.dart
+++ b/flureadium/test/mocks/mock_platform.dart
@@ -24,6 +24,7 @@ class MockFlureadiumPlatform
   List<ReaderTTSVoice> mockVoices = [];
   bool mockGoToLocatorResult = true;
   Uint8List? mockRenderFirstPageResult;
+  Uint8List? mockExtractPageThumbnailResult;
 
   // Stream controllers for testing
   final StreamController<ReadiumReaderStatus> _readerStatusController =
@@ -314,6 +315,22 @@ class MockFlureadiumPlatform
       }),
     );
     return mockRenderFirstPageResult;
+  }
+
+  @override
+  Future<Uint8List?> extractPageThumbnail(
+    String href,
+    int maxHeight,
+    int quality,
+  ) async {
+    calls.add(
+      MockMethodCall('extractPageThumbnail', {
+        'href': href,
+        'maxHeight': maxHeight,
+        'quality': quality,
+      }),
+    );
+    return mockExtractPageThumbnailResult;
   }
 
   // State Streams

--- a/flureadium_platform_interface/CHANGELOG.md
+++ b/flureadium_platform_interface/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.6.1
+## 0.7.0
+
+### New Features
+
+- Add `extractPageThumbnail(href, maxHeight, quality)` to `FlureadiumPlatform` and `MethodChannelFlureadium`.
+- The method-channel implementation sends `extractPageThumbnail` with `[href, maxHeight, quality]` and returns nullable `Uint8List` JPEG bytes.
 
 ### Bug Fixes
 
@@ -6,6 +11,7 @@
 
 ### Testing
 
+- Add method-channel integration tests for thumbnail argument forwarding, nullable byte results, and native exception propagation.
 - Add 8 unit tests for href encoding: fromJson decoding, toJson encoding, roundtrip idempotency, and edge cases (spaces-only, brackets-only, mixed special characters).
 
 ---

--- a/flureadium_platform_interface/README.md
+++ b/flureadium_platform_interface/README.md
@@ -10,6 +10,12 @@ To implement a new platform-specific implementation of `flureadium`, extend [`Fl
 
 This package is endorsed and used by the `flureadium` package. It should not be used directly by app developers.
 
+## Current platform contract
+
+Platform implementations are expected to provide publication lifecycle, visual navigation, playback, preference, decoration, and resource helper APIs. Recent resource helpers include `renderFirstPage()` for PDF cover generation and `extractPageThumbnail()` for downscaled JPEG thumbnails from image resources in the currently open publication.
+
+`extractPageThumbnail()` should return `null` when a platform cannot resolve or decode the resource. Platforms that do not support thumbnail extraction may keep the default `UnimplementedError` until they add support.
+
 ## Note on breaking changes
 
 Strongly prefer non-breaking changes (such as adding a method to the interface) over breaking changes for this package.

--- a/flureadium_platform_interface/lib/flureadium_platform_interface.dart
+++ b/flureadium_platform_interface/lib/flureadium_platform_interface.dart
@@ -113,6 +113,22 @@ abstract class FlureadiumPlatform extends PlatformInterface {
   Future<bool> goToLocator(Locator locator) =>
       throw UnimplementedError('goToLocator() has not been implemented.');
 
+  /// Extracts a downscaled JPEG thumbnail of a publication resource.
+  ///
+  /// [href] is the resource href as it appears in `Publication.readingOrder` or
+  /// `Publication.tableOfContents`. [maxHeight] caps the longest side of the
+  /// output image in pixels. [quality] is the JPEG quality (0-100).
+  ///
+  /// Returns null if the publication is closed, the href cannot be resolved,
+  /// or the resource cannot be decoded as an image.
+  Future<Uint8List?> extractPageThumbnail(
+    String href,
+    int maxHeight,
+    int quality,
+  ) => throw UnimplementedError(
+    'extractPageThumbnail() has not been implemented.',
+  );
+
   // COMMON PLAYBACK API - BEGIN
   /// Play the publication from the given locator, or resume if null.
   Future<void> play(Locator? fromLocator) =>

--- a/flureadium_platform_interface/lib/method_channel_flureadium.dart
+++ b/flureadium_platform_interface/lib/method_channel_flureadium.dart
@@ -151,6 +151,16 @@ class MethodChannelFlureadium extends FlureadiumPlatform {
       false;
 
   @override
+  Future<Uint8List?> extractPageThumbnail(
+    String href,
+    int maxHeight,
+    int quality,
+  ) async => await methodChannel.invokeMethod<Uint8List>(
+    'extractPageThumbnail',
+    [href, maxHeight, quality],
+  );
+
+  @override
   Future<void> setEPUBPreferences(EPUBPreferences preferences) async {
     defaultPreferences = preferences;
     await currentReaderWidget?.setEPUBPreferences(preferences);

--- a/flureadium_platform_interface/pubspec.yaml
+++ b/flureadium_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium_platform_interface
 description: "Platform interface for Flureadium, providing shared models, exceptions, and the abstract FlureadiumPlatform class for EPUB, PDF, and audiobook reading."
-version: 0.6.1
+version: 0.7.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium_platform_interface/test/integration/method_channel_test.dart
+++ b/flureadium_platform_interface/test/integration/method_channel_test.dart
@@ -101,6 +101,81 @@ void main() {
       });
     });
 
+    group('extractPageThumbnail', () {
+      test('sends correct method and arguments', () async {
+        await platform.extractPageThumbnail('page1.jpg', 80, 70);
+
+        expect(methodCalls.length, equals(1));
+        expect(methodCalls.last.method, equals('extractPageThumbnail'));
+        expect(methodCalls.last.arguments, equals(['page1.jpg', 80, 70]));
+      });
+
+      test('returns Uint8List when channel returns bytes', () async {
+        final fakeBytes = Uint8List.fromList([0xFF, 0xD8, 0xFF, 0xE0]);
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(platform.methodChannel, (call) async {
+              methodCalls.add(call);
+              if (call.method == 'extractPageThumbnail') {
+                return fakeBytes;
+              }
+              return _mockResponse(call);
+            });
+
+        final result = await platform.extractPageThumbnail('page1.jpg', 80, 70);
+
+        expect(result, equals(fakeBytes));
+      });
+
+      test('returns null when channel returns null', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(platform.methodChannel, (call) async {
+              methodCalls.add(call);
+              if (call.method == 'extractPageThumbnail') {
+                return null;
+              }
+              return _mockResponse(call);
+            });
+
+        final result = await platform.extractPageThumbnail(
+          'missing.jpg',
+          80,
+          70,
+        );
+
+        expect(result, isNull);
+      });
+
+      test('propagates PlatformException from native', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(platform.methodChannel, (call) async {
+              methodCalls.add(call);
+              if (call.method == 'extractPageThumbnail') {
+                throw PlatformException(
+                  code: 'DECODE_FAILED',
+                  message: 'Could not decode image',
+                );
+              }
+              return _mockResponse(call);
+            });
+
+        expect(
+          () => platform.extractPageThumbnail('bad.jpg', 80, 70),
+          throwsA(isA<PlatformException>()),
+        );
+      });
+    });
+
+    group('FlureadiumPlatform default implementation', () {
+      test('extractPageThumbnail throws UnimplementedError by default', () {
+        final fakePlatform = _FakeFlureadiumPlatform();
+
+        expect(
+          () => fakePlatform.extractPageThumbnail('page1.jpg', 80, 70),
+          throwsA(isA<UnimplementedError>()),
+        );
+      });
+    });
+
     group('TTS API', () {
       test('ttsEnable sends preferences and locator', () async {
         final prefs = TTSPreferences(
@@ -525,6 +600,12 @@ dynamic _mockResponse(MethodCall call) {
     default:
       return null;
   }
+}
+
+/// Minimal concrete subclass to verify [FlureadiumPlatform] default impls.
+class _FakeFlureadiumPlatform extends FlureadiumPlatform {
+  @override
+  Future<String?> getLinkContent(Link link) async => null;
 }
 
 class MockReaderWidget implements ReadiumReaderWidgetInterface {


### PR DESCRIPTION
## Summary

- Add `extractPageThumbnail` across the Dart facade, platform interface, Android, iOS, and web stub.
- Fix CBZ/PDF `goToLocator` routing and early CBZ navigation readiness behavior.
- Stabilize Android TTS foreground-service startup with an immediate startup media notification.
- Update docs, READMEs, changelogs, and release versions for `flureadium 0.11.0` and `flureadium_platform_interface 0.7.0`.

## Validation

- `flutter test` in `flureadium_platform_interface`
- `flutter test` in `flureadium`

Device and simulator integration tests were not run.
