### PR TITLE
Fix relative href normalisation asymmetry (release 0.7.1 / 0.12.1)

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.12.1
+
+### Bug Fixes
+
+- **readingOrder href format**: `pub.readingOrder` hrefs now match what the `Locator` stream emits — bare paths as the native Readium parser produced them, with no synthetic leading slash (`001.jpg`, not `/001.jpg`). This fixes silent failures in code that compares a `Locator.href` against `readingOrder[i].href`, or round-trips an href through a native API, where the leading slash made the two never match. Comes from `flureadium_platform_interface` 0.7.1.
+
+### Testing
+
+- Add a CBZ integration regression that asserts `pub.readingOrder.first.href` equals the live `Locator.href` for the same resource.
+
+### Documentation
+
+- Note in the publication API reference that `readingOrder` hrefs share the `Locator` stream's format.
+
 ## 0.12.0
 
 ### New Features

--- a/flureadium/docs/05-testing/native-unit-tests.md
+++ b/flureadium/docs/05-testing/native-unit-tests.md
@@ -1,0 +1,54 @@
+# Native Unit Test Runner
+
+`scripts/run_native_unit_tests.sh` runs the platform-native unit tests — Android (Kotlin/Robolectric) and iOS (Swift/XCTest) — in one pass. These tests are separate from `flutter test`, which only covers Dart code.
+
+The script exists so you don't have to remember two different toolchains and their setup. It finds the tools each platform needs, and when it can't find one it asks you for a path instead of failing — so a fresh checkout works on someone else's machine, not just the original author's.
+
+## Usage
+
+```bash
+cd flureadium/flureadium
+./scripts/run_native_unit_tests.sh                  # both platforms
+./scripts/run_native_unit_tests.sh --skip-ios       # Android only
+./scripts/run_native_unit_tests.sh --ios-class ModelTests --skip-android
+./scripts/run_native_unit_tests.sh --verbose        # full tool output
+```
+
+### Options
+
+| Option | Effect |
+|--------|--------|
+| `--skip-android` | Skip the Android tests |
+| `--skip-ios` | Skip the iOS tests |
+| `--java-home <path>` | Use this JDK for Android instead of auto-detecting |
+| `--ios-device <id>` | iOS simulator UDID to use (auto-detected otherwise) |
+| `--ios-class <Class>` | Run a single XCTest class, e.g. `ModelTests` |
+| `--verbose` | Stream full tool output instead of the trimmed view |
+| `--help` | Print usage and exit |
+
+It runs both platforms in sequence, keeps going if one fails, and prints a pass/fail summary at the end. The exit code is non-zero if any run failed or could not start.
+
+## What it detects
+
+**Java (Android).** Gradle 8.x needs JDK 17 or newer. The script looks in this order: `$JAVA_HOME`, the `--java-home` value, the macOS `java_home` helper, the JetBrains Runtime bundled with Android Studio, and `java` on `PATH`. If none of them is a JDK 17+, it asks you to type a path (or `skip`).
+
+**Gradle (Android).** Tests run through the example app's Gradle wrapper at `example/android/gradlew`, so no separate Gradle install is needed. The task is `:flureadium:testDebugUnitTest`. Robolectric runs on the JVM, so no device or emulator is involved.
+
+**Simulator (iOS, macOS only).** It uses a booted simulator if one is running, otherwise it lists the installed iPhone simulators and boots the one you pick (and shuts that one down again on exit). It builds the example app for the simulator first — `flutter build ios --simulator --debug` — because XCTest fails silently without a fresh build when test files or dependencies changed. iOS is skipped with a reason on non-macOS hosts.
+
+## Logs
+
+Each run writes to `test_logs/native_run_<timestamp>/`:
+
+- `summary.log` — the pass/fail trail printed to the terminal
+- `android.log` — full Gradle output
+- `ios_build.log` — the `flutter build ios` output
+- `ios_test.log` — full `xcodebuild test` output
+
+The terminal shows a trimmed view by default — build verdicts, test results, and anything that looks like a failure. The full output always lands in these files. On failure the last 40 lines of the relevant log are echoed so you can see the cause without opening the file. Use `--verbose` to stream everything live.
+
+## When to use it
+
+Reach for the script for the common case: run all native tests, or all of one platform. For the fine-grained iOS work — a single test method, deployment-target errors, simulator-runtime selection, registering a new `.swift` file in the Xcode project — see [ios-unit-tests.md](ios-unit-tests.md), which documents the raw `xcodebuild` commands the script wraps.
+
+Android test sources live in `android/src/test/kotlin/`. The script runs the whole `testDebugUnitTest` task; there is no single-class flag on the Android side yet.

--- a/flureadium/docs/api-reference/publication.md
+++ b/flureadium/docs/api-reference/publication.md
@@ -67,6 +67,11 @@ for (final link in pub.readingOrder) {
 }
 ```
 
+Hrefs are returned in the same format the `Locator` stream emits — as the
+native Readium parser produced them, with no synthetic leading slash. A bare
+resource such as `001.jpg` stays `001.jpg`, so an href round-tripped between
+`readingOrder` and a live `Locator` compares equal.
+
 ### resources
 
 **Type:** `List<Link>`

--- a/flureadium/example/integration_test/cbz_test.dart
+++ b/flureadium/example/integration_test/cbz_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
 import 'package:flureadium/flureadium.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -127,7 +130,34 @@ void main() {
 
       expect(bytes, isNull);
     });
+
+    // Regression test for the Dart-side href normalisation asymmetry fixed by
+    // flureadium-djg. Before the fix, Publication.fromJson injected a leading
+    // slash ('/001.jpg') while the Locator stream emitted the bare href
+    // ('001.jpg'), so this assertion would have read '/001.jpg' == '001.jpg'
+    // and failed.
+    testWidgets('readingOrder hrefs match Locator stream format', (
+      tester,
+    ) async {
+      app.main(initialAsset: 'assets/pubs/sample_comic.cbz');
+      final locator = await _waitForCbzReaderReady(tester);
+
+      final path = await _extractAsset('assets/pubs/sample_comic.cbz');
+      final pub = await Flureadium().loadPublication(path);
+
+      expect(pub.readingOrder.first.href, equals(locator.href));
+    });
   });
+}
+
+Future<String> _extractAsset(String assetPath) async {
+  final bytes = await rootBundle.load(assetPath);
+  final filename = assetPath.split('/').last;
+  final tmp = File(
+    '${Directory.systemTemp.path}/${DateTime.now().millisecondsSinceEpoch}_$filename',
+  );
+  await tmp.writeAsBytes(bytes.buffer.asUint8List());
+  return tmp.path;
 }
 
 Future<Locator> _waitForCbzReaderReady(

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.11.0"
+    version: "0.12.0"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.12.0
+version: 0.12.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flureadium_platform_interface: ^0.7.0
+  flureadium_platform_interface: ^0.7.1
   rxdart: ^0.28.0
   wakelock_plus: ^1.2.8
   web: ^1.1.1

--- a/flureadium/scripts/run_native_unit_tests.sh
+++ b/flureadium/scripts/run_native_unit_tests.sh
@@ -1,0 +1,377 @@
+#!/bin/bash
+
+# Native Unit Test Runner for Flureadium
+#
+# Runs the platform-native unit tests that live outside `flutter test`:
+#   - Android: Kotlin/Robolectric JVM tests (testDebugUnitTest)
+#   - iOS:     Swift/XCTest tests (RunnerTests)
+#
+# Runs both sequentially, continues on failure, and prints a summary.
+# It detects the tools each platform needs and, when detection fails,
+# asks you for a path instead of giving up — so it works on a fresh
+# checkout by another contributor, not just the original machine.
+#
+# Usage:
+#   ./scripts/run_native_unit_tests.sh [options]
+#
+# Options:
+#   --skip-android        Skip Android tests
+#   --skip-ios            Skip iOS tests
+#   --java-home <path>    Use this JDK instead of auto-detecting (Android)
+#   --ios-device <id>     iOS simulator UDID to use (auto-detected if omitted)
+#   --ios-class <Class>   Run only one XCTest class, e.g. ModelTests
+#   --verbose             Stream full tool output to the terminal
+#   --help                Show this help and exit
+#
+# Android notes:
+#   Tests run through the example app's Gradle wrapper
+#   (example/android/gradlew), so no separate Gradle install is needed.
+#   The task is :flureadium:testDebugUnitTest. Robolectric runs on the JVM,
+#   so no device or emulator is required — only a JDK 17+.
+#
+# iOS notes (macOS only):
+#   The script builds the example app for the simulator first
+#   (flutter build ios --simulator --debug) — XCTest fails silently without
+#   a fresh build when test files or dependencies changed. It then runs
+#   xcodebuild test against a booted simulator, booting one if needed.
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXAMPLE_DIR="$PLUGIN_DIR/example"
+ANDROID_APP_DIR="$EXAMPLE_DIR/android"
+IOS_APP_DIR="$EXAMPLE_DIR/ios"
+LOG_BASE="$PLUGIN_DIR/test_logs"
+MIN_JAVA_MAJOR=17
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+VERBOSE=false
+SKIP_ANDROID=false
+SKIP_IOS=false
+JAVA_HOME_OVERRIDE=""
+IOS_DEVICE=""
+IOS_CLASS=""
+BOOTED_BY_SCRIPT=""   # simulator UDID this script booted (shut down on exit)
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+usage() {
+  sed -n '3,36p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --skip-android) SKIP_ANDROID=true; shift ;;
+    --skip-ios)     SKIP_IOS=true;     shift ;;
+    --java-home)    JAVA_HOME_OVERRIDE="$2"; shift 2 ;;
+    --ios-device)   IOS_DEVICE="$2";   shift 2 ;;
+    --ios-class)    IOS_CLASS="$2";    shift 2 ;;
+    --verbose)      VERBOSE=true;      shift ;;
+    --help|-h)      usage ;;
+    *)
+      printf "${RED}Unknown option: %s${NC}\n" "$1" >&2
+      echo "Run with --help for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Log directory ─────────────────────────────────────────────────────────────
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_DIR="$LOG_BASE/native_run_$TIMESTAMP"
+mkdir -p "$LOG_DIR"
+SUMMARY_LOG="$LOG_DIR/summary.log"
+
+# ── Logging helper ────────────────────────────────────────────────────────────
+log() {
+  echo -e "$1" | tee -a "$SUMMARY_LOG"
+}
+
+# ── Cleanup ───────────────────────────────────────────────────────────────────
+cleanup() {
+  if [ -n "$BOOTED_BY_SCRIPT" ]; then
+    log "  Shutting down simulator booted by this script ($BOOTED_BY_SCRIPT)."
+    xcrun simctl shutdown "$BOOTED_BY_SCRIPT" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+trap 'exit 2' INT TERM
+
+# ── Test runner ───────────────────────────────────────────────────────────────
+# Lines worth surfacing live in non-verbose mode. The full output always lands
+# in the per-step log file; this only trims the terminal view. Gradle and
+# xcodebuild bury the result under build chatter (UP-TO-DATE tasks, code
+# signing, framework copying), so we keep the build/test verdicts and anything
+# that looks like a failure, and drop the rest.
+SIGNAL_FILTER='BUILD SUCCESSFUL|BUILD FAILED|FAILURE:|Test Case |Test Suite |Executed [0-9]+ test|TEST (SUCCEEDED|FAILED)|\*\* TEST|tests? completed|> Task .*FAILED| > .*(PASSED|FAILED|SKIPPED)$|error:|[Ee]xception|AssertionError'
+
+# Streams to a per-platform log. --verbose echoes everything; otherwise only the
+# signal lines above are shown live, and the failure tail is dumped on failure.
+run_test() {
+  local label="$1"
+  local logfile="$2"
+  shift 2
+
+  log ""
+  log "${BLUE}▶  $label${NC}"
+
+  local exit_code=0
+  if [ "$VERBOSE" = true ]; then
+    "$@" 2>&1 | tee "$logfile"
+    exit_code=${PIPESTATUS[0]}
+  else
+    "$@" 2>&1 | tee "$logfile" | grep --line-buffered -E "$SIGNAL_FILTER"
+    exit_code=${PIPESTATUS[0]}
+  fi
+
+  if [ $exit_code -eq 0 ]; then
+    log "${GREEN}   passed${NC}"
+    return 0
+  fi
+  log "${RED}   FAILED${NC}"
+  if [ "$VERBOSE" = false ]; then
+    log "   Last 40 lines of ${logfile}:"
+    tail -n 40 "$logfile" | tee -a "$SUMMARY_LOG"
+  else
+    log "   See $logfile"
+  fi
+  return 1
+}
+
+# ── Java detection ────────────────────────────────────────────────────────────
+# Echoes the major version of the JDK at $1, or nothing if it can't be read.
+java_major_at() {
+  local home="$1"
+  [ -x "$home/bin/java" ] || return 0
+  local raw
+  raw=$("$home/bin/java" -version 2>&1 | head -1)
+  # Matches `"17.0.9"`, `"1.8.0_xxx"`, `"21"`; collapses old 1.x scheme to x.
+  local ver
+  ver=$(echo "$raw" | grep -oE '"[0-9._]+"' | tr -d '"')
+  case "$ver" in
+    1.*) echo "$ver" | cut -d. -f2 ;;
+    "")  : ;;
+    *)   echo "$ver" | cut -d. -f1 ;;
+  esac
+}
+
+# Validates a candidate JAVA_HOME against MIN_JAVA_MAJOR. Sets RESOLVED_JAVA_HOME
+# and returns 0 on success.
+RESOLVED_JAVA_HOME=""
+try_java_home() {
+  local home="$1"
+  [ -n "$home" ] || return 1
+  local major
+  major=$(java_major_at "$home")
+  [ -n "$major" ] || return 1
+  if (( major >= MIN_JAVA_MAJOR )); then
+    RESOLVED_JAVA_HOME="$home"
+    return 0
+  fi
+  return 1
+}
+
+# Detects a usable JDK from common locations; prompts for a path if none works.
+detect_java() {
+  RESOLVED_JAVA_HOME=""
+
+  # 1. Explicit override or inherited JAVA_HOME.
+  try_java_home "$JAVA_HOME_OVERRIDE" && return 0
+  try_java_home "$JAVA_HOME" && return 0
+
+  # 2. macOS java_home helper, newest qualifying JDK.
+  if command -v /usr/libexec/java_home > /dev/null 2>&1; then
+    local mac_home
+    mac_home=$(/usr/libexec/java_home -v "${MIN_JAVA_MAJOR}+" 2>/dev/null || true)
+    try_java_home "$mac_home" && return 0
+  fi
+
+  # 3. JetBrains Runtime shipped with Android Studio (macOS + Linux globs).
+  local candidate
+  for candidate in \
+    /Applications/Android\ Studio*.app/Contents/jbr/Contents/Home \
+    "$HOME"/Applications/Android\ Studio*.app/Contents/jbr/Contents/Home \
+    /opt/android-studio*/jbr \
+    "$HOME"/android-studio*/jbr; do
+    try_java_home "$candidate" && return 0
+  done
+
+  # 4. java on PATH — resolve to its home.
+  if command -v java > /dev/null 2>&1; then
+    local bin home
+    bin=$(command -v java)
+    # Follow symlinks where realpath is available.
+    if command -v realpath > /dev/null 2>&1; then
+      bin=$(realpath "$bin")
+    fi
+    home=$(dirname "$(dirname "$bin")")
+    try_java_home "$home" && return 0
+  fi
+
+  # 5. Ask the user.
+  log "${YELLOW}Could not auto-detect a JDK ${MIN_JAVA_MAJOR}+ for Android tests.${NC}"
+  log "Gradle 8.x needs JDK ${MIN_JAVA_MAJOR} or newer."
+  while true; do
+    printf "\n  Enter the path to a JDK %d+ home (or 'skip' to skip Android): " \
+      "$MIN_JAVA_MAJOR" >&2
+    local answer
+    read -r answer </dev/tty
+    if [ "$answer" = "skip" ]; then
+      return 1
+    fi
+    if try_java_home "$answer"; then
+      return 0
+    fi
+    printf "  Not a valid JDK %d+ home: %s\n" "$MIN_JAVA_MAJOR" "$answer" >&2
+  done
+}
+
+# ── iOS simulator detection ───────────────────────────────────────────────────
+# Lists booted simulators; if none, offers to boot one. Sets IOS_DEVICE.
+resolve_ios_simulator() {
+  [ -n "$IOS_DEVICE" ] && return 0
+
+  local booted
+  booted=$(xcrun simctl list devices available 2>/dev/null \
+    | grep 'Booted' | grep -oE '[A-F0-9-]{36}' | head -1)
+  if [ -n "$booted" ]; then
+    IOS_DEVICE="$booted"
+    log "  Using booted simulator: $IOS_DEVICE"
+    return 0
+  fi
+
+  log "  No booted simulator. Available iPhone simulators:"
+  local -a names=() ids=()
+  while IFS= read -r line; do
+    local name id
+    name=$(echo "$line" | sed -E 's/ \([A-F0-9-]{36}\).*//' | xargs)
+    id=$(echo "$line" | grep -oE '[A-F0-9-]{36}' | head -1)
+    [ -z "$id" ] && continue
+    names+=("$name"); ids+=("$id")
+  done < <(xcrun simctl list devices available 2>/dev/null | grep -E 'iPhone')
+
+  if [ ${#ids[@]} -eq 0 ]; then
+    log "  ${RED}No iPhone simulators installed.${NC} Create one in Xcode, then re-run."
+    return 1
+  fi
+
+  local i
+  for i in "${!ids[@]}"; do
+    log "    $((i+1))) ${names[$i]}  (${ids[$i]})"
+  done
+
+  local choice
+  while true; do
+    printf "\n  Select a simulator to boot [1-%d]: " "${#ids[@]}" >&2
+    read -r choice </dev/tty
+    if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= ${#ids[@]} )); then
+      break
+    fi
+    printf "  Enter a number between 1 and %d.\n" "${#ids[@]}" >&2
+  done
+
+  IOS_DEVICE="${ids[$((choice-1))]}"
+  log "  Booting ${names[$((choice-1))]} ($IOS_DEVICE)..."
+  xcrun simctl boot "$IOS_DEVICE" 2>/dev/null || true
+  BOOTED_BY_SCRIPT="$IOS_DEVICE"
+  # Give the simulator a moment to come up before xcodebuild attaches.
+  xcrun simctl bootstatus "$IOS_DEVICE" -b 2>/dev/null || true
+  return 0
+}
+
+# ── Header ────────────────────────────────────────────────────────────────────
+log "${YELLOW}══════════════════════════════════════════════════════════════════${NC}"
+log "${YELLOW}  Flureadium Native Unit Test Runner${NC}"
+log "${YELLOW}══════════════════════════════════════════════════════════════════${NC}"
+log "Plugin:  $PLUGIN_DIR"
+log "Logs:    $LOG_DIR"
+log ""
+
+OVERALL_EXIT=0
+
+# ── Android ───────────────────────────────────────────────────────────────────
+log "${CYAN}── Android (Kotlin/Robolectric) ─────────────────────────────────────${NC}"
+if [ "$SKIP_ANDROID" = false ]; then
+  if [ ! -x "$ANDROID_APP_DIR/gradlew" ]; then
+    log "  ${RED}No Gradle wrapper at $ANDROID_APP_DIR/gradlew.${NC}"
+    log "  Run 'flutter pub get' in $EXAMPLE_DIR first."
+    OVERALL_EXIT=1
+  elif ! detect_java; then
+    log "  Skipped — no usable JDK ${MIN_JAVA_MAJOR}+."
+  else
+    log "  JDK:    $RESOLVED_JAVA_HOME"
+    log "  Task:   :flureadium:testDebugUnitTest"
+    if ! ( cd "$ANDROID_APP_DIR" && JAVA_HOME="$RESOLVED_JAVA_HOME" \
+        run_test \
+          "Android — :flureadium:testDebugUnitTest" \
+          "$LOG_DIR/android.log" \
+          ./gradlew :flureadium:testDebugUnitTest --console=plain ); then
+      OVERALL_EXIT=1
+    fi
+  fi
+else
+  log "  Skipped (explicitly skipped)"
+fi
+
+# ── iOS ───────────────────────────────────────────────────────────────────────
+log ""
+log "${CYAN}── iOS (Swift/XCTest) ───────────────────────────────────────────────${NC}"
+if [ "$SKIP_IOS" = false ]; then
+  if [ "$(uname)" != "Darwin" ]; then
+    log "  Skipped — iOS tests require macOS."
+  elif ! command -v xcrun > /dev/null 2>&1; then
+    log "  ${RED}xcrun not found.${NC} Install Xcode and command-line tools, then re-run."
+    OVERALL_EXIT=1
+  elif ! resolve_ios_simulator; then
+    log "  Skipped — no simulator available."
+  else
+    # Mandatory: build before testing, or XCTest fails silently.
+    log "  Building example app for the simulator (required before XCTest)..."
+    if ! ( cd "$EXAMPLE_DIR" && \
+        run_test \
+          "iOS — flutter build ios --simulator --debug" \
+          "$LOG_DIR/ios_build.log" \
+          flutter build ios --simulator --debug ); then
+      log "  ${RED}Build failed — skipping iOS tests.${NC}"
+      OVERALL_EXIT=1
+    else
+      ONLY_TESTING="RunnerTests"
+      [ -n "$IOS_CLASS" ] && ONLY_TESTING="RunnerTests/$IOS_CLASS"
+      if ! ( cd "$IOS_APP_DIR" && \
+          run_test \
+            "iOS — xcodebuild test ($ONLY_TESTING)" \
+            "$LOG_DIR/ios_test.log" \
+            xcodebuild test \
+              -workspace Runner.xcworkspace \
+              -scheme Runner \
+              -configuration Debug \
+              -destination "id=$IOS_DEVICE" \
+              -only-testing:"$ONLY_TESTING" ); then
+        OVERALL_EXIT=1
+      fi
+    fi
+  fi
+else
+  log "  Skipped (explicitly skipped)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+log ""
+log "${CYAN}══════════════════════════════════════════════════════════════════${NC}"
+if [ $OVERALL_EXIT -eq 0 ]; then
+  log "${GREEN}All native unit tests passed.${NC}"
+else
+  log "${RED}One or more native unit test runs failed or could not start.${NC}"
+  log "Logs: $LOG_DIR/"
+fi
+log "${CYAN}══════════════════════════════════════════════════════════════════${NC}"
+
+exit $OVERALL_EXIT

--- a/flureadium_platform_interface/CHANGELOG.md
+++ b/flureadium_platform_interface/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.7.1
+
+### Bug Fixes
+
+- **Relative href normalisation**: `Publication.fromJson` no longer adds a leading slash to relative hrefs when a manifest is unpackaged and has no `self` link. A bare href like `001.jpg` used to come back as `/001.jpg`, while `Locator.fromJson` left it untouched — so `pub.readingOrder.first.href` and the `Locator` stream disagreed about the same resource, and any caller passing an href between the two and a native API hit a format mismatch. Such hrefs now keep the form the native Readium parser produced. Packaged manifests, and manifests with a `self` link, behave as before.
+
+### Testing
+
+- Cover all three `Publication.fromJson` base-URL branches: no self link and not packaged (hrefs verbatim), self link present (resolved against the self URL), and packaged (leading slash kept).
+
+---
+
 ## 0.7.0
 
 ### New Features

--- a/flureadium_platform_interface/lib/src/shared/publication/publication.dart
+++ b/flureadium_platform_interface/lib/src/shared/publication/publication.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: must_be_immutable
 
 import 'package:collection/collection.dart';
-import 'package:dfunc/dfunc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:fimber/fimber.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -177,19 +176,28 @@ class Publication with EquatableMixin implements JSONable {
 
     final jsonObject = Map<String, dynamic>.of(json);
 
-    String baseUrl;
+    final selfHref = packaged
+        ? null
+        : Link.fromJsonArray(
+            jsonObject.optJsonArray('links', remove: true),
+          ).firstWithRel('self')?.href;
+    final String? resolvedBaseUrl;
     if (packaged) {
-      baseUrl = '/';
+      resolvedBaseUrl = '/';
+    } else if (selfHref != null) {
+      resolvedBaseUrl =
+          Uri.tryParse(selfHref)?.removeLastComponent().toString() ?? '/';
     } else {
-      final href = Link.fromJsonArray(
-        jsonObject.optJsonArray('links', remove: true),
-      ).firstWithRel('self')?.href;
-      baseUrl =
-          href?.let(
-            (it) => Uri.tryParse(it)?.removeLastComponent().toString(),
-          ) ??
-          '/';
+      // No self link, not packaged: hrefs are bare relative paths the
+      // native Readium parser already produced. Skip baseHref normalisation
+      // to keep the format symmetric with Locator.fromJson and avoid
+      // prepending a spurious '/' that breaks native APIs (e.g.
+      // extractPageThumbnail container resource lookups).
+      resolvedBaseUrl = null;
     }
+    final hrefNormalizer = resolvedBaseUrl == null
+        ? linkHrefNormalizerIdentity
+        : normalizeHref(resolvedBaseUrl);
 
     final context = jsonObject.optStringsFromArrayOrSingle(
       '@context',
@@ -197,7 +205,7 @@ class Publication with EquatableMixin implements JSONable {
     );
     final metadata = Metadata.fromJson(
       jsonObject.optNullableMap('metadata', remove: true),
-      normalizeHref: normalizeHref(baseUrl),
+      normalizeHref: hrefNormalizer,
     );
     if (metadata == null) {
       Fimber.i('[metadata] is required $jsonObject');
@@ -207,7 +215,7 @@ class Publication with EquatableMixin implements JSONable {
     final links =
         Link.fromJsonArray(
               jsonObject.safeRemove<List<dynamic>>('links'),
-              normalizeHref: normalizeHref(baseUrl),
+              normalizeHref: hrefNormalizer,
             )
             .map(
               (it) => (!packaged || !it.rels.contains('self'))
@@ -225,23 +233,23 @@ class Publication with EquatableMixin implements JSONable {
     );
     final readingOrder = Link.fromJsonArray(
       readingOrderJSON,
-      normalizeHref: normalizeHref(baseUrl),
+      normalizeHref: hrefNormalizer,
     ).where((it) => it.type != null).toList();
 
     final resources = Link.fromJsonArray(
       jsonObject.safeRemove<List<dynamic>>('resources'),
-      normalizeHref: normalizeHref(baseUrl),
+      normalizeHref: hrefNormalizer,
     ).where((it) => it.type != null).toList();
 
     final tableOfContents = Link.fromJsonArray(
       jsonObject.safeRemove<List<dynamic>>('toc'),
-      normalizeHref: normalizeHref(baseUrl),
+      normalizeHref: hrefNormalizer,
     );
 
     // Parses subcollections from the remaining JSON properties.
     final subcollections = PublicationCollection.collectionsFromJSON(
       jsonObject,
-      normalizeHref: normalizeHref(baseUrl),
+      normalizeHref: hrefNormalizer,
     );
 
     return Publication(

--- a/flureadium_platform_interface/pubspec.yaml
+++ b/flureadium_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium_platform_interface
 description: "Platform interface for Flureadium, providing shared models, exceptions, and the abstract FlureadiumPlatform class for EPUB, PDF, and audiobook reading."
-version: 0.7.0
+version: 0.7.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium_platform_interface/test/models/publication_test.dart
+++ b/flureadium_platform_interface/test/models/publication_test.dart
@@ -69,6 +69,65 @@ void main() {
         expect(publication.readingOrder, isEmpty);
         expect(publication.resources, isEmpty);
       });
+
+      test(
+        'parses readingOrder hrefs verbatim when no self link and not packaged',
+        () {
+          final json = {
+            'metadata': {'title': 'Comic'},
+            'links': <dynamic>[],
+            'readingOrder': [
+              {'href': '001.jpg', 'type': 'image/jpeg'},
+              {'href': '002.jpg', 'type': 'image/jpeg'},
+            ],
+          };
+
+          final publication = Publication.fromJson(json);
+
+          expect(publication, isNotNull);
+          expect(publication!.readingOrder.first.href, equals('001.jpg'));
+          expect(publication.readingOrder[1].href, equals('002.jpg'));
+        },
+      );
+
+      test('applies baseHref derived from self link when present', () {
+        final json = {
+          'metadata': {'title': 'Remote Book'},
+          'links': [
+            {
+              'href': 'http://example.com/path/manifest.json',
+              'rel': 'self',
+              'type': 'application/json',
+            },
+          ],
+          'readingOrder': [
+            {'href': 'chapter1.xhtml', 'type': 'application/xhtml+xml'},
+          ],
+        };
+
+        final publication = Publication.fromJson(json);
+
+        expect(publication, isNotNull);
+        expect(
+          publication!.readingOrder.first.href,
+          equals('http://example.com/path/chapter1.xhtml'),
+        );
+      });
+
+      test('preserves leading slash when packaged: true', () {
+        final json = {
+          'metadata': {'title': 'Packaged Book'},
+          'links': <dynamic>[],
+          'readingOrder': [
+            {'href': 'chapter1.xhtml', 'type': 'application/xhtml+xml'},
+          ],
+        };
+
+        final publication = Publication.fromJson(json, packaged: true);
+
+        expect(publication, isNotNull);
+        expect(publication!.readingOrder.first.href, equals('/chapter1.xhtml'));
+      });
     });
 
     group('toJson', () {


### PR DESCRIPTION
## What this does

Fixes the Dart-side href normalisation asymmetry and cuts patch releases for both packages.

`Publication.fromJson` fell back to a `/` base URL for an unpackaged manifest with no `self` link, so every relative href picked up a leading slash (`001.jpg` became `/001.jpg`). `Locator.fromJson` did no such thing, so the two disagreed about the same resource, and any code passing an href between them and a native API hit a format mismatch. The parser now leaves those hrefs as the native Readium parser produced them. Packaged manifests, and manifests with a `self` link, are unchanged.

## Changes

- **platform_interface**: skip baseHref normalisation when a manifest is unpackaged and has no self link; unit tests for all three `Publication.fromJson` base-URL branches.
- **plugin**: CBZ integration regression asserting `pub.readingOrder.first.href` equals the live `Locator.href`; a note in the publication API reference about the href format.
- **tooling**: `scripts/run_native_unit_tests.sh` runs the Android (Robolectric) and iOS (XCTest) native unit tests in one pass, detecting the JDK, Gradle wrapper, and simulator, and prompting for a path when a tool is missing. Documented in `docs/05-testing/native-unit-tests.md`.
- **releases**: `flureadium_platform_interface` 0.7.1, `flureadium` 0.12.1 (dependency pinned `^0.7.1`); changelogs updated.

## Testing

- `flutter test` passes for both packages.
- Android native unit tests pass through the new runner.
- iOS native unit tests and the CBZ integration test need a Mac and simulator (deferred). The href branch is pure Dart, so no native code changed.

platform_interface and flureadium changes are kept in separate commits per repo policy.
