### PR TITLE
Require platform interface 0.10.3

### DIFF
--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.18.1
+
+### Bug Fixes
+
+- **The platform interface constraint now requires 0.10.3.** 0.18.0 shipped with `flureadium_platform_interface: ^0.10.2`, which also allows 0.10.2 itself. Under 0.10.2 a bare `toc=` makes `Locations.tocFragment` return an empty string rather than `null`, so the null check this package's own documentation shows — `if (fragment != null)` before calling `findTocIndexByFragment` — passes on a fragment that names no heading, and two positions in unrelated chapters compare equal. A fresh `pub get` on 0.18.0 resolved 0.10.3 anyway; a lockfile already pinned to 0.10.2 did not, and got the broken pairing with no warning. The constraint says what the code needs now.
+
+---
+
 ## 0.18.0
 
 ### Breaking Changes

--- a/flureadium/docs/api-reference/publication.md
+++ b/flureadium/docs/api-reference/publication.md
@@ -367,6 +367,14 @@ if (fragment != null) {
 }
 ```
 
+The null check in that example is the whole guard, and it needs
+`flureadium_platform_interface` 0.10.3 or newer to work. Before 0.10.3 a bare
+`toc=` — a fragment that is present but names no heading — made `tocFragment`
+return an empty string, which passes `!= null` and sends a fragment that
+identifies nothing into the lookup. 0.18.1 requires 0.10.3 for that reason; if
+you are on 0.18.0 with a lockfile pinned to 0.10.2, upgrade the platform
+interface.
+
 The lookup runs two passes: first inside the resource `path` names, then across
 the whole TOC. `ownFile` says which pass matched. `index` is -1 when neither
 did, and for an empty fragment.

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.18.0
+version: 0.18.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flureadium_platform_interface: ^0.10.2
+  flureadium_platform_interface: ^0.10.3
   wakelock_plus: ^1.2.8
   web: ^1.1.1
   collection: ^1.19.1


### PR DESCRIPTION
0.18.0 shipped with `flureadium_platform_interface: ^0.10.2`. That constraint also allows 0.10.2 itself, and it should not.

The empty-`toc=` guard has two halves and only one of them lives in this package. The injected JavaScript stopped producing a bare `toc=`, and platform interface 0.10.3 made `Locations.tocFragment` read one as absent. On 0.10.2 that getter still returns an empty string, so this pattern — the one `docs/api-reference/publication.md` tells hosts to write — passes on a fragment that names no heading:

```dart
final fragment = locator.locations?.tocFragment;
if (fragment != null) {
  final match = findTocIndexByFragment(...);
}
```

Two positions in unrelated chapters then compare equal.

## Who was affected

A fresh `pub get` on 0.18.0 resolved 0.10.3 anyway, so a new consumer never saw this. A lockfile already pinned to 0.10.2 did not resolve forward, and got the broken pairing with nothing to warn it.

## Changes

- `pubspec.yaml`: constraint `^0.10.2` → `^0.10.3`, version `0.18.0` → `0.18.1`
- `CHANGELOG.md`: a 0.18.1 entry naming what breaks under 0.10.2 and who is exposed
- `docs/api-reference/publication.md`: the `findTocIndexByFragment` example now states that its null check needs 0.10.3, since that example is what misleads a host on the older pairing
- `example/pubspec.lock`: the example depends on the plugin by path, so its committed lockfile carries the plugin version and had to move with it
- `README.md`, `flureadium/README.md`, `docs/getting-started/installation.md`: three copy-paste install snippets said `flureadium: ^0.18.0`. That constraint resolves 0.18.1 anyway, so nothing broke, but it named the release whose platform interface constraint is wrong

Released as 0.18.1 because 0.18.0 is published and cannot be amended.

No code change — `lib/` is untouched.

## Validation

`./validate run phase-exit` on `6ba77e8`, all five rows PASS:

```
static                 PASS  No issues found! (ran in 3.8s)
static-plugin          PASS  No issues found!
static-plugin-canary   PASS  flureadium_lints is wired up in all 3 packages
static-lints           PASS  No issues found!
suites                 PASS  ✅ ALL RUN SUITES PASSED
```
