### PR TITLE
Fix Android Auto discovery + release 0.14.1

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **Android Auto discovery**: `PluginMediaService` now advertises the legacy `android.media.browse.MediaBrowserService` intent-filter action. Android Auto connects as a platform `MediaBrowser` client and finds media apps by scanning for that action, so without it the app never appeared in the Android Auto app list — even though the media3 `MediaLibraryService` and the `com.google.android.gms.car.application` descriptor were already in place. Also removed a non-standard `android.media.session.MediaSessionService` action that was a `browse`/`session` typo. No API or runtime behaviour change: media3's `MediaLibraryService` already bridges to the legacy browser interface, so this only fixes the manifest advertisement.
+- **Now Playing title race (iOS)**: the lock-screen/CarPlay title could briefly revert from "Book - Chapter" to just "Book" when the cover image finished loading. `NowPlayingInfoUpdater` loads the cover on a background task and wrote the artwork into the shared `NowPlayingInfo.Media` value type off the main thread, so it could overwrite a chapter-title update made on the main thread. Cover updates are now delivered on the main thread, serializing them with the title and chapter writes.
 
 ### Testing
 

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.14.1
+
+### Bug Fixes
+
+- **Android Auto discovery**: `PluginMediaService` now advertises the legacy `android.media.browse.MediaBrowserService` intent-filter action. Android Auto connects as a platform `MediaBrowser` client and finds media apps by scanning for that action, so without it the app never appeared in the Android Auto app list — even though the media3 `MediaLibraryService` and the `com.google.android.gms.car.application` descriptor were already in place. Also removed a non-standard `android.media.session.MediaSessionService` action that was a `browse`/`session` typo. No API or runtime behaviour change: media3's `MediaLibraryService` already bridges to the legacy browser interface, so this only fixes the manifest advertisement.
+
+### Testing
+
+- Added `PluginMediaServiceManifestTest` (Android JVM): asserts the shipped source manifest advertises `android.media.browse.MediaBrowserService` and no longer declares the non-standard `android.media.session.MediaSessionService`.
+
 ## 0.14.0
 
 ### Bug Fixes

--- a/flureadium/android/src/main/AndroidManifest.xml
+++ b/flureadium/android/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
             <action android:name="androidx.media3.session.MediaLibraryService"/>
             <action android:name="androidx.media3.session.MediaSessionService"/>
             <action android:name="androidx.media2.session.MediaSessionService"/>
-            <action android:name="android.media.session.MediaSessionService" />
+            <action android:name="android.media.browse.MediaBrowserService" />
         </intent-filter>
     </service>
   </application>

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PluginMediaServiceManifestTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PluginMediaServiceManifestTest.kt
@@ -1,0 +1,38 @@
+package dev.mulev.flureadium
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import java.io.File
+
+/**
+ * Guards the [PluginMediaService] intent-filter contract in the shipped source manifest.
+ *
+ * Android Auto connects as a platform `MediaBrowser` client and enumerates media apps by the
+ * presence of the legacy `android.media.browse.MediaBrowserService` action. Without it the app
+ * is never listed, even though media3's `MediaLibraryService` already bridges to the legacy
+ * `MediaBrowserServiceCompat` interface at runtime. This reads the raw source manifest (not a
+ * merged/Robolectric manifest) so it asserts what actually ships to consumers.
+ */
+internal class PluginMediaServiceManifestTest {
+
+    private val manifest = File("src/main/AndroidManifest.xml").readText()
+
+    @Test
+    fun advertisesLegacyMediaBrowserServiceForAndroidAuto() {
+        assertTrue(
+            manifest.contains("android.media.browse.MediaBrowserService"),
+            "PluginMediaService must advertise android.media.browse.MediaBrowserService " +
+                "so Android Auto can discover it as a browsable media app",
+        )
+    }
+
+    @Test
+    fun dropsNonStandardMediaSessionServiceAction() {
+        assertFalse(
+            manifest.contains("android.media.session.MediaSessionService"),
+            "android.media.session.MediaSessionService is not a real platform action " +
+                "(a browse/session typo) and must not be declared",
+        )
+    }
+}

--- a/flureadium/docs/guides/audiobook-playback.md
+++ b/flureadium/docs/guides/audiobook-playback.md
@@ -636,7 +636,7 @@ Play/pause, skip (next/previous chapter), and seek on the head unit drive the sa
 
 The two platforms differ in what the host does. No Dart API call is involved either way:
 
-- **Android Auto** — nothing to add. The plugin declares the `com.google.android.gms.car.application` meta-data and ships the `automotive_app_desc.xml` descriptor, and Android manifest merging brings them into your app. See [Android platform setup](../platform-specific/android.md#6-android-auto-optional).
+- **Android Auto** — nothing to add. The plugin declares the `com.google.android.gms.car.application` meta-data, ships the `automotive_app_desc.xml` descriptor, and advertises the `android.media.browse.MediaBrowserService` action that Android Auto scans for on its media service; Android manifest merging brings them all into your app. See [Android platform setup](../platform-specific/android.md#6-android-auto-optional).
 - **CarPlay** — add a CarPlay scene to the scene manifest and the `com.apple.developer.carplay-audio` entitlement. The entitlement requires an Apple per-app grant (request lead time applies). See [iOS platform setup](../platform-specific/ios.md#4-carplay-optional).
 
 No Flureadium Dart API changes are needed — the browse tree is built natively from the already-open publication.

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -103,7 +103,7 @@ The descriptor it ships at `res/xml/automotive_app_desc.xml`:
 </automotiveApp>
 ```
 
-The plugin also declares `PluginMediaService` with the `MediaLibraryService` intent filter and `foregroundServiceType="mediaPlayback"`, plus the foreground-service permissions from step 4 (`FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MEDIA_PLAYBACK`) — all merge in too. A host only needs to act if it defines its own `automotive_app_desc.xml` or the same meta-data, in which case the standard manifest-merger conflict rules apply.
+The plugin also declares `PluginMediaService` with an intent filter that advertises both the media3 `MediaLibraryService` action and the legacy `android.media.browse.MediaBrowserService` action that Android Auto scans for when it enumerates media apps, along with `foregroundServiceType="mediaPlayback"` and the foreground-service permissions from step 4 (`FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MEDIA_PLAYBACK`); all of these merge in too. A host only needs to act if it defines its own `automotive_app_desc.xml` or the same meta-data, in which case the standard manifest-merger conflict rules apply.
 
 **Testing with the Desktop Head Unit (DHU):**
 
@@ -112,13 +112,13 @@ The plugin also declares `PluginMediaService` with the `MediaLibraryService` int
 3. Start the head-unit server on the device: `adb forward tcp:5277 tcp:5277`, then run the DHU binary from the SDK (`extras/google/auto/desktop-head-unit`).
 4. Open the audiobook in the app so a publication is loaded, then pick your app from the DHU's media launcher. The chapter list should browse and transport controls (play/pause/skip) should drive playback.
 
-> Android Auto validates the media app before showing it. If the app does not appear, check the merged manifest (in the build output) for the `com.google.android.gms.car.application` meta-data and confirm the media service is exported.
+> Android Auto validates the media app before showing it. If the app does not appear, check the merged manifest (in the build output) for the `com.google.android.gms.car.application` meta-data, confirm the media service is exported, and confirm its intent-filter advertises the `android.media.browse.MediaBrowserService` action Android Auto scans for.
 
 ## Implementation Details
 
 ### Android Auto Browse Tree
 
-`PluginMediaService` runs as a media3 `MediaLibraryService` (not just `MediaSessionService`), which is what Android Auto requires to browse content. `AudiobookBrowseTree` builds the tree the head unit requests:
+`PluginMediaService` runs as a media3 `MediaLibraryService` (not just `MediaSessionService`) and advertises the legacy `android.media.browse.MediaBrowserService` action in its intent filter. Android Auto connects as a platform `MediaBrowser` client, so it needs both: the `MediaLibraryService` to browse content and the legacy browse action to discover the app in the first place. `AudiobookBrowseTree` builds the tree the head unit requests:
 
 - The tree is **one level deep**: a browsable root whose children are the open publication's chapters (its `readingOrder` entries).
 - Each chapter is a playable `MediaItem` whose id (`ch_<index>`) round-trips back to a Readium `Locator` the audiobook navigator can seek to. The index matches the audio player's timeline index, so selecting a chapter on the head unit drives a seek on the same navigator the in-app controls use.

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.14.0"
+    version: "0.14.1"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/ios/flureadium/Sources/flureadium/navigator/NowPlayingInfoUpdater.swift
+++ b/flureadium/ios/flureadium/Sources/flureadium/navigator/NowPlayingInfoUpdater.swift
@@ -55,8 +55,13 @@ public class NowPlayingInfoUpdater {
       chapterCount: publication.readingOrder.count
     )
 
-    // Update the artwork once cover is loaded.
+    // Update the artwork once the cover is loaded. Delivery is confined to the
+    // main thread: the cover load runs on a background Task, and `media` is a
+    // value type, so writing `media?.artwork` off-thread would read-modify-write
+    // the whole struct and could clobber a concurrent title/chapter update made
+    // on the main thread. Hopping to main serializes it with the other mutations.
     $cover
+      .receive(on: DispatchQueue.main)
       .sink { cover in
         nowPlaying.media?.artwork = cover
       }

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.14.0
+version: 0.14.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
Fixes two separate bugs and cuts release 0.14.1.

## Android Auto discovery (the main fix)

The plugin's media service only advertised the media3 `MediaLibraryService` intent-filter action. Android Auto finds browsable media apps by scanning for the legacy `android.media.browse.MediaBrowserService` action, which the manifest never declared, so apps built on the plugin never showed up in the Android Auto app list. This adds the browse action to the `PluginMediaService` intent-filter and removes a non-standard `android.media.session.MediaSessionService` entry that was a typo. `MediaLibraryService` already bridges to the legacy browser interface at runtime, so this is a manifest-only change with no API or behaviour difference.

There's a new Android JVM test, `PluginMediaServiceManifestTest`, that reads the shipped manifest and asserts the browse action is present and the bogus session action is gone.

## Now Playing title race (iOS)

This one surfaced while running the native suite for the change above. `NowPlayingInfoUpdater` loaded the cover image on a background task and wrote it into `NowPlayingInfo.shared.media` (a value struct) off the main thread, so it could overwrite a chapter-title update made on the main thread and briefly flip the lock-screen/CarPlay title from "Book - Chapter" back to "Book". The cover sink now delivers on the main thread. Every other writer of that struct already runs on the main actor (the Readium audio and TTS delegates are both `@MainActor`), so all writes to it now happen on the main thread.

## Docs and release

- `docs/platform-specific/android.md` and `docs/guides/audiobook-playback.md`: corrected the Android Auto sections to mention the browse action.
- CHANGELOG: 0.14.1 entry covering both fixes.
- Version bumped 0.14.0 to 0.14.1.

## Verification

- Android JVM unit tests pass, including the new manifest test.
- `flutter test`: 209 passed, 3 skipped.
- iOS: I couldn't build or run the simulator in this environment, so the Now Playing fix isn't machine-verified yet. It needs a green `RunnerTests` run before 0.14.1 is published.
