### PR TITLE
Advertise 0.18.1 in the example lockfile and install snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.18.0
+  flureadium: ^0.18.1
 ```
 
 Then follow the platform-specific setup below. For full details, see the [Installation Guide](flureadium/docs/getting-started/installation.md).

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -23,7 +23,7 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.18.0
+  flureadium: ^0.18.1
 ```
 
 > Developed and tested with **Flutter 3.44.7 (Dart 3.12.2)**. The `pubspec.yaml` constraints (`sdk: >=3.8.0 <4.0.0`, `flutter: >=3.3.0`) remain the source of truth for supported versions.

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.18.0
+  flureadium: ^0.18.1
 ```
 
 Run:

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.0"
+    version: "0.18.1"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:


### PR DESCRIPTION
Follow-up to #67, which fixed the constraint in `pubspec.yaml` but left four places still naming 0.18.0.

## Changes

- `flureadium/example/pubspec.lock` — the example depends on the plugin by path, so its committed lockfile carries the plugin version and stayed at `0.18.0` after the bump
- `README.md`, `flureadium/README.md`, `flureadium/docs/getting-started/installation.md` — three copy-paste install snippets said `flureadium: ^0.18.0`

`^0.18.0` resolves to 0.18.1 anyway, so nothing is broken by these. They point a new host at the release whose platform interface constraint is wrong, which is the version nobody should be directed to now.

## Scope

Swept the repo for every remaining `0.18.0` and `0.10.2` outside CHANGELOGs and build output. One reference remains and is deliberate: the sentence in `docs/api-reference/publication.md` that describes the broken 0.18.0 + 0.10.2 pairing.

The example's `pubspec.yaml` and both `pubspec_overrides.yaml` needed no change — they use path references carrying no version.

No code change; `lib/` is untouched.
