### PR TITLE
Point the user-stage checklist at the plan's new home

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -52,3 +52,5 @@
 # - linear.api-key
 # - github.org
 # - github.repo
+
+sync.remote: "git+https://github.com/mulev/flureadium.git"

--- a/validators.conf
+++ b/validators.conf
@@ -39,4 +39,4 @@ finalize   | all    | cd flureadium && ./scripts/run_all_tests.sh
 # input tap` at the same point reported at once. Reflowable EPUB on Android is
 # automated in example/integration_test/tap_test.dart; everything below is what
 # is left, and it is a real device or simulator by hand.
-user       | tap    | cd flureadium/example && flutter run --release -d <device>   # both platforms: an iOS device or simulator for the iOS items, an Android device or emulator for the fixed-layout one. Checklist: project_plans/flureadium/todo/flureadium_feat_native_tap_callback/phase_5_prove_the_tap.md
+user       | tap    | cd flureadium/example && flutter run --release -d <device>   # both platforms: an iOS device or simulator for the iOS items, an Android device or emulator for the fixed-layout one. Checklist: project_plans/flureadium/done/flureadium_feat_native_tap_callback/phase_5_prove_the_tap.md


### PR DESCRIPTION
One line in `validators.conf`.

`0.17.0` shipped and closed `flureadium-8rc`, so its plan moved from `project_plans/flureadium/todo/` to `done/`. The `user | tap` row is the only repo file that names that path, and the checklist it points at is the entire content of that row — the five device items no runner can drive. A stale path there means `./validate list user` hands over a pointer to nothing.

`./validate list user` prints the corrected path.