### PR TITLE
flureadium 0.14.0: Flutter 3.44 SwiftPM compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,11 @@ CLAUDE.md
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+
+# FVM Version Cache
+.fvm/
+.fvmrc
+
+# direnv (local — not imposed on contributors)
+.envrc
+.direnv/

--- a/flureadium/.gitignore
+++ b/flureadium/.gitignore
@@ -37,3 +37,14 @@ build/
 
 # Integration test logs
 test_logs/
+
+# FVM Version Cache
+.fvm/
+.fvmrc
+
+# Local IDE settings (fvm SDK path, etc.)
+.vscode/settings.json
+
+# direnv (local — not imposed on contributors)
+.envrc
+.direnv/

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.14.0
+
+### Bug Fixes
+
+- **iOS/macOS Swift Package Manager compile**: several Swift sources used Foundation types (`TimeInterval`, `JSONSerialization`, `Data`, `NSCoder`, and similar) without importing Foundation, relying on it arriving transitively through CocoaPods. Under Flutter 3.44+ (SwiftPM on by default) SwiftPM compiles each module with strict per-file imports, so those files no longer built: `Cannot find type 'TimeInterval' in scope`. Each such source now imports Foundation explicitly. No API or behaviour change; CocoaPods builds were unaffected.
+
+### Testing
+
+- Validated on Flutter 3.44.7 / Dart 3.12.2: the Dart and widget unit tests, the Android Robolectric JVM unit tests, and the example integration suite (`launch`, `epub`, `epub_tts`, `audiobook`, `cbz`, `divina`, `error_handling`, `webpub`) all pass on Android and iOS.
+
 ## 0.13.3
 
 ### Bug Fixes

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -23,8 +23,10 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.11.0
+  flureadium: ^0.14.0
 ```
+
+> Developed and tested with **Flutter 3.44.7 (Dart 3.12.2)**. The `pubspec.yaml` constraints (`sdk: >=3.8.0 <4.0.0`, `flutter: >=3.3.0`) remain the source of truth for supported versions.
 
 ### Platform Setup
 

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ This guide covers setting up Flureadium in your Flutter project for all supporte
 - Flutter 3.3.0 or higher
 - Dart SDK 3.8.0 or higher
 
-> **Contributor note:** this release is developed and tested with Flutter 3.38.9 (Dart 3.10.8). The package `pubspec.yaml` constraints above remain the source of truth for supported versions. Contributors may pin the toolchain locally with [fvm](https://fvm.app) (`fvm use 3.38.9`); the fvm files (`.fvmrc`, `.fvm/`) are gitignored and not required to build.
+> **Contributor note:** this release is developed and tested with Flutter 3.44.7 (Dart 3.12.2). The package `pubspec.yaml` constraints above remain the source of truth for supported versions. Contributors may pin the toolchain locally with [fvm](https://fvm.app) (`fvm use 3.44.7`); the fvm files (`.fvmrc`, `.fvm/`) are gitignored and not required to build.
 
 ## Add Dependency
 
@@ -15,7 +15,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.11.0
+  flureadium: ^0.14.0
 ```
 
 Run:

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -7,6 +7,8 @@ This guide covers setting up Flureadium in your Flutter project for all supporte
 - Flutter 3.3.0 or higher
 - Dart SDK 3.8.0 or higher
 
+> **Contributor note:** this release is developed and tested with Flutter 3.38.9 (Dart 3.10.8). The package `pubspec.yaml` constraints above remain the source of truth for supported versions. Contributors may pin the toolchain locally with [fvm](https://fvm.app) (`fvm use 3.38.9`); the fvm files (`.fvmrc`, `.fvm/`) are gitignored and not required to build.
+
 ## Add Dependency
 
 Add Flureadium to your `pubspec.yaml`:

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,14 +191,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.13.3"
+    version: "0.14.0"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../../flureadium_platform_interface"
       relative: true
     source: path
-    version: "0.7.1"
+    version: "0.8.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/flureadium/ios/flureadium/Sources/flureadium/EdgeTapInterceptView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/EdgeTapInterceptView.swift
@@ -7,6 +7,7 @@
 //  by tapping on the left/right edges of the screen.
 //
 
+import Foundation
 import UIKit
 
 /// View that intercepts edge taps for page navigation when Readium's

--- a/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/FlureadiumPlugin.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Flutter
 import Combine
 import UIKit

--- a/flureadium/ios/flureadium/Sources/flureadium/ImageReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ImageReaderView.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Flutter
 import ReadiumNavigator
 import ReadiumShared

--- a/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/PdfReaderView.swift
@@ -6,6 +6,7 @@
 //  Follows the same pattern as ReadiumReaderView.swift for EPUB.
 //
 
+import Foundation
 import ReadiumNavigator
 import ReadiumShared
 import Flutter

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderChannel.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderChannel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Flutter
 import ReadiumShared
 

--- a/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/ReadiumReaderView.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumNavigator
 import ReadiumAdapterGCDWebServer
 import ReadiumShared

--- a/flureadium/ios/flureadium/Sources/flureadium/model/FlutterAudioPreferences.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/model/FlutterAudioPreferences.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct FlutterAudioPreferences {
   public var volume: Double
 

--- a/flureadium/ios/flureadium/Sources/flureadium/model/FlutterMediaOverlay.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/model/FlutterMediaOverlay.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumShared
 
 struct FlutterMediaOverlay {

--- a/flureadium/ios/flureadium/Sources/flureadium/model/ReadiumTimeBasedState.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/model/ReadiumTimeBasedState.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumShared
 
 public enum TimebasedState: String {

--- a/flureadium/ios/flureadium/Sources/flureadium/navigator/FlutterAudioNavigator.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/navigator/FlutterAudioNavigator.swift
@@ -1,3 +1,4 @@
+import Foundation
 import AVFoundation
 import Combine
 import MediaPlayer

--- a/flureadium/ios/flureadium/Sources/flureadium/navigator/FlutterTTSNavigator.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/navigator/FlutterTTSNavigator.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Combine
 import AVFAudio
 import ReadiumShared

--- a/flureadium/ios/flureadium/Sources/flureadium/navigator/NowPlayingInfoUpdater.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/navigator/NowPlayingInfoUpdater.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Daniel Dam Freiling on 28/10/2025.
 //
+import Foundation
 import Combine
 import ReadiumShared
 import MediaPlayer

--- a/flureadium/ios/flureadium/Sources/flureadium/utils/EventStreamHandler.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/utils/EventStreamHandler.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Flutter
 
 /// A minimal seam over `EventStreamHandler` so event routing (e.g. the plugin's

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.13.3
+version: 0.14.0
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flureadium_platform_interface: ^0.7.1
+  flureadium_platform_interface: ^0.8.0
   rxdart: ^0.28.0
   wakelock_plus: ^1.2.8
   web: ^1.1.1

--- a/flureadium_platform_interface/.gitignore
+++ b/flureadium_platform_interface/.gitignore
@@ -79,3 +79,14 @@ build/
 
 # Freezed
 **/*.freezed.dart
+
+# FVM Version Cache
+.fvm/
+.fvmrc
+
+# Local IDE settings (fvm SDK path, etc.)
+.vscode/settings.json
+
+# direnv (local — not imposed on contributors)
+.envrc
+.direnv/


### PR DESCRIPTION
## What

Makes `flureadium` build and pass on Flutter 3.44.7 / Dart 3.12.2, and cuts the 0.14.0 release.

The blocking change is iOS Swift Package Manager compatibility. Flutter 3.44 turns SPM on by default, and SPM compiles each module with strict per-file imports. Several Swift sources used Foundation types (`TimeInterval`, `JSONSerialization`, `Data`, `NSCoder`, and similar) without importing Foundation; they relied on it arriving transitively through CocoaPods. Under SPM those files no longer built (`Cannot find type 'TimeInterval' in scope`). Each such source now imports Foundation explicitly. No API or behaviour change, and CocoaPods builds were unaffected.

## Changes

- iOS: explicit `import Foundation` in the 13 Swift sources that use Foundation types.
- Release: `flureadium` 0.13.3 to 0.14.0; `flureadium_platform_interface` constraint `^0.7.1` to `^0.8.0`; CHANGELOG 0.14.0 entry.
- Docs: tested-version notes to Flutter 3.44.7 / Dart 3.12.2 (README and installation guide); dependency snippet to `^0.14.0`.
- Tooling: gitignore local fvm and direnv files; contributor note on the fvm toolchain.

## Verification

- Dart and widget unit tests: 209 pass / 3 skip on 3.44.7.
- Android Robolectric JVM tests: 168 pass on the 3.44 toolchain.
- iOS: SPM-enabled compile succeeds with no `Cannot find type` errors; native XCTest passes.
- Example integration suite on Android and iOS: all eight flows pass (launch, epub, epub_tts, audiobook, cbz, divina, error_handling, webpub).

## Release order

`flureadium_platform_interface` 0.8.0 (merged in #50) has to be published to pub.dev before `flureadium` 0.14.0, since the new constraint cannot resolve until 0.8.0 exists.

## Notes

The pre-existing iOS files over 300 LOC (`FlureadiumPlugin`, `ReadiumReaderView`, `PdfReaderView`) got a one-line import addition only. Splitting them is tracked separately in `flureadium-o4i`, `-fc5`, and `-ef8`.
