### PR TITLE
Fix the Android control-panel info type lost on saved-state restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.17.0
+  flureadium: ^0.17.1
 ```
 
 Then follow the platform-specific setup below. For full details, see the [Installation Guide](flureadium/docs/getting-started/installation.md).

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.17.1
+
+### Bug Fixes
+
+- **An Android control-panel layout other than the default survives activity recreation now**: `ControlPanelInfoType` read the Flutter spelling (`chapterTitle`) but wrote the Kotlin constant name (`CHAPTER_TITLE`), because the only function producing the wire spelling sat on the companion where an instance `toString()` call could never reach it. Android saved state writes the value with `?.toString()`, so a saved `chapterTitle` came back unparseable and the reader's `else -> STANDARD` fallback turned it into the default. After a rotation, a low-memory kill or process death, the media notification and lockscreen quietly reverted to publication title plus authors. The wire spelling is now the enum's own `toString()`, which fixes the TTS and audiobook paths together, and the unreachable companion function is gone.
+
+### Documentation
+
+- `docs/platform-specific/android.md` has a "Saved-State Restore" section: one provider whose bundle nests a child bundle per live navigator, nothing re-asks Dart for preferences on restore, and enums crossing the bundle use the spelling the method channel uses. It also names the split between the hand-written codecs, which fall back to a default on a string they cannot read, and the EPUB bundle's kotlinx encoding, which throws.
+
 ## 0.17.0
 
 ### Breaking changes

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -23,7 +23,7 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.17.0
+  flureadium: ^0.17.1
 ```
 
 > Developed and tested with **Flutter 3.44.7 (Dart 3.12.2)**. The `pubspec.yaml` constraints (`sdk: >=3.8.0 <4.0.0`, `flutter: >=3.3.0`) remain the source of truth for supported versions.

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ControlPanelInfoType.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ControlPanelInfoType.kt
@@ -7,6 +7,18 @@ enum class ControlPanelInfoType {
     CHAPTER_TITLE,
     TITLE_CHAPTER;
 
+    /**
+     * The Flutter spelling of this value — the same string Dart sends over the
+     * method channel and the only form [Companion.fromString] can read back.
+     */
+    override fun toString(): String = when (this) {
+        STANDARD -> "standard"
+        STANDARD_WCH -> "standardWCh"
+        CHAPTER_TITLE_AUTHOR -> "chapterTitleAuthor"
+        CHAPTER_TITLE -> "chapterTitle"
+        TITLE_CHAPTER -> "titleChapter"
+    }
+
     companion object {
         fun fromString(value: String): ControlPanelInfoType = when (value) {
             "standard" -> STANDARD
@@ -16,14 +28,5 @@ enum class ControlPanelInfoType {
             "titleChapter" -> TITLE_CHAPTER
             else -> STANDARD
         }
-
-        fun toString(type: ControlPanelInfoType): String = when (type) {
-            STANDARD -> "standard"
-            STANDARD_WCH -> "standardWCh"
-            CHAPTER_TITLE_AUTHOR -> "chapterTitleAuthor"
-            CHAPTER_TITLE -> "chapterTitle"
-            TITLE_CHAPTER -> "titleChapter"
-        }
     }
-
 }

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/ControlPanelInfoTypeTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/ControlPanelInfoTypeTest.kt
@@ -1,0 +1,63 @@
+package dev.mulev.flureadium
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for the string contract of [ControlPanelInfoType].
+ *
+ * The saved-state path writes this enum with `?.toString()` and reads it back
+ * through [ControlPanelInfoType.Companion.fromString], so the two must speak
+ * the same spelling — the one Dart sends over the method channel. No case here
+ * depends on the JSON-null differences between JSON-java and AOSP's `org.json`,
+ * so no Robolectric runner is needed.
+ */
+internal class ControlPanelInfoTypeTest {
+
+    @Test
+    fun toString_returnsFlutterSpellingForEveryConstant() {
+        assertEquals("standard", ControlPanelInfoType.STANDARD.toString())
+        assertEquals("standardWCh", ControlPanelInfoType.STANDARD_WCH.toString())
+        assertEquals("chapterTitleAuthor", ControlPanelInfoType.CHAPTER_TITLE_AUTHOR.toString())
+        assertEquals("chapterTitle", ControlPanelInfoType.CHAPTER_TITLE.toString())
+        assertEquals("titleChapter", ControlPanelInfoType.TITLE_CHAPTER.toString())
+    }
+
+    @Test
+    fun fromString_roundTripsEveryConstant() {
+        ControlPanelInfoType.entries.forEach { type ->
+            assertEquals(type, ControlPanelInfoType.fromString(type.toString()))
+        }
+    }
+
+    @Test
+    fun fromString_unknownValueFallsBackToStandard() {
+        assertEquals(ControlPanelInfoType.STANDARD, ControlPanelInfoType.fromString("CHAPTER_TITLE"))
+        assertEquals(ControlPanelInfoType.STANDARD, ControlPanelInfoType.fromString("bogus"))
+    }
+
+    @Test
+    fun ttsPreferences_roundTripKeepsChapterTitle() {
+        val original = FlutterTtsPreferences(controlPanelInfoType = ControlPanelInfoType.CHAPTER_TITLE)
+
+        val restored = FlutterTtsPreferences.fromJSON(FlutterTtsPreferences.toJSON(original))
+
+        assertEquals(ControlPanelInfoType.CHAPTER_TITLE, restored.controlPanelInfoType)
+    }
+
+    @Test
+    fun audioPreferences_roundTripKeepsTitleChapter() {
+        // toJSON drops a null key and fromJSON reads these three with getDouble,
+        // which throws on a missing key, so they must be real values here.
+        val original = FlutterAudioPreferences(
+            volume = 1.0,
+            pitch = 1.0,
+            speed = 1.0,
+            controlPanelInfoType = ControlPanelInfoType.TITLE_CHAPTER,
+        )
+
+        val restored = FlutterAudioPreferences.fromJSON(FlutterAudioPreferences.toJSON(original))
+
+        assertEquals(ControlPanelInfoType.TITLE_CHAPTER, restored.controlPanelInfoType)
+    }
+}

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.17.0
+  flureadium: ^0.17.1
 ```
 
 Run:

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -201,18 +201,23 @@ skips all of it.
 ### Saved-State Restore
 
 Android can destroy the Activity and rebuild it later, after a rotation or
-under "Don't keep activities" during development. `ReadiumReader` registers one
-saved-state provider per navigator, and each provider writes two things into
-the bundle: where the reader was, and how that navigator was configured. On
-restore the navigator is rebuilt from the bundle alone. Nothing asks Dart for
-the preferences a second time, so whatever the bundle loses stays lost.
+under "Don't keep activities" during development. `ReadiumReader` registers a
+single saved-state provider, and the bundle it hands back nests one child
+bundle per live navigator. A child bundle carries where that navigator was and,
+if the navigator has preferences, how it was configured — `ImageNavigator` has
+none, so it stores only the locator. On restore each navigator is rebuilt from
+its child bundle alone. Nothing asks Dart for the preferences a second time, so
+whatever the bundle loses stays lost.
 
 That makes the bundle a wire format with the same rules as the method channel.
 Enums crossing it are written and read in the Flutter spelling, `chapterTitle`
 rather than `CHAPTER_TITLE`, which is what makes a restored value equal the one
-the host set. Write the Kotlin constant name instead and the parser quietly
-falls back to its default. `ControlPanelInfoType` is the worked example: its
-`toString()` returns the wire spelling and `fromString` reads exactly that.
+the host set. `ControlPanelInfoType` is the worked example: its `toString()`
+returns the wire spelling and `fromString` reads exactly that. Write the Kotlin
+constant name into a hand-written codec like that one and the parser quietly
+falls back to its default. The EPUB bundle goes the other way: it encodes
+`EpubPreferences` with kotlinx, which keys enums by constant name and throws on
+a value it does not know rather than defaulting.
 
 ### Event Channels
 

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -198,6 +198,22 @@ including the channels below.
 widget, saved-state restore, and the event channels below. A headless engine
 skips all of it.
 
+### Saved-State Restore
+
+Android can destroy the Activity and rebuild it later, after a rotation or
+under "Don't keep activities" during development. `ReadiumReader` registers one
+saved-state provider per navigator, and each provider writes two things into
+the bundle: where the reader was, and how that navigator was configured. On
+restore the navigator is rebuilt from the bundle alone. Nothing asks Dart for
+the preferences a second time, so whatever the bundle loses stays lost.
+
+That makes the bundle a wire format with the same rules as the method channel.
+Enums crossing it are written and read in the Flutter spelling, `chapterTitle`
+rather than `CHAPTER_TITLE`, which is what makes a restored value equal the one
+the host set. Write the Kotlin constant name instead and the parser quietly
+falls back to its default. `ControlPanelInfoType` is the worked example: its
+`toString()` returns the wire spelling and `fromString` reads exactly that.
+
 ### Event Channels
 
 All four Flutter EventChannels are registered in `ReadiumReader.attach()`, which

--- a/flureadium/docs/platform-specific/android.md
+++ b/flureadium/docs/platform-specific/android.md
@@ -215,9 +215,10 @@ rather than `CHAPTER_TITLE`, which is what makes a restored value equal the one
 the host set. `ControlPanelInfoType` is the worked example: its `toString()`
 returns the wire spelling and `fromString` reads exactly that. Write the Kotlin
 constant name into a hand-written codec like that one and the parser quietly
-falls back to its default. The EPUB bundle goes the other way: it encodes
-`EpubPreferences` with kotlinx, which keys enums by constant name and throws on
-a value it does not know rather than defaulting.
+falls back to its default. The EPUB bundle differs only in what an unreadable
+value costs: it encodes `EpubPreferences` with kotlinx, and every enum in there
+carries a `@SerialName` of its own (`light`, `ltr`, `justify`), so the spelling
+rule is the same — but an unknown one throws instead of quietly defaulting.
 
 ### Event Channels
 

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.17.0"
+    version: "0.17.1"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.17.0
+version: 0.17.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
A control-panel info type other than the default was lost whenever Android
recreated the Activity or the process died. The media notification and
lockscreen quietly dropped back to publication title plus authors, and nothing
reported why.

## What was wrong

`ControlPanelInfoType`'s string contract was asymmetric. `fromString` read the
Flutter spelling (`chapterTitle`), but the write side called the enum's
inherited `Enum.toString()`, which returns the Kotlin constant name
(`CHAPTER_TITLE`). The only function that produced the wire spelling sat on the
companion as `toString(type)`, where an instance `?.toString()` call can never
reach it, and nothing in the repo called it.

Android saved state writes the value with `?.toString()`
(`FlutterTtsPreferences.kt:92`, `FlutterAudioPreferences.kt:73`), so a saved
`chapterTitle` came back as a string `fromString` cannot parse, and its
`else -> STANDARD` branch turned the parse failure into a silent default.
`ReadiumReader.restoreState` rebuilds the navigator from the bundle alone and
never re-asks Dart, so there was no self-heal.

## The fix

The wire mapping is now the enum's own `toString()` override, and the
unreachable companion function is gone. Both write sites are untouched: they
already called `?.toString()`, so they became correct without an edit, and the
TTS and audiobook paths are fixed by the same line. Overriding `toString()`
rather than adding a `toFlutterString()` also means any future string
interpolation of this enum emits something `fromString` can read.

`fromString` still maps an unrecognised string to `STANDARD`. The inbound
method-channel path relies on that, and changing it is a separate decision.

## Tests

`ControlPanelInfoTypeTest.kt` pins the spelling per constant, round-trips every
constant through `fromString(x.toString())`, and runs both preference classes
through the real `toJSON`/`fromJSON` pair — the same calls
`TTSNavigator.storeState`/`restoreState` and the audiobook navigators make. Four
of the five cases failed before the fix.

No integration test is added. The Dart suite drives the plugin through the
method channel, which always spoke the correct spelling; the broken path is
Kotlin-internal. A device check is still worth doing by hand: set
`chapterTitle`, force the Activity to be recreated, and confirm the notification
keeps its layout.

## Also here

- `docs/platform-specific/android.md` gets a "Saved-State Restore" section: one
  provider whose bundle nests a child bundle per live navigator, nothing
  re-asking Dart on restore, and which codecs default on an unreadable value
  versus which throw.
- `0.17.1` opens with the fix and the docs entry. `0.17.0` is released and
  tagged, so nothing was backdated into it. The version bump moves the three
  install snippets and the example's tracked lockfile with it.
- Code review turned up a neighbouring defect this change deliberately does not
  touch: `FlutterAudioPreferences.plus` overwrites `controlPanelInfoType`
  unconditionally, so a volume-only `audioSetPreferences` resets the layout
  before saved state is involved at all. Filed as `flureadium-h4t2`.

Kotlin, Dart and iOS suites are green (`phase-exit` and `finalize` stages).
