### PR TITLE
fix: name SwiftPM library product to match plugin

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.13.1
+
+### Bug Fixes
+
+- **iOS/macOS Swift Package Manager resolution**: The SwiftPM library product in `ios/flureadium/Package.swift` was named `flutter-readium`, which does not match the plugin name. Under Flutter 3.44+ (SwiftPM on by default) an app build failed to resolve the plugin: `product 'flureadium' ... not found in package 'flureadium'`. The product is now named `flureadium`, matching the plugin, so SwiftPM integration resolves. No API or behaviour change; CocoaPods builds were unaffected.
+
 ## 0.13.0
 
 ### New Features

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.1"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/ios/flureadium/Package.swift
+++ b/flureadium/ios/flureadium/Package.swift
@@ -5,14 +5,13 @@
 import PackageDescription
 
 let package = Package(
-    // TODO: Update your plugin name.
     name: "flureadium",
     platforms: [
         .iOS("13.4"),
         .macOS("10.15")
     ],
     products: [
-        .library(name: "flutter-readium", targets: ["flureadium"])
+        .library(name: "flureadium", targets: ["flureadium"])
     ],
     dependencies: [
       .package(url: "https://github.com/readium/swift-toolkit.git", .upToNextMinor(from: "3.5.0")),

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.13.0
+version: 0.13.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## Problem

Flutter 3.44 turns Swift Package Manager on by default. The plugin's `ios/flureadium/Package.swift` declared its library product as `flutter-readium`, which does not match the plugin name. Under SwiftPM an app build fails to resolve the plugin:

```
product 'flureadium' required by package 'fluttergeneratedpluginswiftpackage'
target 'FlutterGeneratedPluginSwiftPackage' not found in package 'flureadium'
```

Flutter requires the library product name to equal the plugin name (underscores become dashes; `flureadium` has none), so it must be `flureadium`.

## Change

- Rename the library product `flutter-readium` -> `flureadium` in `ios/flureadium/Package.swift` (also drop the stale `// TODO: Update your plugin name.` template comment).
- Bump `0.13.0` -> `0.13.1`; add the CHANGELOG entry.

## Verification

`swift package dump-package` now reports the product as `flureadium` -> target `flureadium`. CocoaPods builds were unaffected. No Dart API or behaviour change, so `flutter test` does not exercise this; the real check is SwiftPM resolution in a consuming app build once `0.13.1` is published.