### PR TITLE
chore: pin platform interface to Flutter 3.44.7, release 0.8.0

### DIFF
--- a/flureadium_platform_interface/CHANGELOG.md
+++ b/flureadium_platform_interface/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.0
+
+### Changed
+
+- Validated against Flutter 3.44.7 (Dart 3.12.2). No code changes; the public API is identical to 0.7.1. Bumped so it releases alongside the flureadium package's Flutter 3.44 update.
+
+---
+
 ## 0.7.1
 
 ### Bug Fixes

--- a/flureadium_platform_interface/README.md
+++ b/flureadium_platform_interface/README.md
@@ -22,6 +22,10 @@ Strongly prefer non-breaking changes (such as adding a method to the interface) 
 
 See https://flutter.dev/go/platform-interface-breaking-changes for a discussion on why a less-clean interface is preferable to a breaking change.
 
+## Development
+
+Developed and tested with **Flutter 3.44.7 (Dart 3.12.2)**. The package `pubspec.yaml` constraints (`sdk: >=3.8.0 <4.0.0`, `flutter: >=3.3.0`) remain the source of truth for supported versions. Contributors may pin the toolchain locally with [fvm](https://fvm.app) (`fvm use 3.44.7`); the fvm files are gitignored and not required.
+
 ## License
 
 LGPL v3 -- see [LICENSE](LICENSE) for details.

--- a/flureadium_platform_interface/pubspec.lock
+++ b/flureadium_platform_interface/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -343,26 +343,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -516,10 +516,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   time:
     dependency: transitive
     description:
@@ -593,5 +593,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/flureadium_platform_interface/pubspec.yaml
+++ b/flureadium_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium_platform_interface
 description: "Platform interface for Flureadium, providing shared models, exceptions, and the abstract FlureadiumPlatform class for EPUB, PDF, and audiobook reading."
-version: 0.7.1
+version: 0.8.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## What

Re-pins the toolchain to Flutter 3.44.7 (Dart 3.12.2) and releases `flureadium_platform_interface` 0.8.0.

## Scope

This is the first step of the Flutter 3.44.7 upgrade across the Flureadium packages: re-pin the shared toolchain and cut the platform-interface release. It touches only package metadata, docs, and the lockfile; no Swift or Dart source changes.

## Changes

- `version` 0.7.1 -> 0.8.0
- CHANGELOG 0.8.0 entry
- README tested-version note -> 3.44.7 / Dart 3.12.2, plus the `fvm use` contributor command
- `pubspec.lock` re-resolved on 3.44.7 (SDK-bundled transitive bumps only)

The package has no Dart 3.12 incompatibilities and its public API is identical to 0.7.1.

## Testing

Full package suite: 481 pass, 1 skip, 0 fail on Flutter 3.44.7 / Dart 3.12.2.

## Context (not addressed here)

The upgrade exists because flureadium's consumers (fablum) fail to build on iOS under Flutter 3.44, where Swift Package Manager (now the default) enforces stricter per-file module imports. That Swift fix is a separate, later change in the `flureadium` package and is not part of this PR.

## Release order

0.8.0 is a breaking (minor, pre-1.0) bump, so publish it to pub.dev before `flureadium` 0.14.0, which moves its constraint from `^0.7.1` to `^0.8.0`. Merge and publish this one first.
