### PR TITLE
Let an audiobook host the Android reader widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.16.1
+  flureadium: ^0.16.2
 ```
 
 Then follow the platform-specific setup below. For full details, see the [Installation Guide](flureadium/docs/getting-started/installation.md).

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 0.16.2
+
+### Bug Fixes
+
+- **Android reader widget hosts an audiobook instead of killing the app**: mounting `ReadiumReaderWidget` over an audiobook took the process down with `FATAL EXCEPTION: Publication is not an EPUB, cannot enable epub navigator`. `PublicationReaderKind` had three members (`EPUB`, `PDF`, `IMAGE`) and used `EPUB` as its catch-all, so an audiobook was classified as an EPUB, the widget had no audio-only host to dispatch to, and `epubEnable`'s own conformance guard then rejected the publication the classifier had handed it. The throw happened in a coroutine with no supervisor, so it killed the process rather than surfacing on the error channel. There is now an `AUDIO` kind, matched by `conformsTo(Publication.Profile.AUDIOBOOK)` and checked after PDF and image so the existing precedence and the media-overlay EPUB path are untouched, and the widget mounts an audiobook with no visual navigator at all. A host app can open an audiobook as the reader's first publication, which previously required booting an EPUB and swapping.
+- **Android reader status reaches a subscriber that arrives late**: `ReadiumReaderWidget.init` runs inside the platform-view `create` call, so the statuses it sends leave native before Flutter replies to Dart and before a host app can subscribe from `ReadiumReaderWidget.onReady`. `ReaderStatusEventChannel.sendEvent` wrote to an `eventSink` that only exists once Dart has subscribed, so those statuses went nowhere. EPUB, PDF, and image hosts were unaffected in practice, because their `"ready"` arrives later from `onVisualReaderIsReady()`; an audio host has no later source, so a host app that hides its spinner on `ready` would have waited forever. The channel now holds the most recent status while nobody is listening and delivers it when the first subscriber arrives. Only the latest is held, since status is a state rather than a log, and a status already delivered is never replayed to a later subscriber.
+- **Android reader kind is fixed for the widget's lifetime**: the widget derived its kind from `ReadiumReader.currentPublication` on every access, so opening a publication of another kind under a live platform view could flip the kind, send `dispose()` down the wrong teardown path, and leak the navigator and the is-ready channel the widget had actually enabled. The kind is now captured when the platform view is created. An audio host's `dispose()` also clears `ReadiumReader.currentReaderWidget` only while it is still the registered widget, so a stale teardown cannot wipe a newer widget's registration.
+
+### Documentation
+
+- **Android reader kinds written down**: `docs/platform-specific/android.md` gains a `Reader Kind` section covering the PDF, image, audio, and EPUB precedence and what each kind mounts, and states the reader-status lifecycle including the statuses held for a late first subscriber. `docs/api-reference/streams-events.md` records the same subscription timing next to `onReaderStatusChanged` and no longer claims Android's `ready` comes only from `onVisualReaderIsReady()`.
+- **Audiobook integration-test boot corrected**: `docs/05-testing/integration-tests.md` said an audiobook has to ride on a host EPUB. It now describes the direct boot, scopes the audio-only host to Android (iOS resolves an audiobook to its EPUB reader view and builds a navigator that renders nothing), and says why the audiobook group keeps `openAfterColdBoot` and which runs actually exercise the cold boot.
+
+### Testing
+
+- Android JVM (Robolectric): an audio-only publication mounts the widget with no EPUB navigator machinery, reports `loading` then `ready`, clears its own registration on dispose, and leaves a newer widget's registration alone.
+- Android JVM: `PublicationReaderKind` classifies an audiobook as `AUDIO`, and PDF, DIVINA, bitmap, and media-overlay EPUB publications keep their previous kinds.
+- Android JVM: `ReaderStatusEventChannel` delivers a status sent before the first subscriber, keeps only the latest while unsubscribed, delivers directly while subscribed, and does not replay to a second subscriber.
+- The audiobook integration group boots `assets/pubs/38533.audiobook` directly rather than booting `moby_dick.epub` and opening the audiobook over it, which drops an EPUB load and navigator mount from every run and exercises the fix end to end. Its end-of-book test reuses the publication the group already loaded instead of extracting and parsing the manifest a second time.
+- The audiobook and CBZ suites share one `extractAsset` helper instead of a private copy each, and it now gives every call its own temp directory: the old name was the current millisecond, so two extractions inside one millisecond returned the same path and the second write truncated the file the first caller had opened. `example/test/extract_asset_test.dart` covers both guarantees.
+
 ## 0.16.1
 
 ### Bug Fixes

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -23,7 +23,7 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.16.1
+  flureadium: ^0.16.2
 ```
 
 > Developed and tested with **Flutter 3.44.7 (Dart 3.12.2)**. The `pubspec.yaml` constraints (`sdk: >=3.8.0 <4.0.0`, `flutter: >=3.3.0`) remain the source of truth for supported versions.

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationReaderKind.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/PublicationReaderKind.kt
@@ -8,6 +8,7 @@ internal enum class PublicationReaderKind {
     EPUB,
     PDF,
     IMAGE,
+    AUDIO,
 }
 
 @OptIn(ExperimentalReadiumApi::class)
@@ -21,6 +22,14 @@ internal fun Publication.readerKind(): PublicationReaderKind {
             (readingOrder.isNotEmpty() && readingOrder.all { it.mediaType?.isBitmap == true })
     if (isImagePublication) {
         return PublicationReaderKind.IMAGE
+    }
+
+    // Checked last, so PDF and image precedence is untouched. readium defines
+    // conformsTo(AUDIOBOOK) as readingOrder.allAreAudio behind a non-empty
+    // guard, so a media-overlay EPUB — an all-HTML reading order — is not
+    // captured here and keeps both its EPUB navigator and the karaoke path.
+    if (conformsTo(Publication.Profile.AUDIOBOOK)) {
+        return PublicationReaderKind.AUDIO
     }
 
     return PublicationReaderKind.EPUB

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReaderWidget.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReaderWidget.kt
@@ -59,17 +59,18 @@ class ReadiumReaderWidget(
     private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    private val readerKind: PublicationReaderKind
-        get() = ReadiumReader.currentPublication?.readerKind() ?: PublicationReaderKind.EPUB
+    // Fixed for this widget's lifetime. As a getter over the mutable
+    // ReadiumReader.currentPublication, a publication swap under a live
+    // platform view would flip this widget's kind and send dispose() down the
+    // wrong teardown path — leaking the navigator and is-ready channel it
+    // actually enabled.
+    private val readerKind: PublicationReaderKind =
+        ReadiumReader.currentPublication?.readerKind() ?: PublicationReaderKind.EPUB
 
-    private val isPdf: Boolean
-        get() = readerKind == PublicationReaderKind.PDF
-
-    private val isImage: Boolean
-        get() = readerKind == PublicationReaderKind.IMAGE
-
-    private val isEpub: Boolean
-        get() = readerKind == PublicationReaderKind.EPUB
+    private val isPdf: Boolean = readerKind == PublicationReaderKind.PDF
+    private val isImage: Boolean = readerKind == PublicationReaderKind.IMAGE
+    private val isAudio: Boolean = readerKind == PublicationReaderKind.AUDIO
+    private val isEpub: Boolean = readerKind == PublicationReaderKind.EPUB
 
     private var storedNavigationConfig: FlutterNavigationConfig? = null
 
@@ -80,18 +81,26 @@ class ReadiumReaderWidget(
 
     override fun dispose() {
         Log.d(TAG, "::dispose")
-        // Only send "closed" if this is still the active widget.
         // When Flutter recreates the widget tree (e.g. between integration
         // tests), the OLD platform view disposes asynchronously — after the
-        // NEW widget has already registered its event listener. Without this
-        // guard the stale "closed" event would clobber the new widget's state.
-        if (ReadiumReader.currentReaderWidget === this) {
+        // NEW widget has already registered itself. This guard covers the
+        // "closed" event and the audio teardown below; pdfClose(), imageClose()
+        // and epubClose() still clear currentReaderWidget unconditionally,
+        // which is tracked separately.
+        val isActiveWidget = ReadiumReader.currentReaderWidget === this
+        if (isActiveWidget) {
             ReadiumReader.sendReaderStatus("closed")
         }
         if (isPdf) {
             ReadiumReader.pdfClose()
         } else if (isImage) {
             ReadiumReader.imageClose()
+        } else if (isAudio) {
+            // No navigator and no is-ready channel were enabled, so this
+            // widget's registration is the only thing it owns.
+            if (isActiveWidget) {
+                ReadiumReader.currentReaderWidget = null
+            }
         } else {
             ReadiumReader.epubClose()
         }
@@ -181,6 +190,15 @@ class ReadiumReaderWidget(
                     layout,
                     this@ReadiumReaderWidget,
                 )
+            } else if (isAudio) {
+                // An audio-only publication has no visual navigator to enable.
+                // The widget is a live but empty host, so nothing else will
+                // report readiness — onVisualReaderIsReady() never fires
+                // without a navigator. Reuse the existing "ready" status:
+                // method_channel_flureadium.dart:80 maps statuses with
+                // firstWhere and no orElse, so an unknown string would throw
+                // StateError in every host app.
+                ReadiumReader.sendReaderStatus("ready")
             } else {
                 ReadiumReader.epubEnable(
                     initialLocator,
@@ -378,12 +396,7 @@ class ReadiumReaderWidget(
                 ReadiumReader.sendTextLocatorEvent(finalLocator)
             }
         } catch (e: Exception) {
-            val readerKindLabel = when {
-                isPdf -> "PDF"
-                isImage -> "IMAGE"
-                else -> "EPUB"
-            }
-            Log.e(TAG, "emitOnPageChanged: $readerKindLabel failed! $e")
+            Log.e(TAG, "emitOnPageChanged: ${readerKind.name} failed! $e")
         }
     }
 

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/events/ReaderStatusEventChannel.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/events/ReaderStatusEventChannel.kt
@@ -1,13 +1,37 @@
 package dev.mulev.flureadium.events
 
 import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
 import kotlinx.coroutines.launch
 
 class ReaderStatusEventChannel(messenger: BinaryMessenger) :
     EventChannelWrapper<String>(messenger, "dev.mulev.flureadium/reader-status") {
+
+    // ReadiumReaderWidget.init reports "loading", and an audio-only host also
+    // reports "ready", while the platform view is still being created — before
+    // Flutter replies to Dart, so before a host app can subscribe from
+    // ReadiumReaderWidget.onReady. Sending straight into a null sink would drop
+    // the first widget's whole status sequence, leaving a host that waits for
+    // "ready" waiting forever. Only the latest pending status is kept: status
+    // is a state, not a log, and nothing may accumulate while no one listens.
+    private var pendingStatus: String? = null
+
     override fun sendEvent(data: String) {
         mainScope.launch {
-            eventSink?.success(data)
+            val sink = eventSink
+            if (sink == null) {
+                pendingStatus = data
+            } else {
+                sink.success(data)
+            }
+        }
+    }
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        super.onListen(arguments, events)
+        pendingStatus?.let { status ->
+            pendingStatus = null
+            events?.success(status)
         }
     }
 }

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PublicationReaderKindTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/PublicationReaderKindTest.kt
@@ -120,14 +120,68 @@ internal class PublicationReaderKindTest {
         assertEquals(PublicationReaderKind.EPUB, publication.readerKind())
     }
 
+    @Test
+    fun `returns audio for audiobook publications`() {
+        val publication = publicationWith(
+            conformsToPdf = false,
+            conformsToDivina = false,
+            readingOrder = listOf(
+                linkWithMediaType("audio/mpeg"),
+                linkWithMediaType("audio/mpeg"),
+            ),
+            conformsToAudiobook = true
+        )
+
+        assertEquals(PublicationReaderKind.AUDIO, publication.readerKind())
+    }
+
+    @Test
+    fun `returns pdf when publication matches both pdf and audiobook profiles`() {
+        val publication = publicationWith(
+            conformsToPdf = true,
+            conformsToDivina = false,
+            readingOrder = listOf(linkWithMediaType("audio/mpeg")),
+            conformsToAudiobook = true
+        )
+
+        assertEquals(PublicationReaderKind.PDF, publication.readerKind())
+    }
+
+    @Test
+    fun `returns image when publication matches both divina and audiobook profiles`() {
+        val publication = publicationWith(
+            conformsToPdf = false,
+            conformsToDivina = true,
+            readingOrder = listOf(linkWithMediaType("audio/mpeg")),
+            conformsToAudiobook = true
+        )
+
+        assertEquals(PublicationReaderKind.IMAGE, publication.readerKind())
+    }
+
+    @Test
+    fun `returns epub when publication does not conform to audiobook profile`() {
+        val publication = publicationWith(
+            conformsToPdf = false,
+            conformsToDivina = false,
+            readingOrder = listOf(linkWithMediaType("audio/mpeg")),
+            conformsToAudiobook = false
+        )
+
+        assertEquals(PublicationReaderKind.EPUB, publication.readerKind())
+    }
+
     private fun publicationWith(
         conformsToPdf: Boolean,
         conformsToDivina: Boolean,
         readingOrder: List<Link>,
+        conformsToAudiobook: Boolean = false,
     ): Publication {
         val publication = mock<Publication>()
         `when`(publication.conformsTo(Publication.Profile.PDF)).thenReturn(conformsToPdf)
         `when`(publication.conformsTo(Publication.Profile.DIVINA)).thenReturn(conformsToDivina)
+        `when`(publication.conformsTo(Publication.Profile.AUDIOBOOK))
+            .thenReturn(conformsToAudiobook)
         `when`(publication.readingOrder).thenReturn(readingOrder)
         return publication
     }

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/ReadiumReaderWidgetAudioHostTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/ReadiumReaderWidgetAudioHostTest.kt
@@ -1,0 +1,150 @@
+package dev.mulev.flureadium
+
+import android.content.ContextWrapper
+import android.os.Build
+import androidx.fragment.app.FragmentActivity
+import dev.mulev.flureadium.events.ReaderStatusEventChannel
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Publication
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+/**
+ * Tests that an audio-only publication can host the reader widget: the widget
+ * mounts with no visual navigator, and its teardown releases only what it
+ * registered.
+ *
+ * Uses reflection to set private fields on the ReadiumReader singleton, the
+ * same harness as ReadiumReaderSamePubCacheTest. Dispatchers.setMain with an
+ * unconfined test dispatcher makes the widget's init coroutine run inline
+ * during construction, so both assertions hold as soon as the constructor
+ * returns.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], manifest = Config.NONE)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalReadiumApi::class)
+internal class ReadiumReaderWidgetAudioHostTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        resetReaderState()
+        setReaderField("_currentPublication", audiobookPublication())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        resetReaderState()
+    }
+
+    private fun resetReaderState() {
+        setReaderField("_currentPublication", null)
+        setReaderField("isReadyEventChannel", null)
+        setReaderField("readerStatusEventChannel", null)
+        ReadiumReader.currentReaderWidget = null
+    }
+
+    @Test
+    fun audioHostDoesNotSetUpEpubNavigatorMachinery() {
+        buildAudioHostWidget()
+
+        assertNull(getReaderField("isReadyEventChannel"))
+    }
+
+    @Test
+    fun audioHostDisposeKeepsNewerWidgetRegistration() {
+        val audioWidget = buildAudioHostWidget()
+        val newerWidget = mock(ReadiumReaderWidget::class.java)
+        ReadiumReader.currentReaderWidget = newerWidget
+
+        audioWidget.dispose()
+
+        assertSame(newerWidget, ReadiumReader.currentReaderWidget)
+    }
+
+    @Test
+    fun audioHostReportsLoadingThenReady() {
+        val statuses = subscribeToReaderStatus()
+
+        buildAudioHostWidget()
+
+        assertEquals(listOf("loading", "ready"), statuses)
+    }
+
+    @Test
+    fun activeAudioHostDisposeClearsItsRegistration() {
+        val audioWidget = buildAudioHostWidget()
+
+        audioWidget.dispose()
+
+        assertNull(ReadiumReader.currentReaderWidget)
+    }
+
+    /** Attaches a listener to the reader-status channel and records what it receives. */
+    private fun subscribeToReaderStatus(): List<String> {
+        val received = mutableListOf<String>()
+        val channel = ReaderStatusEventChannel(mock(BinaryMessenger::class.java))
+        setReaderField("readerStatusEventChannel", channel)
+        channel.onListen(
+            null,
+            object : EventChannel.EventSink {
+                override fun success(event: Any?) {
+                    received.add(event as String)
+                }
+
+                override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) = Unit
+
+                override fun endOfStream() = Unit
+            }
+        )
+        return received
+    }
+
+    private fun buildAudioHostWidget(): ReadiumReaderWidget {
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).setup().get()
+        return ReadiumReaderWidget(
+            ContextWrapper(activity),
+            1,
+            emptyMap(),
+            mock(BinaryMessenger::class.java)
+        )
+    }
+
+    private fun audiobookPublication(): Publication {
+        val publication = mock(Publication::class.java)
+        `when`(publication.conformsTo(Publication.Profile.AUDIOBOOK)).thenReturn(true)
+        return publication
+    }
+
+    private fun setReaderField(name: String, value: Any?) {
+        val field = ReadiumReader::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(ReadiumReader, value)
+    }
+
+    private fun getReaderField(name: String): Any? {
+        val field = ReadiumReader::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(ReadiumReader)
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/events/ReaderStatusEventChannelTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/events/ReaderStatusEventChannelTest.kt
@@ -1,0 +1,97 @@
+package dev.mulev.flureadium.events
+
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.mockito.Mockito.mock
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests that a status sent before Flutter subscribes is still delivered.
+ *
+ * The reader widget reports "loading" — and an audio-only host reports
+ * "ready" — while the platform view is being created, which is before Flutter
+ * replies to Dart and therefore before a host app can subscribe from onReady.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ReaderStatusEventChannelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun deliversStatusSentBeforeTheFirstSubscriber() {
+        val channel = ReaderStatusEventChannel(mock(BinaryMessenger::class.java))
+        val sink = RecordingSink()
+
+        channel.sendEvent("ready")
+        channel.onListen(null, sink)
+
+        assertEquals(listOf("ready"), sink.events)
+    }
+
+    @Test
+    fun keepsOnlyTheLatestStatusForTheFirstSubscriber() {
+        val channel = ReaderStatusEventChannel(mock(BinaryMessenger::class.java))
+        val sink = RecordingSink()
+
+        channel.sendEvent("loading")
+        channel.sendEvent("ready")
+        channel.onListen(null, sink)
+
+        assertEquals(listOf("ready"), sink.events)
+    }
+
+    @Test
+    fun deliversStatusDirectlyWhileSubscribed() {
+        val channel = ReaderStatusEventChannel(mock(BinaryMessenger::class.java))
+        val sink = RecordingSink()
+        channel.onListen(null, sink)
+
+        channel.sendEvent("loading")
+        channel.sendEvent("ready")
+
+        assertEquals(listOf("loading", "ready"), sink.events)
+    }
+
+    @Test
+    fun doesNotReplayADeliveredStatusToALaterSubscriber() {
+        val channel = ReaderStatusEventChannel(mock(BinaryMessenger::class.java))
+        val firstSink = RecordingSink()
+        channel.onListen(null, firstSink)
+        channel.sendEvent("ready")
+
+        val secondSink = RecordingSink()
+        channel.onListen(null, secondSink)
+
+        assertEquals(emptyList(), secondSink.events)
+    }
+
+    private class RecordingSink : EventChannel.EventSink {
+        val events = mutableListOf<String>()
+
+        override fun success(event: Any?) {
+            events.add(event as String)
+        }
+
+        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) = Unit
+
+        override fun endOfStream() = Unit
+    }
+}

--- a/flureadium/docs/05-testing/integration-tests.md
+++ b/flureadium/docs/05-testing/integration-tests.md
@@ -102,24 +102,19 @@ Conventions:
 ## Jumping to the last track instead of skipping to it
 
 The end-of-book audiobook test needs the last reading-order track. Stepping there
-with repeated `Audio Next Chapter` taps cost one poll per track. Load the manifest
-and jump straight to the end instead:
+with repeated `Audio Next Chapter` taps cost one poll per track. Take the last
+link from the reading order and jump straight to it instead:
 
 ```dart
-final path = await _extractAsset('assets/pubs/38533.audiobook');
-final pub = await Flureadium().loadPublication(path);
-await Flureadium().goByLink(pub.readingOrder.last, pub);
+await Flureadium().goByLink(audiobookPub.readingOrder.last, audiobookPub);
 ```
 
-`loadPublication` only parses the manifest, so it is cheap; `goByLink` is the same
-navigation the app performs. The near-end seek and natural play-out that follow
-stay as they are — that tail is real audio time and is the point of the test.
-
-Note the audiobook is still opened through the button flow (boot the default EPUB,
-tap `Open AudioBook`), not a direct `initialAsset` boot. On Android the reader
-widget hosts a visual navigator and an audiobook has none, so it must ride on an
-EPUB host; audio plays on top. CBZ and DIVINA are image publications with their own
-navigator, so those groups can and do boot directly via `initialAsset`.
+`audiobookPub` is the publication the group already loaded in `setUpAll` through
+the shared `extractAsset` helper. `goByLink` resolves the link against that
+manifest and navigates — it never reopens the publication it is handed, so the
+book the test is listening to is untouched. The near-end seek and natural play-out
+that follow stay as they are: that tail is real audio time and is the point of the
+test.
 
 ## Sharing one app boot across a group with `ensureAppShowing`
 
@@ -170,18 +165,22 @@ Conventions:
   TTS, audio, `ended-seen`, and the audio-error latch in its `setState`, so a
   reopen gives each test a clean slate.
 
-### Audiobooks: boot a host EPUB, then open the audiobook
+### Audiobooks: boot the audiobook directly
 
-An audiobook has no visual navigator, so on Android it cannot be a direct
-`initialAsset` boot — it rides on an EPUB host. `ensureAppShowing` takes
-`openAfterColdBoot` for this: the group cold-boots the host EPUB and then taps
-the audiobook's `Open …` button, so both the cold-boot and reuse paths finish on
-a freshly opened audiobook.
+An audiobook mounts the reader widget as an audio-only host: no visual navigator
+is enabled, and the widget reports itself ready on its own. It is therefore an
+ordinary `initialAsset` boot on both platforms, so the audiobook group cold-boots
+the audiobook itself.
+
+The group still passes `openAfterColdBoot`, for a different reason than before:
+its tests open four publications through four buttons, and the flag makes the
+cold-boot path tap the button too, so whichever test runs first gets the
+publication it asked for.
 
 ```dart
 await ensureAppShowing(
   tester,
-  initialAsset: 'assets/pubs/moby_dick.epub',
+  initialAsset: 'assets/pubs/38533.audiobook',
   reopenButton: 'Open AudioBook',
   openAfterColdBoot: true,
 );

--- a/flureadium/docs/05-testing/integration-tests.md
+++ b/flureadium/docs/05-testing/integration-tests.md
@@ -167,13 +167,17 @@ Conventions:
 
 ### Audiobooks: boot the audiobook directly
 
-An audiobook mounts the reader widget as an audio-only host: no visual navigator
-is enabled, and the widget reports itself ready on its own. It is therefore an
-ordinary `initialAsset` boot on both platforms, so the audiobook group cold-boots
-the audiobook itself.
+On Android an audiobook mounts the reader widget as an audio-only host: no visual
+navigator is enabled, and the widget reports itself ready on its own, so it is an
+ordinary `initialAsset` boot. The audiobook group cold-boots the audiobook itself
+on both platforms — iOS has no audio reader kind yet, so `ReaderViewKind` resolves
+an audiobook to `.epub` and builds a content-less EPUB navigator over the audio
+tracks. That navigator does not crash and nothing renders through it either way,
+which is why iOS survives the direct boot; giving iOS the same audio-only host is
+`flureadium-5wu`.
 
 The group still passes `openAfterColdBoot`, for a different reason than before:
-its tests open four publications through four buttons, and the flag makes the
+its tests open five publications through five buttons, and the flag makes the
 cold-boot path tap the button too, so whichever test runs first gets the
 publication it asked for.
 
@@ -187,8 +191,14 @@ await ensureAppShowing(
 ```
 
 The audiobook group wraps this in a local `showAudiobook(tester, button: …)` so
-variant tests (`Open AudioBook NoTitle`/`BadUrl`/`BadStream`) reuse the same boot
-path and just pass their own button.
+variant tests (`Open AudioBook NoTitle`/`Streamed`/`BadUrl`/`BadStream`) reuse the
+same boot path and just pass their own button.
+
+The cold-boot arm only runs when the app is not already on screen, so the direct
+boot happens in a standalone `flutter test integration_test/audiobook_test.dart`
+run. In `all_tests.dart` the launch group boots first and the audiobook group
+takes the reuse path, and `all_tests_android_ci.dart` leaves the group out
+altogether — neither CI bundle exercises the audiobook boot (`flureadium-p1q`).
 
 This is applied to all four group test files (`audiobook`, `cbz`, `divina`,
 `epub_tts`) — each boots once per group and reuses the running app between tests.

--- a/flureadium/docs/api-reference/streams-events.md
+++ b/flureadium/docs/api-reference/streams-events.md
@@ -209,10 +209,17 @@ enum ReadiumReaderStatus {
 | Status | Android | iOS |
 |--------|---------|-----|
 | `loading` | Emitted from `ReadiumReaderWidget.init` | Emitted from `ReadiumReaderView.init` |
-| `ready` | Emitted from `onVisualReaderIsReady()` | Emitted from first `locationDidChange` |
+| `ready` | Emitted from `onVisualReaderIsReady()`, or from `ReadiumReaderWidget.init` for an audiobook, which has no visual navigator to signal it | Emitted from first `locationDidChange` |
 | `closed` | Emitted from `ReadiumReaderWidget.dispose()` | Emitted on publication close |
 | `error` | Not currently emitted natively | Emitted from `didFailToLoadResourceAt` |
 | `reachedEndOfPublication` | Not emitted natively (Dart-side only) | Not emitted natively (Dart-side only) |
+
+On Android the widget's `init` runs inside the platform-view `create` call, which
+finishes before Flutter replies to Dart. A `loading`, and the `ready` an audiobook
+sends from `init`, therefore leave native before any Dart subscriber can exist, so
+the native side holds the most recent status and delivers it when the first
+subscriber arrives. Only the latest is held: status is a state rather than a log,
+and a status already delivered is never replayed to a later subscriber.
 
 See [Android platform docs](../platform-specific/android.md#event-channels) for implementation details.
 

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -15,7 +15,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.16.1
+  flureadium: ^0.16.2
 ```
 
 Run:

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -200,8 +200,40 @@ state events.
 
 Reader status lifecycle:
 - `"loading"` — emitted from `ReadiumReaderWidget.init` when the native view is created
-- `"ready"` — emitted from `onVisualReaderIsReady()` when Readium signals the reader is ready
+- `"ready"` — emitted from `onVisualReaderIsReady()` when Readium signals the reader is ready, or directly from `ReadiumReaderWidget.init` for an audio-only publication, which has no visual navigator to signal it
 - `"closed"` — emitted from `ReadiumReaderWidget.dispose()` before tearing down the navigator
+
+`ReadiumReaderWidget.init` runs inside the platform-view `create` call, which
+finishes before Flutter replies to Dart — so `"loading"`, and the `"ready"` an
+audio-only host sends from the same place, are emitted before a host app can
+subscribe from `onReady`. `ReaderStatusEventChannel` holds the most recent
+status while no one is listening and delivers it once, when the first
+subscriber arrives. Only the latest one is held: reader status is a state, not
+a log, and a status already delivered is never replayed to a later subscriber.
+
+### Reader Kind
+
+`PublicationReaderKind` decides which reader can host an open publication, and
+`ReadiumReaderWidget` freezes that decision when the platform view is created.
+Classification comes from Readium's own profile checks, in this order:
+
+| Kind | Matched when | What the widget mounts |
+|---|---|---|
+| `PDF` | `conformsTo(Profile.PDF)` | Pdfium navigator |
+| `IMAGE` | `conformsTo(Profile.DIVINA)`, or every reading-order item is a bitmap | Image navigator |
+| `AUDIO` | `conformsTo(Profile.AUDIOBOOK)` | Nothing — no visual navigator exists for audio |
+| `EPUB` | Everything else | EPUB navigator |
+
+`EPUB` is the fallback, so anything with an HTML reading order lands there —
+including a media-overlay ("karaoke") book, whose reading order is HTML rather
+than audio. Those keep their EPUB navigator and their existing audio path.
+
+An `AUDIO` host is a live but empty platform view: it registers itself, emits
+`"ready"` straight from `init`, and enables no navigator. The visual reader
+operations still answer, with their inert defaults — `isLocatorVisible` returns
+`false`, `isReaderReady` returns `true`, `getLocatorFragments` echoes the
+locator it was given, and preference or navigation calls are no-ops. Playback
+itself runs through the audio navigator and the media session, not the widget.
 
 ### Platform View
 
@@ -221,7 +253,7 @@ class ReadiumReaderViewFactory(
 
 Uses Readium Kotlin Toolkit:
 - `Streamer` for EPUB parsing
-- `Navigator` for EPUB, PDF, and image-based content display
+- `Navigator` for EPUB, PDF, and image-based content display; an audiobook gets no visual navigator
 - `TTS` and `MediaPlayer` for audio
 - `PdfiumNavigator` for PDF rendering (via Pdfium adapter)
 

--- a/flureadium/example/integration_test/audiobook_test.dart
+++ b/flureadium/example/integration_test/audiobook_test.dart
@@ -3,14 +3,14 @@ library;
 
 import 'dart:io';
 
-import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flureadium/flureadium.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'helpers/audiobook_track.dart';
 import 'helpers/ensure_app_showing.dart';
+import 'helpers/extract_asset.dart';
 import 'helpers/pump_until.dart';
 
 void main() {
@@ -56,18 +56,23 @@ void main() {
               '')
           .contains('true');
 
-  // Boots (or reuses) the app and opens the wanted audiobook. On Android the
-  // reader widget must host an EPUB, so an audiobook cannot be a direct
-  // initialAsset boot: the group cold-boots the host EPUB and then opens the
-  // audiobook via [button]. openAfterColdBoot makes the cold-boot path tap
-  // [button] too, so both cold and reuse calls end on a freshly opened
-  // audiobook — its open-generation bump being the observable "loaded" signal.
+  // Both the cold boot and the group's manifest load must name the same file,
+  // or the baseline track and the last-track jump would point at a different
+  // book than the one on screen.
+  const audiobookAsset = 'assets/pubs/38533.audiobook';
+
+  // Boots (or reuses) the app and opens the wanted audiobook. The audiobook is
+  // the cold-boot publication now that the Android reader widget can host one
+  // (flureadium-3wd). openAfterColdBoot keeps the cold-boot path tapping
+  // [button] as well, so a variant test (NoTitle/BadUrl/BadStream) still gets
+  // its own publication when it happens to run first — the open-generation bump
+  // being the observable "loaded" signal either way.
   Future<void> showAudiobook(
     WidgetTester tester, {
     String button = 'Open AudioBook',
   }) => ensureAppShowing(
     tester,
-    initialAsset: 'assets/pubs/moby_dick.epub',
+    initialAsset: audiobookAsset,
     reopenButton: button,
     openAfterColdBoot: true,
   );
@@ -90,7 +95,7 @@ void main() {
     late final String firstTrack;
 
     setUpAll(() async {
-      final path = await _extractAsset('assets/pubs/38533.audiobook');
+      final path = await extractAsset(audiobookAsset);
       audiobookPub = await Flureadium().loadPublication(path);
       firstTrack = audiobookPub.readingOrder.first.href;
     });
@@ -310,14 +315,10 @@ void main() {
       await waitForPlaying(tester);
 
       // Jump straight to the last reading-order track instead of skipping
-      // track by track. goByLink is the same navigation the app performs;
-      // loading the manifest separately just gets the reading order so we can
-      // pick the last link. The audiobook stays opened through showAudiobook
-      // above — on Android the reader widget must host an EPUB, so an audiobook
-      // cannot be a direct initialAsset boot.
-      final path = await _extractAsset('assets/pubs/38533.audiobook');
-      final pub = await Flureadium().loadPublication(path);
-      await Flureadium().goByLink(pub.readingOrder.last, pub);
+      // track by track. goByLink is the same navigation the app performs, and
+      // the group's already-loaded publication supplies the reading order —
+      // locatorFromLink is pure manifest arithmetic, so no reload is needed.
+      await Flureadium().goByLink(audiobookPub.readingOrder.last, audiobookPub);
 
       // Wait for the last track's duration to be reported.
       await pumpUntil(
@@ -481,17 +482,4 @@ void main() {
       skip: !Platform.isIOS,
     );
   });
-}
-
-// Extracts a bundled asset to a temp file so loadPublication can read the
-// manifest to pick the last reading-order track. Mirrors the app's own
-// _extractAsset and cbz_test's copy.
-Future<String> _extractAsset(String assetPath) async {
-  final bytes = await rootBundle.load(assetPath);
-  final filename = assetPath.split('/').last;
-  final tmp = File(
-    '${Directory.systemTemp.path}/${DateTime.now().millisecondsSinceEpoch}_$filename',
-  );
-  await tmp.writeAsBytes(bytes.buffer.asUint8List());
-  return tmp.path;
 }

--- a/flureadium/example/integration_test/audiobook_test.dart
+++ b/flureadium/example/integration_test/audiobook_test.dart
@@ -63,10 +63,12 @@ void main() {
 
   // Boots (or reuses) the app and opens the wanted audiobook. The audiobook is
   // the cold-boot publication now that the Android reader widget can host one
-  // (flureadium-3wd). openAfterColdBoot keeps the cold-boot path tapping
-  // [button] as well, so a variant test (NoTitle/BadUrl/BadStream) still gets
-  // its own publication when it happens to run first — the open-generation bump
-  // being the observable "loaded" signal either way.
+  // (flureadium-3wd); iOS still resolves it to the EPUB reader view, which
+  // renders nothing either way and survives the boot (flureadium-5wu).
+  // openAfterColdBoot keeps the cold-boot path tapping [button] as well, so a
+  // variant test (NoTitle/Streamed/BadUrl/BadStream) still gets its own
+  // publication when it happens to run first — the open-generation bump being
+  // the observable "loaded" signal either way.
   Future<void> showAudiobook(
     WidgetTester tester, {
     String button = 'Open AudioBook',

--- a/flureadium/example/integration_test/cbz_test.dart
+++ b/flureadium/example/integration_test/cbz_test.dart
@@ -1,11 +1,9 @@
-import 'dart:io';
-
-import 'package:flutter/services.dart';
 import 'package:flureadium/flureadium.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'helpers/ensure_app_showing.dart';
+import 'helpers/extract_asset.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -169,7 +167,7 @@ void main() {
       );
       final locator = await _waitForCbzReaderReady(tester);
 
-      final path = await _extractAsset('assets/pubs/sample_comic.cbz');
+      final path = await extractAsset('assets/pubs/sample_comic.cbz');
       final pub = await Flureadium().loadPublication(path);
 
       expect(pub.readingOrder.first.href, equals(locator.href));
@@ -243,16 +241,6 @@ void main() {
       );
     });
   });
-}
-
-Future<String> _extractAsset(String assetPath) async {
-  final bytes = await rootBundle.load(assetPath);
-  final filename = assetPath.split('/').last;
-  final tmp = File(
-    '${Directory.systemTemp.path}/${DateTime.now().millisecondsSinceEpoch}_$filename',
-  );
-  await tmp.writeAsBytes(bytes.buffer.asUint8List());
-  return tmp.path;
 }
 
 Future<Locator> _waitForCbzReaderReady(

--- a/flureadium/example/integration_test/helpers/ensure_app_showing.dart
+++ b/flureadium/example/integration_test/helpers/ensure_app_showing.dart
@@ -31,12 +31,10 @@ bool appAlreadyShowing(WidgetTester tester, String reopenButton) =>
 /// test group boot once and reuse the app between tests instead of paying a
 /// fresh boot per test.
 ///
-/// Set [openAfterColdBoot] when the wanted publication cannot be an
-/// `initialAsset` boot — an audiobook has no visual reader to host on Android,
-/// so the group cold-boots a host EPUB via [initialAsset] and then opens the
-/// audiobook through [reopenButton]. With it set, the cold-boot path taps
-/// [reopenButton] too, so every call ends with the wanted publication freshly
-/// opened regardless of whether the app was already up.
+/// Set [openAfterColdBoot] when a group's tests open several publications
+/// through different [reopenButton]s. The cold-boot path then taps the button
+/// too, so whichever test runs first gets the publication it asked for instead
+/// of the one [initialAsset] happened to boot.
 Future<void> ensureAppShowing(
   WidgetTester tester, {
   required String initialAsset,

--- a/flureadium/example/integration_test/helpers/extract_asset.dart
+++ b/flureadium/example/integration_test/helpers/extract_asset.dart
@@ -2,17 +2,16 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 
-/// Copies a bundled asset to a uniquely named temp file and returns its path.
+/// Copies a bundled asset to a temp file and returns its path.
 ///
 /// `loadPublication` and `openPublication` need a real filesystem path, and the
-/// asset bundle is not one. The timestamp keeps repeat calls from colliding, so
-/// a suite can extract the same asset more than once.
+/// asset bundle is not one. Each call gets its own temp directory, so a suite
+/// can extract the same asset more than once without one copy overwriting the
+/// file another caller is still reading.
 Future<String> extractAsset(String assetPath) async {
   final bytes = await rootBundle.load(assetPath);
-  final filename = assetPath.split('/').last;
-  final tmp = File(
-    '${Directory.systemTemp.path}/${DateTime.now().millisecondsSinceEpoch}_$filename',
-  );
+  final dir = Directory.systemTemp.createTempSync('flureadium_asset_');
+  final tmp = File('${dir.path}/${assetPath.split('/').last}');
   await tmp.writeAsBytes(bytes.buffer.asUint8List());
   return tmp.path;
 }

--- a/flureadium/example/integration_test/helpers/extract_asset.dart
+++ b/flureadium/example/integration_test/helpers/extract_asset.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+/// Copies a bundled asset to a uniquely named temp file and returns its path.
+///
+/// `loadPublication` and `openPublication` need a real filesystem path, and the
+/// asset bundle is not one. The timestamp keeps repeat calls from colliding, so
+/// a suite can extract the same asset more than once.
+Future<String> extractAsset(String assetPath) async {
+  final bytes = await rootBundle.load(assetPath);
+  final filename = assetPath.split('/').last;
+  final tmp = File(
+    '${Directory.systemTemp.path}/${DateTime.now().millisecondsSinceEpoch}_$filename',
+  );
+  await tmp.writeAsBytes(bytes.buffer.asUint8List());
+  return tmp.path;
+}

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.16.1"
+    version: "0.16.2"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/example/test/extract_asset_test.dart
+++ b/flureadium/example/test/extract_asset_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/helpers/extract_asset.dart';
+
+void main() {
+  // extractAsset does real file I/O, which only completes on the real event
+  // loop — so these are plain tests rather than testWidgets bodies, whose fake
+  // async never lets the write finish.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const asset = 'assets/pubs/sample_comic.cbz';
+
+  test('writes the asset bytes to a readable file', () async {
+    final path = await extractAsset(asset);
+    final file = File(path);
+
+    expect(file.existsSync(), isTrue);
+    expect(
+      file.readAsBytesSync(),
+      (await rootBundle.load(asset)).buffer.asUint8List(),
+    );
+    expect(path, endsWith('sample_comic.cbz'));
+  });
+
+  test('repeat extractions of one asset cannot overwrite each other', () async {
+    // Two calls in the same millisecond used to resolve to the same path, so
+    // the second write truncated the file the first caller had already handed
+    // to loadPublication. Each extraction gets its own directory instead.
+    final first = await extractAsset(asset);
+    final second = await extractAsset(asset);
+
+    expect(File(first).parent.path, isNot(File(second).parent.path));
+    expect(File(first).existsSync(), isTrue);
+    expect(File(second).existsSync(), isTrue);
+  });
+}

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.16.1
+version: 0.16.2
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
Mounting the reader widget over an audiobook killed the Android app process. `PublicationReaderKind` had three members (`EPUB`, `PDF`, `IMAGE`) and used `EPUB` as its catch-all, so an audiobook was classified as an EPUB. The widget then had no audio-only host to dispatch to, and `epubEnable`'s own conformance guard rejected the publication the classifier had just handed it. The throw happened in an unsupervised coroutine, so it took the process down instead of surfacing as an error event.

Fixes `flureadium-3wd`. Phase 2 then puts that capability to use in the integration tests (`flureadium-6g1.1`). Epic: `flureadium-6g1`.

Ships as `flureadium` 0.16.2. `flureadium_platform_interface` is untouched, so its lower bound stays at `^0.10.0`.

## Phase 1: Android audio host

- `PublicationReaderKind` gains `AUDIO`, matched by `conformsTo(Publication.Profile.AUDIOBOOK)`. The check sits last, after PDF and image, so the existing precedence is untouched and a media-overlay EPUB with an HTML reading order still classifies as `EPUB`.
- `ReadiumReaderWidget` takes an audio branch that enables no navigator and reports `"ready"` itself, because nothing else will for an audio host.
- The reader kind is frozen at construction. It used to be a getter over the mutable `ReadiumReader.currentPublication`, so a publication swap under a live platform view could flip the kind, send `dispose()` down the wrong teardown path, and leak the navigator and the is-ready channel the widget had actually enabled.
- The audio teardown clears `ReadiumReader.currentReaderWidget` only while this widget is still the registered one, so a stale dispose cannot wipe a newer widget's registration.

A code review caught a second defect before this merged: `ReadiumReaderWidget.init` runs inside the platform-view `create` call, so the statuses it sends leave native before Flutter replies to Dart and before a host app can subscribe from `onReady`. They landed in a null sink. That was invisible for EPUB, PDF, and image hosts, whose `"ready"` arrives later from `onVisualReaderIsReady`, but an audio host has no later source, so a host app waiting for `"ready"` would wait forever. `ReaderStatusEventChannel` now keeps the most recent status while nobody is listening and sends it once when the first subscriber arrives. Only the latest is kept, since status is a state rather than a log, and a delivered status is never replayed to a later subscriber.

## Phase 2: audiobook direct boot

The audiobook integration group used to cold-boot `moby_dick.epub` and then tap `Open AudioBook`, because the widget could not host an audiobook. It now boots `assets/pubs/38533.audiobook` itself. That drops an EPUB load and a navigator mount from every run of the suite, and it is the end-to-end proof of Phase 1. This is Tier 1 #1 of the integration-test speedup work.

`openAfterColdBoot` stays, for the reason it is actually needed: the group opens five publications through five buttons, so the cold-boot path taps the button too and whichever test runs first gets the publication it asked for. The end-of-book test also stops re-extracting and reloading the audiobook to read its reading order, since `setUpAll` already holds that publication and `goByLink` only resolves the link against the manifest it is handed.

Both suites now share one `extractAsset` helper instead of carrying a byte-identical private copy each. The helper gives every call its own temp directory: it used to name the file after the current millisecond, so two extractions inside one millisecond resolved to the same path and the second write truncated the file the first caller had already opened.

## Testing

- Android JVM unit tests: `testDebugUnitTest` green, with new cases for `AUDIO` classification and precedence, audio-host mount and teardown, and reader-status delivery to a late first subscriber.
- Plugin and example Dart suites green; `flutter analyze` clean in `example/`, which is the only compile gate for `integration_test/`.
- Audiobook and CBZ integration groups run on an Android device and an iOS device, both green.

## Known gaps, filed separately

- `flureadium-5wu`: iOS has no audio reader kind, so an audiobook resolves to `.epub` and builds a content-less EPUB navigator. It does not crash, which is why iOS survives the direct boot, and the testing guide now says so rather than claiming the audio-only host works on both platforms.
- `flureadium-0c2`: `pdfClose()`, `imageClose()`, and `epubClose()` still clear `currentReaderWidget` unconditionally, so a stale dispose can wipe a newer widget's registration for those three kinds. Hoisting the guard changes teardown for all of them and needs a device run.
- `flureadium-p1q`: neither CI bundle exercises the new cold boot. `all_tests.dart` boots the launch group first, so the audiobook group takes the reuse path, and the Android CI bundle leaves the group out.
- `flureadium-83h`: `ReadiumReaderWidget.kt` is 747 lines and carries a LOC waiver in this work. Its measured size is unchanged here.
