### PR TITLE
fix: reuse audiobook media session on chapter jump

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **iOS/macOS Swift Package Manager resolution**: The SwiftPM library product in `ios/flureadium/Package.swift` was named `flutter-readium`, which does not match the plugin name. Under Flutter 3.44+ (SwiftPM on by default) an app build failed to resolve the plugin: `product 'flureadium' ... not found in package 'flureadium'`. The product is now named `flureadium`, matching the plugin, so SwiftPM integration resolves. No API or behaviour change; CocoaPods builds were unaffected.
+- **Android audiobook chapter-jump freeze**: Jumping to a chapter from the table of contents or resuming from a bookmark no longer freezes playback. `play(locator)` used to rebuild the media session every call, so a jump made while audio was playing created a second `MediaLibrarySession` with the same default (empty) id; media3 rejects duplicate session ids, and the error handler tore down the only player, leaving playback stuck at the new chapter's `0:00`. `play(locator)` now reuses the open session for the same navigator and seeks, releasing the old session only when switching navigators (audiobook to TTS). The transport buttons (`next()`/`previous()`) and the initial `play(null)` are unchanged.
 
 ## 0.13.0
 

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,9 +1,14 @@
+## 0.13.2
+
+### Bug Fixes
+
+- **Android audiobook chapter-jump freeze**: Jumping to a chapter from the table of contents or resuming from a bookmark no longer freezes playback. `play(locator)` used to rebuild the media session every call, so a jump made while audio was playing created a second `MediaLibrarySession` with the same default (empty) id; media3 rejects duplicate session ids, and the error handler tore down the only player, leaving playback stuck at the new chapter's `0:00`. `play(locator)` now reuses the open session for the same navigator and seeks, releasing the old session only when switching navigators (audiobook to TTS). The transport buttons (`next()`/`previous()`) and the initial `play(null)` are unchanged.
+
 ## 0.13.1
 
 ### Bug Fixes
 
 - **iOS/macOS Swift Package Manager resolution**: The SwiftPM library product in `ios/flureadium/Package.swift` was named `flutter-readium`, which does not match the plugin name. Under Flutter 3.44+ (SwiftPM on by default) an app build failed to resolve the plugin: `product 'flureadium' ... not found in package 'flureadium'`. The product is now named `flureadium`, matching the plugin, so SwiftPM integration resolves. No API or behaviour change; CocoaPods builds were unaffected.
-- **Android audiobook chapter-jump freeze**: Jumping to a chapter from the table of contents or resuming from a bookmark no longer freezes playback. `play(locator)` used to rebuild the media session every call, so a jump made while audio was playing created a second `MediaLibrarySession` with the same default (empty) id; media3 rejects duplicate session ids, and the error handler tore down the only player, leaving playback stuck at the new chapter's `0:00`. `play(locator)` now reuses the open session for the same navigator and seeks, releasing the old session only when switching navigators (audiobook to TTS). The transport buttons (`next()`/`previous()`) and the initial `play(null)` are unchanged.
 
 ## 0.13.0
 

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PluginMediaService.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PluginMediaService.kt
@@ -59,6 +59,37 @@ private const val STARTUP_NOTIFICATION_CHANNEL_NAME = "Media playback"
 private const val STARTUP_NOTIFICATION_TITLE = "Flureadium playback"
 private const val STARTUP_NOTIFICATION_TEXT = "Preparing playback"
 
+/**
+ * The lifecycle action to take when opening a media session for [an incoming
+ * navigator] while [a navigator] already owns the live session (or none does).
+ */
+internal enum class SessionAction {
+    /** No live session — build a new one. */
+    FRESH,
+
+    /** The live session already belongs to this navigator — keep it. */
+    REUSE,
+
+    /** A different navigator owns the live session — release it, then build. */
+    REPLACE,
+}
+
+/**
+ * Decides how [PluginMediaService.Binder.openSession] should treat a request for
+ * [incoming] given the [current] navigator of the live session (`null` when none
+ * is open). Reusing the same navigator's session is what keeps `play(locator)`
+ * from rebuilding a duplicate session on a chapter jump.
+ */
+@OptIn(ExperimentalReadiumApi::class)
+internal fun sessionActionFor(
+    current: AnyMediaNavigator?,
+    incoming: AnyMediaNavigator,
+): SessionAction = when {
+    current == null -> SessionAction.FRESH
+    current === incoming -> SessionAction.REUSE
+    else -> SessionAction.REPLACE
+}
+
 @ExperimentalCoroutinesApi
 @OptIn(ExperimentalReadiumApi::class)
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -103,6 +134,15 @@ class PluginMediaService : MediaLibraryService() {
             publication: Publication? = null,
         ) where N : AnyMediaNavigator, N : Media3Adapter {
             Log.d(TAG, "openSession")
+
+            when (sessionActionFor(sessionMutable.value?.navigator, navigator)) {
+                SessionAction.REUSE -> {
+                    Log.d(TAG, "openSession: reusing live session for the same navigator")
+                    return
+                }
+                SessionAction.REPLACE -> closeSession()
+                SessionAction.FRESH -> {}
+            }
 
             val activityIntent = createSessionActivityIntent()
             val player = navigator.asMedia3Player()

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PluginMediaServiceFacade.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PluginMediaServiceFacade.kt
@@ -49,6 +49,13 @@ class PluginMediaServiceFacade(
         publication: Publication? = null,
     ) where N : AnyMediaNavigator, N : Media3Adapter {
         coroutineQueue.await {
+            // Already bound with a live session for this navigator — reuse it
+            // instead of rebinding and relaunching a session collector. Read the
+            // binder's own session (set synchronously by openSession), not the
+            // mirrored `sessionMutable` the async collector lags behind.
+            if (sessionActionFor(binder?.session?.value?.navigator, navigator) == SessionAction.REUSE) {
+                return@await
+            }
             PluginMediaService.start(application)
             binder = try {
                 PluginMediaService.bind(application)

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PluginMediaServiceReuseTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PluginMediaServiceReuseTest.kt
@@ -1,0 +1,39 @@
+package dev.mulev.flureadium
+
+import org.mockito.Mockito.mock
+import org.readium.navigator.media.common.MediaNavigator
+import org.readium.r2.shared.ExperimentalReadiumApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers the session-reuse decision that stops `play(locator)` from rebuilding a
+ * duplicate [PluginMediaService.Session] on a chapter jump or bookmark tap.
+ *
+ * The decision is reference-identity based: the same navigator instance reuses
+ * the live session, a different navigator replaces it, and no open session opens
+ * a fresh one.
+ */
+@OptIn(ExperimentalReadiumApi::class)
+internal class PluginMediaServiceReuseTest {
+
+    private fun navigator(): AnyMediaNavigator =
+        mock(MediaNavigator::class.java) as AnyMediaNavigator
+
+    @Test
+    fun sessionActionFor_noOpenSession_isFresh() {
+        assertEquals(SessionAction.FRESH, sessionActionFor(null, navigator()))
+    }
+
+    @Test
+    fun sessionActionFor_sameNavigator_isReuse() {
+        val nav = navigator()
+
+        assertEquals(SessionAction.REUSE, sessionActionFor(nav, nav))
+    }
+
+    @Test
+    fun sessionActionFor_differentNavigator_isReplace() {
+        assertEquals(SessionAction.REPLACE, sessionActionFor(navigator(), navigator()))
+    }
+}

--- a/flureadium/docs/05-testing/native-unit-tests.md
+++ b/flureadium/docs/05-testing/native-unit-tests.md
@@ -37,7 +37,7 @@ Gradle skips `:flureadium:testDebugUnitTest` when its inputs haven't changed, re
 
 **Gradle (Android).** Tests run through the example app's Gradle wrapper at `example/android/gradlew`, so no separate Gradle install is needed. The task is `:flureadium:testDebugUnitTest`. Robolectric runs on the JVM, so no device or emulator is involved.
 
-**Simulator (iOS, macOS only).** It uses a booted simulator if one is running, otherwise it lists the installed iPhone simulators and boots the one you pick (and shuts that one down again on exit). It builds the example app for the simulator first — `flutter build ios --simulator --debug` — because XCTest fails silently without a fresh build when test files or dependencies changed. iOS is skipped with a reason on non-macOS hosts.
+**Simulator (iOS, macOS only).** It uses a booted simulator if one is running, otherwise it lists the installed iPhone simulators and boots the one you pick. It builds the example app for the simulator first — `flutter build ios --simulator --debug` — because XCTest fails silently without a fresh build when test files or dependencies changed. iOS is skipped with a reason on non-macOS hosts. The script leaves your simulators as it found them: one it booted itself is shut down on exit, and one that was already running is left running. `xcodebuild test` tears down its own test destination and can shut down a simulator it did not boot, so if it closes an already-running simulator the script re-boots it on exit.
 
 ## Logs
 

--- a/flureadium/docs/guides/audiobook-playback.md
+++ b/flureadium/docs/guides/audiobook-playback.md
@@ -72,6 +72,14 @@ await flureadium.resume();
 await flureadium.stop();
 ```
 
+`play(locator)` doubles as the chapter-jump and bookmark-resume control. Called
+while audio is already playing, it reuses the open media session and seeks to the
+new position instead of tearing playback down and rebuilding it, so jumping to a
+chapter from a table of contents or a saved bookmark continues without a gap. An
+earlier Android version rebuilt the session on every `play(locator)`, which
+collided on the media3 session id and froze playback at the new chapter's start;
+see [platform-specific/android.md](../platform-specific/android.md#audiobook-media-session-reuse).
+
 ### Track Navigation
 
 ```dart

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -221,6 +221,33 @@ mid-stream/post-load delivery stays best-effort. Covered by `ReadiumReaderTimeba
 **Files:**
 - `AudiobookNavigator.kt` — `onAudioNavigatorEnded()` and the `State.Ended` branch
 
+### Audiobook Media Session Reuse
+
+`PluginMediaService` holds one live `MediaLibrarySession` per navigator.
+`play(locator)` (the path a table-of-contents chapter tap or a bookmark resume
+drives) routes through `Binder.openSession`, which decides what to do from the
+navigator already backing the live session (`sessionActionFor`):
+
+- **Same navigator**: reuse the open session and seek; do not build a new one.
+- **Different navigator**: release the old session (an audiobook ↔ TTS switch), then open a new one.
+- **None open**: open a fresh session.
+
+media3 requires every live `MediaSession` to have a unique id, and the default id
+is the empty string. An earlier version rebuilt the session on every
+`play(locator)`, so a chapter jump created a second session with the same empty
+id while the first was still live; media3 threw `Session ID must be unique` and
+the error handler tore down the only player, freezing playback at the new
+chapter's `0:00`. Reusing the session removes the collision.
+`PluginMediaServiceFacade` mirrors the check at the bind layer: when it is
+already bound with a live session for the same navigator it skips rebinding, so a
+repeat `play(locator)` does not leak a session collector. Covered by
+`PluginMediaServiceReuseTest` and the `play(locator) to a later chapter while
+playing keeps playback going` integration test.
+
+**Files:**
+- `PluginMediaService.kt` — `Binder.openSession` reuse/replace guard, `sessionActionFor`
+- `PluginMediaServiceFacade.kt` — same-navigator short-circuit before rebinding
+
 ### PDF Support
 
 PDF support is implemented using Readium's Pdfium adapter, which provides native PDF rendering via Android's Pdfium library.

--- a/flureadium/example/integration_test/audiobook_test.dart
+++ b/flureadium/example/integration_test/audiobook_test.dart
@@ -188,6 +188,55 @@ void main() {
       },
     );
 
+    testWidgets(
+      'play(locator) to a later chapter while playing keeps playback going',
+      (tester) async {
+        // The Table-of-Contents / bookmark jump path: play(fromLocator) must
+        // reuse the already-open media session instead of rebuilding it. On
+        // Android a rebuild hit Media3's "Session ID must be unique" collision
+        // and froze playback at the new chapter's start (flureadium-yc9). Only
+        // play(fromLocator) opens a session — goToLocator ('Ch.1') uses the
+        // separate go path — so drive play() directly with a non-null locator.
+        await showAudiobook(tester);
+        await tester.tap(find.text('Audio Play'));
+        await waitForPlaying(tester);
+
+        final before = currentTrack(tester);
+
+        // Build a locator for a later reading-order track and jump to it via
+        // play(fromLocator). Loading the manifest separately just gets the
+        // reading order, mirroring the end-of-book test above.
+        final path = await _extractAsset('assets/pubs/38533.audiobook');
+        final pub = await Flureadium().loadPublication(path);
+        final target = pub.locatorFromLink(pub.readingOrder[1]);
+        expect(target, isNotNull, reason: 'need a locator for a later track');
+        await Flureadium().play(target);
+
+        // The track changed to the jumped-to chapter and playback stayed active.
+        await pumpUntil(
+          tester,
+          () => currentTrack(tester) != before,
+          timeout: const Duration(seconds: 10),
+        );
+        expect(currentTrack(tester), isNot(before));
+        expect(find.text('Audio Pause'), findsOneWidget);
+
+        // Not frozen: the position keeps advancing after the jump. Pre-fix it
+        // stuck at the new chapter's 0:00 because the session was torn down.
+        final settled = timebasedPosition(tester);
+        final advanced = await pumpUntil(
+          tester,
+          () => timebasedPosition(tester).posMs > settled.posMs,
+          timeout: const Duration(seconds: 10),
+        );
+        expect(
+          advanced,
+          isTrue,
+          reason: 'playback must keep advancing after a play(locator) jump',
+        );
+      },
+    );
+
     testWidgets('untitled chapter audiobook plays and skips without crashing', (
       tester,
     ) async {

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.13.1"
+    version: "0.13.2"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.13.1
+version: 0.13.2
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues

--- a/flureadium/scripts/run_native_unit_tests.sh
+++ b/flureadium/scripts/run_native_unit_tests.sh
@@ -69,6 +69,7 @@ JAVA_HOME_OVERRIDE=""
 IOS_DEVICE=""
 IOS_CLASS=""
 BOOTED_BY_SCRIPT=""   # simulator UDID this script booted (shut down on exit)
+WAS_PREBOOTED=false  # target sim was already booted before this run; re-boot after xcodebuild
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 usage() {
@@ -110,6 +111,15 @@ cleanup() {
   if [ -n "$BOOTED_BY_SCRIPT" ]; then
     log "  Shutting down simulator booted by this script ($BOOTED_BY_SCRIPT)."
     xcrun simctl shutdown "$BOOTED_BY_SCRIPT" 2>/dev/null || true
+  elif [ "$WAS_PREBOOTED" = true ] && [ -n "$IOS_DEVICE" ]; then
+    # xcodebuild tears down its test destination and can shut down a simulator it
+    # did not boot. Re-boot the one we found already running so we leave it as we
+    # found it. simctl boot is a no-op (errors harmlessly) if it is still up.
+    if ! xcrun simctl list devices 2>/dev/null | grep -q "$IOS_DEVICE.*Booted"; then
+      log "  Re-booting simulator xcodebuild shut down ($IOS_DEVICE)."
+      xcrun simctl boot "$IOS_DEVICE" 2>/dev/null || true
+      xcrun simctl bootstatus "$IOS_DEVICE" -b 2>/dev/null || true
+    fi
   fi
 }
 trap cleanup EXIT
@@ -247,13 +257,18 @@ detect_java() {
 # ── iOS simulator detection ───────────────────────────────────────────────────
 # Lists booted simulators; if none, offers to boot one. Sets IOS_DEVICE.
 resolve_ios_simulator() {
-  [ -n "$IOS_DEVICE" ] && return 0
+  if [ -n "$IOS_DEVICE" ]; then
+    # User supplied a device; note if it is already booted so we can restore it.
+    xcrun simctl list devices 2>/dev/null | grep -q "$IOS_DEVICE.*Booted" && WAS_PREBOOTED=true
+    return 0
+  fi
 
   local booted
   booted=$(xcrun simctl list devices available 2>/dev/null \
     | grep 'Booted' | grep -oE '[A-F0-9-]{36}' | head -1)
   if [ -n "$booted" ]; then
     IOS_DEVICE="$booted"
+    WAS_PREBOOTED=true
     log "  Using booted simulator: $IOS_DEVICE"
     return 0
   fi
@@ -392,8 +407,8 @@ if [ $OVERALL_EXIT -eq 0 ]; then
   log "${GREEN}All native unit tests passed.${NC}"
 else
   log "${RED}One or more native unit test runs failed or could not start.${NC}"
-  log "Logs: $LOG_DIR/"
 fi
+log "Logs: $LOG_DIR/"
 log "${CYAN}══════════════════════════════════════════════════════════════════${NC}"
 
 exit $OVERALL_EXIT


### PR DESCRIPTION
## What changed

`play(locator)` rebuilt the media session on every call. Jumping to a chapter from the table of contents or a bookmark while audio was playing opened a second `MediaLibrarySession` with the same default (empty) id. media3 rejects duplicate session ids, and the navigator's error handler then closed the only player, freezing playback at the new chapter's 0:00.

`openSession` now looks at the navigator already backing the live session (`sessionActionFor`) and decides what to do:

- same navigator: reuse the open session and seek
- different navigator: release the old one, then open fresh
- no session yet: open fresh

The facade runs the same check against the binder's own session before rebinding, so a repeated `play(locator)` no longer leaks a session collector.

`next()`/`previous()` and the initial `play(null)` are unchanged.

## Tests

- Unit test for the reuse decision (`PluginMediaServiceReuseTest`)
- Example integration scenario: chapter jump while playing

## Release

Bumps flureadium to 0.13.2 with a changelog entry. `flureadium_platform_interface` is unchanged and stays at 0.7.1. Docs updated: `audiobook-playback.md`, `platform-specific/android.md`.