### PR TITLE
Resolve audiobook track durations off the Android main thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.19.0
+  flureadium: ^0.19.1
 ```
 
 Then follow the platform-specific setup below. For full details, see the [Installation Guide](flureadium/docs/getting-started/installation.md).

--- a/flureadium/CHANGELOG.md
+++ b/flureadium/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.19.1
+
+### Bug Fixes
+
+- **Opening a streamed audiobook no longer blocks the Android main thread, so Android stops putting up its not-responding dialog.** Readium works out a reading-order item's missing duration by reading the audio file itself, through a `MediaDataSource` whose reads sit inside `runBlocking`. This package built the audiobook navigator on the main dispatcher, so that read happened on the very thread Android watches. Against a local file it is a disk seek nobody notices. Against a streamed audiobook every probe is an HTTPS round trip, and a manifest that declares no per-track durations pays one per track, in sequence, on the UI thread: a dozen tracks held the main thread far past the five seconds at which Android decides an app is gone. Measured on a physical device opening a Project Gutenberg audiobook, the gap between the navigator being asked for and the player being built ran 10.4 to 12.8 seconds, with the device's own hang detector reporting single main-looper messages over six seconds and 667 dropped frames on the cold-start restore path. Durations now resolve on `Dispatchers.IO`, a few at a time, before the navigator is built, and the resolved reading order goes to Readium so its blocking fallback never runs. A manifest that already declares its durations is passed straight through and issues no request at all. A probe that fails leaves the duration absent rather than zero: Readium refuses a publication outright when a reading-order entry declares a zero duration, so a track whose length cannot be determined costs you a missing length instead of a book that will not open.
+
+### Documentation
+
+- `docs/guides/audiobook-playback.md` says which thread duration resolution runs on, what a manifest without per-track durations costs when the audio is streamed, and what a failed probe leaves behind.
+
+---
+
 ## 0.19.0
 
 ### Behaviour Changes

--- a/flureadium/README.md
+++ b/flureadium/README.md
@@ -23,7 +23,7 @@ A comprehensive Flutter plugin for reading EPUB ebooks, audiobooks, and comics u
 
 ```yaml
 dependencies:
-  flureadium: ^0.19.0
+  flureadium: ^0.19.1
 ```
 
 > Developed and tested with **Flutter 3.44.7 (Dart 3.12.2)**. The `pubspec.yaml` constraints (`sdk: >=3.8.0 <4.0.0`, `flutter: >=3.3.0`) remain the source of truth for supported versions.

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
@@ -406,11 +406,13 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
                 // Restore Audio navigator
                 Log.d(TAG, ":storeState - restore audio navigator")
                 bundle.getBundle(audioNavigatorStateKey)?.let { state ->
+                    // Publish the field before initNavigator(), which now suspends while
+                    // it resolves missing track durations on Dispatchers.IO. A release()
+                    // arriving during that window must find a navigator to release.
                     audiobookNavigator =
-                        AudiobookNavigator.restoreState(pub, this@ReadiumReader, state).apply {
-                            initNavigator()
-                            Log.d(TAG, ":storeState - audioNavigator restored")
-                        }
+                        AudiobookNavigator.restoreState(pub, this@ReadiumReader, state)
+                    audiobookNavigator?.initNavigator()
+                    Log.d(TAG, ":storeState - audioNavigator restored")
                 }
             } else if (bundle.getBoolean(syncAudioEnabledKey)) {
                 // Restore Sync Audio navigator
@@ -425,10 +427,8 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
                                 this@ReadiumReader,
                                 state
                             )
-                                .apply {
-                                    initNavigator()
-                                    Log.d(TAG, ":storeState - syncAudioNavigator restored")
-                                }
+                        syncAudiobookNavigator?.initNavigator()
+                        Log.d(TAG, ":storeState - syncAudioNavigator restored")
                     }
                 } else {
                     Log.e(TAG, ":storeState - no media overlays for sync audio navigator")
@@ -1173,19 +1173,23 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
             syncAudiobookNavigator = null
 
             if (overlays == null) {
+                // Publish the field before initNavigator(). It suspends on
+                // Dispatchers.IO to resolve missing track durations, yielding the
+                // looper for as long as those requests take, so a stop(), an
+                // audioDisable() or a second audioEnable() can interleave. Assigning
+                // afterwards left the field null for that whole window: the teardown
+                // released nothing and this init then installed a live navigator and
+                // MediaSession into a reader that had already been told to stop.
                 audiobookNavigator = AudiobookNavigator(
                     ap, this@ReadiumReader, initialLocator, preferences
-                ).apply {
-                    initNavigator()
-                }
+                )
+                audiobookNavigator?.initNavigator()
             } else {
                 val ail = initialLocator ?: epubNavigator?.currentLocator?.value
                 syncAudiobookNavigator = SyncAudiobookNavigator(
                     ap, overlays, this@ReadiumReader, ail, preferences
-                ).apply {
-                    initNavigator()
-                }
-
+                )
+                syncAudiobookNavigator?.initNavigator()
             }
         } ?: throw Exception("Publication not opened")
     }

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
@@ -406,12 +406,9 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
                 // Restore Audio navigator
                 Log.d(TAG, ":storeState - restore audio navigator")
                 bundle.getBundle(audioNavigatorStateKey)?.let { state ->
-                    // Publish the field before initNavigator(), which now suspends while
-                    // it resolves missing track durations on Dispatchers.IO. A release()
-                    // arriving during that window must find a navigator to release.
-                    audiobookNavigator =
+                    initPublished(
                         AudiobookNavigator.restoreState(pub, this@ReadiumReader, state)
-                    audiobookNavigator?.initNavigator()
+                    ) { audiobookNavigator = it }
                     Log.d(TAG, ":storeState - audioNavigator restored")
                 }
             } else if (bundle.getBoolean(syncAudioEnabledKey)) {
@@ -420,14 +417,14 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
                 val (ap, mediaOverlays) = pub.makeSyncAudiobook()
                 if (mediaOverlays != null) {
                     bundle.getBundle(syncAudioNavigatorStateKey)?.let { state ->
-                        syncAudiobookNavigator =
+                        initPublished(
                             SyncAudiobookNavigator.restoreState(
                                 ap,
                                 mediaOverlays,
                                 this@ReadiumReader,
                                 state
                             )
-                        syncAudiobookNavigator?.initNavigator()
+                        ) { syncAudiobookNavigator = it }
                         Log.d(TAG, ":storeState - syncAudioNavigator restored")
                     }
                 } else {
@@ -1159,6 +1156,34 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
         syncAudiobookNavigator?.seekTo(offsetSeconds)
     }
 
+    /**
+     * Assigns [navigator] to its field through [publish], runs its suspending
+     * [AudiobookNavigator.initNavigator], and clears the field again if that throws.
+     *
+     * Both halves matter. Publishing first is required because initNavigator resolves
+     * missing track durations off the main thread and so suspends: a stop(), an
+     * audioDisable() or a second audioEnable() arriving in that window has to find the
+     * navigator in order to release and cancel it. Clearing on failure is required
+     * because the field is published by then, and a half-built navigator left in it
+     * makes the reader lie — storeState() persists audioEnabled = true across process
+     * death, goToLocator() reports the locator handled, and play() silently does
+     * nothing. initNavigator throws on a non-audio publication and on any
+     * createNavigator error, so this is a reachable path, not a theoretical one.
+     */
+    private suspend fun <T : AudiobookNavigator> initPublished(
+        navigator: T,
+        publish: (T?) -> Unit,
+    ) {
+        publish(navigator)
+        try {
+            navigator.initNavigator()
+        } catch (e: Exception) {
+            navigator.release()
+            publish(null)
+            throw e
+        }
+    }
+
     @OptIn(InternalReadiumApi::class)
     suspend fun audioEnable(initialLocator: Locator?, preferences: FlutterAudioPreferences) {
         _audioPreferences = preferences
@@ -1173,23 +1198,14 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
             syncAudiobookNavigator = null
 
             if (overlays == null) {
-                // Publish the field before initNavigator(). It suspends on
-                // Dispatchers.IO to resolve missing track durations, yielding the
-                // looper for as long as those requests take, so a stop(), an
-                // audioDisable() or a second audioEnable() can interleave. Assigning
-                // afterwards left the field null for that whole window: the teardown
-                // released nothing and this init then installed a live navigator and
-                // MediaSession into a reader that had already been told to stop.
-                audiobookNavigator = AudiobookNavigator(
-                    ap, this@ReadiumReader, initialLocator, preferences
-                )
-                audiobookNavigator?.initNavigator()
+                initPublished(
+                    AudiobookNavigator(ap, this@ReadiumReader, initialLocator, preferences)
+                ) { audiobookNavigator = it }
             } else {
                 val ail = initialLocator ?: epubNavigator?.currentLocator?.value
-                syncAudiobookNavigator = SyncAudiobookNavigator(
-                    ap, overlays, this@ReadiumReader, ail, preferences
-                )
-                syncAudiobookNavigator?.initNavigator()
+                initPublished(
+                    SyncAudiobookNavigator(ap, overlays, this@ReadiumReader, ail, preferences)
+                ) { syncAudiobookNavigator = it }
             }
         } ?: throw Exception("Publication not opened")
     }

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
@@ -407,7 +407,8 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
                 Log.d(TAG, ":storeState - restore audio navigator")
                 bundle.getBundle(audioNavigatorStateKey)?.let { state ->
                     initPublished(
-                        AudiobookNavigator.restoreState(pub, this@ReadiumReader, state)
+                        AudiobookNavigator.restoreState(pub, this@ReadiumReader, state),
+                        current = { audiobookNavigator },
                     ) { audiobookNavigator = it }
                     Log.d(TAG, ":storeState - audioNavigator restored")
                 }
@@ -423,7 +424,8 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
                                 mediaOverlays,
                                 this@ReadiumReader,
                                 state
-                            )
+                            ),
+                            current = { syncAudiobookNavigator },
                         ) { syncAudiobookNavigator = it }
                         Log.d(TAG, ":storeState - syncAudioNavigator restored")
                     }
@@ -1158,28 +1160,51 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
 
     /**
      * Assigns [navigator] to its field through [publish], runs its suspending
-     * [AudiobookNavigator.initNavigator], and clears the field again if that throws.
+     * [AudiobookNavigator.initNavigator], and clears the field again if that throws —
+     * but only while the field still holds this navigator, per [current].
      *
-     * Both halves matter. Publishing first is required because initNavigator resolves
-     * missing track durations off the main thread and so suspends: a stop(), an
-     * audioDisable() or a second audioEnable() arriving in that window has to find the
-     * navigator in order to release and cancel it. Clearing on failure is required
-     * because the field is published by then, and a half-built navigator left in it
-     * makes the reader lie — storeState() persists audioEnabled = true across process
-     * death, goToLocator() reports the locator handled, and play() silently does
-     * nothing. initNavigator throws on a non-audio publication and on any
-     * createNavigator error, so this is a reachable path, not a theoretical one.
+     * Publishing first is required because initNavigator resolves missing track
+     * durations off the main thread and so suspends: a stop(), an audioDisable() or a
+     * second audioEnable() arriving in that window has to find the navigator in order
+     * to release and cancel it.
+     *
+     * Clearing on failure is required because the field is published by then, and a
+     * half-built navigator left in it makes the reader lie — storeState() persists
+     * audioEnabled = true across process death, goToLocator() reports the locator
+     * handled, and play() silently does nothing. initNavigator throws on a non-audio
+     * publication and on any createNavigator error, so this is reachable.
+     *
+     * Clearing *conditionally* is required because audio calls are not serialized:
+     * PublicationChannel launches each one on its own coroutine. A second audioEnable()
+     * releases the first navigator — cancelling its init — and publishes its own before
+     * the first init's failure is even observed. An unconditional clear would then erase
+     * the live navigator, orphaning a real ExoPlayer session and MediaSession that every
+     * teardown path guards on the field and so can never release. Identity comparison,
+     * not equality: two navigators over the same publication are not interchangeable.
+     *
+     * A failing release() must not swallow the reason we are here, nor skip the clear.
+     * It ends in `withContext(Dispatchers.Main.immediate)`, which throws immediately when
+     * the calling coroutine is already cancelled — the common case on this path.
+     *
+     * The bound is a partial guard only. `initPublished(Sync...) { audiobookNavigator = it }`
+     * compiles, because SyncAudiobookNavigator is an AudiobookNavigator; the reverse does
+     * not. Match the navigator to its own field.
      */
     private suspend fun <T : AudiobookNavigator> initPublished(
         navigator: T,
+        current: () -> AudiobookNavigator?,
         publish: (T?) -> Unit,
     ) {
         publish(navigator)
         try {
             navigator.initNavigator()
         } catch (e: Exception) {
-            navigator.release()
-            publish(null)
+            try {
+                navigator.release()
+            } catch (releaseFailure: Exception) {
+                e.addSuppressed(releaseFailure)
+            }
+            if (current() === navigator) publish(null)
             throw e
         }
     }
@@ -1199,12 +1224,14 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
 
             if (overlays == null) {
                 initPublished(
-                    AudiobookNavigator(ap, this@ReadiumReader, initialLocator, preferences)
+                    AudiobookNavigator(ap, this@ReadiumReader, initialLocator, preferences),
+                    current = { audiobookNavigator },
                 ) { audiobookNavigator = it }
             } else {
                 val ail = initialLocator ?: epubNavigator?.currentLocator?.value
                 initPublished(
-                    SyncAudiobookNavigator(ap, overlays, this@ReadiumReader, ail, preferences)
+                    SyncAudiobookNavigator(ap, overlays, this@ReadiumReader, ail, preferences),
+                    current = { syncAudiobookNavigator },
                 ) { syncAudiobookNavigator = it }
             }
         } ?: throw Exception("Publication not opened")

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/ReadiumReader.kt
@@ -1202,7 +1202,10 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
             try {
                 navigator.release()
             } catch (releaseFailure: Exception) {
-                e.addSuppressed(releaseFailure)
+                // Both can be the same JobCancellationException instance when one
+                // cancellation cancelled the init and the release; addSuppressed throws
+                // IllegalArgumentException on itself.
+                if (releaseFailure !== e) e.addSuppressed(releaseFailure)
             }
             if (current() === navigator) publish(null)
             throw e

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigator.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigator.kt
@@ -78,10 +78,20 @@ open class AudiobookNavigator(
             throw Exception("Couldn't create AudioNavigatorFactory")
         }
 
+        // Readium's createNavigator falls back to MediaMetadataRetriever for every
+        // reading-order item without a duration, and that fallback blocks the calling
+        // thread (runBlocking inside a MediaDataSource callback). For a streamed
+        // audiobook that is one socket read per track. Resolve here, on IO, so the
+        // main-thread hop below never probes anything.
+        val resolvedReadingOrder = withContext(Dispatchers.IO) {
+            resolveTrackDurations(publication, publication.readingOrder)
+        }
+
         mainScope.async {
             audioNavigator = navigatorFactory.createNavigator(
                 this@AudiobookNavigator.initialLocator,
-                preferences.toExoPlayerPreferences()
+                preferences.toExoPlayerPreferences(),
+                resolvedReadingOrder,
             ).getOrElse { error ->
                 Log.e(TAG, ":initNavigator - $error")
                 throw Exception(PublicationError.invoke(error).message)

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigator.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigator.kt
@@ -78,16 +78,23 @@ open class AudiobookNavigator(
             throw Exception("Couldn't create AudioNavigatorFactory")
         }
 
-        // Readium's createNavigator falls back to MediaMetadataRetriever for every
-        // reading-order item without a duration, and that fallback blocks the calling
-        // thread (runBlocking inside a MediaDataSource callback). For a streamed
-        // audiobook that is one socket read per track. Resolve here, on IO, so the
-        // main-thread hop below never probes anything.
-        val resolvedReadingOrder = withContext(Dispatchers.IO) {
-            resolveTrackDurations(publication, publication.readingOrder)
-        }
-
         mainScope.async {
+            // Readium's createNavigator falls back to MediaMetadataRetriever for every
+            // reading-order item without a duration, and that fallback blocks the
+            // calling thread (runBlocking inside a MediaDataSource callback). For a
+            // streamed audiobook that is one socket read per track. Resolve first, on
+            // IO, so the createNavigator call below never probes anything.
+            //
+            // This sits inside mainScope rather than on the caller's coroutine so
+            // dispose() can stop it: dispose() calls cancelChildren() on this scope,
+            // which cancels its children but leaves the scope's own Job alive. Probed
+            // from the caller instead, a release() arriving mid-probe cancelled nothing
+            // and this async went on to build a live navigator and MediaSession for a
+            // reader that had already torn down.
+            val resolvedReadingOrder = withContext(Dispatchers.IO) {
+                resolveTrackDurations(publication, publication.readingOrder)
+            }
+
             audioNavigator = navigatorFactory.createNavigator(
                 this@AudiobookNavigator.initialLocator,
                 preferences.toExoPlayerPreferences(),

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbe.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbe.kt
@@ -1,0 +1,114 @@
+package dev.mulev.flureadium.navigators
+
+import android.media.MediaDataSource
+import android.media.MediaMetadataRetriever
+import android.media.MediaMetadataRetriever.METADATA_KEY_DURATION
+import android.util.Log
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.getOrElse
+import org.readium.r2.shared.util.resource.Resource
+import java.io.IOException
+
+private const val TAG = "TrackDurationProbe"
+
+/**
+ * Returns [links] with every missing duration probed from the track itself.
+ *
+ * Readium's own fallback (AudioNavigatorFactory.createNavigator -> MetadataRetriever)
+ * does this from whatever thread calls it, and it blocks: MediaMetadataRetriever's
+ * MediaDataSource callbacks are synchronous, so a streamed track parks the caller on
+ * a socket read. This runs the same work up front, off the main thread, so the
+ * factory's fallback never fires.
+ *
+ * MUST be called from a blocking-tolerant dispatcher — [kotlinx.coroutines.Dispatchers.IO].
+ * A link that already declares a positive duration is returned untouched, with no
+ * probe and no network request. A probe that fails leaves the duration `null`,
+ * never `0.0`: Readium reads `0.0` as "missing" (`takeUnless { it == Duration.ZERO }`)
+ * and would fall straight back into the blocking path, and
+ * `AudioNavigatorFactory.invoke` rejects a publication outright when any
+ * reading-order duration is `0.0`.
+ *
+ * @param concurrency how many tracks are probed at once, so an N-track book costs
+ *   about N/[concurrency] round-trips instead of N.
+ */
+internal suspend fun resolveTrackDurations(
+    publication: Publication,
+    links: List<Link>,
+    concurrency: Int = 4,
+): List<Link> = coroutineScope {
+    val gate = Semaphore(concurrency)
+
+    links
+        .map { link ->
+            async {
+                val declared = link.duration
+                if (declared != null && declared > 0.0) {
+                    link
+                } else {
+                    gate.withPermit { link.copy(duration = probeDuration(publication, link)) }
+                }
+            }
+        }
+        .awaitAll()
+}
+
+/** The track's duration in seconds, or `null` when it cannot be read. Never `0.0`. */
+private fun probeDuration(publication: Publication, link: Link): Double? {
+    val resource = publication.get(link) ?: return null
+    val retriever = MediaMetadataRetriever()
+
+    return try {
+        retriever.setDataSource(ResourceMediaDataSource(resource))
+        retriever.extractMetadata(METADATA_KEY_DURATION)
+            ?.toIntOrNull()
+            ?.takeIf { it > 0 }
+            ?.let { it / 1000.0 }
+    } catch (e: Exception) {
+        Log.w(TAG, ":probeDuration - ${link.href} unavailable: ${e.message}")
+        null
+    } finally {
+        // release(), not close(): close() is API 29 and this module's minSdk is 24.
+        retriever.release()
+        resource.close()
+    }
+}
+
+/**
+ * Bridges a Readium [Resource] to the synchronous [MediaDataSource] the platform
+ * retriever demands. `runBlocking` here is deliberate: the whole probe runs on
+ * Dispatchers.IO, where blocking a thread is what the thread is for.
+ */
+internal class ResourceMediaDataSource(
+    private val resource: Resource,
+) : MediaDataSource() {
+
+    override fun readAt(position: Long, buffer: ByteArray, offset: Int, size: Int): Int {
+        if (size == 0) return 0
+
+        val data = runBlocking {
+            resource.read(position until position + size)
+                .getOrElse { throw IOException("Resource read failed: $it") }
+        }
+
+        if (data.isEmpty()) return -1
+
+        data.copyInto(buffer, offset)
+        return data.size
+    }
+
+    override fun getSize(): Long =
+        runBlocking {
+            resource.length()
+                .getOrElse { throw IOException("Resource length failed: $it") }
+        }
+
+    /** No-op: [probeDuration]'s `finally` owns the resource's lifetime, so it closes exactly once. */
+    override fun close() = Unit
+}

--- a/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbe.kt
+++ b/flureadium/android/src/main/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbe.kt
@@ -24,8 +24,11 @@ private const val TAG = "TrackDurationProbe"
  * Readium's own fallback (AudioNavigatorFactory.createNavigator -> MetadataRetriever)
  * does this from whatever thread calls it, and it blocks: MediaMetadataRetriever's
  * MediaDataSource callbacks are synchronous, so a streamed track parks the caller on
- * a socket read. This runs the same work up front, off the main thread, so the
- * factory's fallback never fires.
+ * a socket read. This runs the same work up front, off the main thread, so that
+ * fallback fires only for the tracks this probe could not resolve. Each of those
+ * still costs one blocking probe on whatever thread calls `createNavigator`, which
+ * for [AudiobookNavigator] is the Android main thread — a track left `null` is
+ * cheaper than a book that refuses to open, not free.
  *
  * MUST be called from a blocking-tolerant dispatcher — [kotlinx.coroutines.Dispatchers.IO].
  * A link that already declares a positive duration is returned untouched, with no

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/AudioNavigatorPublishOrderConventionTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/AudioNavigatorPublishOrderConventionTest.kt
@@ -1,0 +1,90 @@
+package dev.mulev.flureadium
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * An audio navigator must be assigned to its field before `initNavigator()` runs.
+ *
+ * `AudiobookNavigator.initNavigator` resolves missing track durations on
+ * `Dispatchers.IO` before it touches the main thread, so it suspends — for a
+ * 246-track streamed book, for as long as those requests take. Anything arriving
+ * on the reader in that window runs against the field as it is: `stop()`,
+ * `audioDisable()` and a second `audioEnable()` all call
+ * `audiobookNavigator?.release()`.
+ *
+ * Written as `field = Navigator(...).apply { initNavigator() }`, the assignment
+ * happens only after `initNavigator()` returns. The field stays null for the whole
+ * suspension, so a concurrent teardown releases nothing and the init that is still
+ * in flight then installs a live AudioNavigator, media service and MediaSession
+ * into a reader that was already told to stop. Publishing the field first also
+ * lets `release()`'s `mainScope.cancelChildren()` reach the pending
+ * `mainScope.async`.
+ *
+ * This was safe until durations moved off the main thread: `initNavigator()` held
+ * the looper, so nothing could interleave. It is not safe now, and the shape that
+ * caused it is invisible at a glance — hence this test.
+ *
+ * The other navigators (EPUB, PDF, image, TTS) do not probe durations and do not
+ * suspend before publishing, so `.apply { initNavigator() }` remains fine for them
+ * and this test deliberately ignores them.
+ */
+internal class AudioNavigatorPublishOrderConventionTest {
+
+    /** A call with no receiver, so it runs inside an `apply`/`run` scope. */
+    private val bareInitNavigator = Regex("""(^|[^.\w])initNavigator\(\)""")
+
+    @Test
+    fun audioNavigatorsArePublishedBeforeInitNavigatorRuns() {
+        val sourceRoot = mainSourceRoot()
+        val sources = sourceRoot.walkTopDown().filter { it.extension == "kt" }.toList()
+        assertTrue(sources.isNotEmpty(), "found no Kotlin sources under ${sourceRoot.absolutePath}")
+
+        val offenders = sources.flatMap { file -> unpublishedAudioInitsIn(file) }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "audio navigators whose initNavigator() runs before the field is assigned — " +
+                "assign the field, then call initNavigator() on it:\n" +
+                offenders.joinToString("\n") { "  $it" },
+        )
+    }
+
+    /**
+     * Bare `initNavigator()` calls in [file] whose enclosing construction names an
+     * audio navigator. `SyncAudiobookNavigator` contains `AudiobookNavigator`, so
+     * one needle catches both.
+     */
+    private fun unpublishedAudioInitsIn(file: File): List<String> {
+        val lines = file.readLines()
+        return lines.indices
+            .filter { bareInitNavigator.containsMatchIn(lines[it]) }
+            .filter { index -> constructsAudioNavigatorAbove(lines, index) }
+            .map { index -> "${file.name}:${index + 1}: ${lines[index].trim()}" }
+    }
+
+    /**
+     * Whether the statement the call at [index] belongs to constructs an audio
+     * navigator. The construction can wrap over several lines, so the search walks
+     * back to the line that opened the expression.
+     */
+    private fun constructsAudioNavigatorAbove(lines: List<String>, index: Int): Boolean =
+        (index - 1 downTo maxOf(0, index - LOOKBEHIND)).asSequence()
+            .map { lines[it] }
+            .takeWhile { "=" !in it || "AudiobookNavigator" in it }
+            .any { "AudiobookNavigator" in it }
+
+    private fun mainSourceRoot(): File {
+        val start = File("").absoluteFile
+        return generateSequence(start) { it.parentFile }
+            .map { File(it, "src/main/kotlin") }
+            .firstOrNull { it.isDirectory }
+            ?: error("cannot locate src/main/kotlin from $start")
+    }
+
+    private companion object {
+        /** Longest audio-navigator construction in the plugin spans 5 lines; 8 is slack. */
+        const val LOOKBEHIND = 8
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/AudioNavigatorPublishOrderConventionTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/AudioNavigatorPublishOrderConventionTest.kt
@@ -7,28 +7,31 @@ import kotlin.test.assertTrue
 /**
  * An audio navigator must be assigned to its field before `initNavigator()` runs.
  *
- * `AudiobookNavigator.initNavigator` resolves missing track durations on
- * `Dispatchers.IO` before it touches the main thread, so it suspends — for a
- * 246-track streamed book, for as long as those requests take. Anything arriving
- * on the reader in that window runs against the field as it is: `stop()`,
- * `audioDisable()` and a second `audioEnable()` all call
+ * `AudiobookNavigator.initNavigator` resolves missing track durations off the main
+ * thread, so it suspends — for a 246-track streamed book, for as long as those
+ * requests take. Anything arriving on the reader in that window runs against the
+ * field as it is: `stop()`, `audioDisable()` and a second `audioEnable()` all call
  * `audiobookNavigator?.release()`.
  *
  * Written as `field = Navigator(...).apply { initNavigator() }`, the assignment
  * happens only after `initNavigator()` returns. The field stays null for the whole
- * suspension, so a concurrent teardown releases nothing and the init that is still
- * in flight then installs a live AudioNavigator, media service and MediaSession
- * into a reader that was already told to stop. Publishing the field first also
- * lets `release()`'s `mainScope.cancelChildren()` reach the pending
- * `mainScope.async`.
+ * suspension, so a concurrent teardown releases nothing and the init still in
+ * flight then installs a live AudioNavigator, media service and MediaSession into a
+ * reader that was already told to stop.
  *
- * This was safe until durations moved off the main thread: `initNavigator()` held
- * the looper, so nothing could interleave. It is not safe now, and the shape that
- * caused it is invisible at a glance — hence this test.
+ * Publishing the field is necessary but not sufficient, and the other half lives in
+ * `AudiobookNavigator.initNavigator` rather than here: the duration probe runs
+ * inside `mainScope`, so `dispose()`'s `cancelChildren()` reaches it. Probed on the
+ * caller's coroutine it was outside that scope, and `cancelChildren()` does not
+ * cancel the scope's own Job, so a release() arriving mid-probe cancelled nothing.
  *
- * The other navigators (EPUB, PDF, image, TTS) do not probe durations and do not
- * suspend before publishing, so `.apply { initNavigator() }` remains fine for them
- * and this test deliberately ignores them.
+ * This was all safe until durations moved off the main thread: `initNavigator()`
+ * held the looper, so nothing could interleave. It is not safe now, and the shape
+ * that caused it is invisible at a glance — hence this test.
+ *
+ * Only the audio navigators probe durations, so only they are checked here. EPUB,
+ * PDF, image and TTS still use `.apply { initNavigator() }`; whether any of them
+ * suspends before publishing is a separate question this test makes no claim about.
  */
 internal class AudioNavigatorPublishOrderConventionTest {
 

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigatorDurationResolutionTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigatorDurationResolutionTest.kt
@@ -31,12 +31,19 @@ import kotlin.test.assertTrue
 private const val NAVIGATOR_PATH = "dev/mulev/flureadium/navigators/AudiobookNavigator.kt"
 
 /**
- * `AudiobookNavigator.initNavigator` must resolve missing track durations before it
- * hops to `mainScope`, and hand the result to Readium's `createNavigator`. Otherwise
+ * `AudiobookNavigator.initNavigator` must resolve missing track durations on
+ * `Dispatchers.IO` and hand the result to Readium's `createNavigator`. Otherwise
  * Readium's own duration fallback runs on the Android main thread and parks it on one
- * socket read per un-timed track — the ANR this phase fixes.
+ * socket read per un-timed track — the ANR this work fixes.
  *
- * The first case is behavioural. The other two read the source, because `initNavigator`
+ * The IO hop belongs *inside* `mainScope.async`, not before it. `dispose()` cancels
+ * that scope's children and `cancelChildren()` leaves the scope's own Job alive, so a
+ * probe started outside the scope survives a `release()` and goes on to build a live
+ * navigator and MediaSession for a reader that has already torn down. Sitting inside
+ * the scope costs nothing: `withContext(Dispatchers.IO)` is what keeps the work off
+ * the main thread, not the position relative to the hop.
+ *
+ * The first case is behavioural. The others read the source, because `initNavigator`
  * builds its `ExoPlayerNavigatorFactory` inline and there is no seam to observe the
  * call from a JVM test; adding an injection point only a test would use is the
  * speculative parameter YAGNI forbids. This repo already guards conventions that way —
@@ -78,18 +85,35 @@ internal class AudiobookNavigatorDurationResolutionTest {
     }
 
     @Test
-    fun initNavigatorResolvesDurationsBeforeTheMainThreadHop() {
+    fun durationsResolveOnIoBeforeCreateNavigatorRuns() {
         val body = initNavigatorBody()
 
         val ioHop = body.indexOfFirst { "withContext(Dispatchers.IO)" in it }
         val resolution = body.indexOfFirst { "resolveTrackDurations(" in it }
-        val mainHop = body.indexOfFirst { "mainScope.async {" in it }
+        val create = body.indexOfFirst { "createNavigator(" in it }
 
         assertTrue(ioHop >= 0, "initNavigator never switches to Dispatchers.IO")
         assertTrue(resolution >= 0, "initNavigator never calls resolveTrackDurations")
+        assertTrue(create >= 0, "initNavigator no longer calls createNavigator")
+        assertTrue(ioHop < resolution, "resolveTrackDurations must run inside the IO hop")
+        assertTrue(resolution < create, "durations must be resolved before createNavigator runs")
+    }
+
+    @Test
+    fun theIoHopSitsInsideMainScopeSoDisposeCanCancelIt() {
+        val body = initNavigatorBody()
+
+        val mainHop = body.indexOfFirst { "mainScope.async {" in it }
+        val ioHop = body.indexOfFirst { "withContext(Dispatchers.IO)" in it }
+
         assertTrue(mainHop >= 0, "initNavigator no longer hops to mainScope")
-        assertTrue(ioHop < mainHop, "the IO hop must come before the main-thread hop")
-        assertTrue(resolution < mainHop, "durations must be resolved before the main-thread hop")
+        assertTrue(ioHop >= 0, "initNavigator never switches to Dispatchers.IO")
+        assertTrue(
+            mainHop < ioHop,
+            "the IO hop must sit inside mainScope.async so dispose()'s cancelChildren() " +
+                "reaches the probe — started outside that scope, a release() arriving " +
+                "mid-probe cancels nothing and this init still builds a live navigator",
+        )
     }
 
     @Test

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigatorDurationResolutionTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/AudiobookNavigatorDurationResolutionTest.kt
@@ -1,0 +1,132 @@
+package dev.mulev.flureadium.navigators
+
+import android.os.Build
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Href
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertTrue
+
+private const val NAVIGATOR_PATH = "dev/mulev/flureadium/navigators/AudiobookNavigator.kt"
+
+/**
+ * `AudiobookNavigator.initNavigator` must resolve missing track durations before it
+ * hops to `mainScope`, and hand the result to Readium's `createNavigator`. Otherwise
+ * Readium's own duration fallback runs on the Android main thread and parks it on one
+ * socket read per un-timed track — the ANR this phase fixes.
+ *
+ * The first case is behavioural. The other two read the source, because `initNavigator`
+ * builds its `ExoPlayerNavigatorFactory` inline and there is no seam to observe the
+ * call from a JVM test; adding an injection point only a test would use is the
+ * speculative parameter YAGNI forbids. This repo already guards conventions that way —
+ * see `CoroutineScopeHandlerConventionTest`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+@OptIn(ExperimentalReadiumApi::class, ExperimentalCoroutinesApi::class)
+internal class AudiobookNavigatorDurationResolutionTest {
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun probingRunsOffTheMainDispatcher() {
+        val publication = mock(Publication::class.java)
+        val link = Link(href = Href(Url("t1.mp3")!!), mediaType = MediaType.MP3)
+        val probeThread = AtomicReference<Thread>()
+        `when`(publication.get(link)).thenAnswer {
+            probeThread.set(Thread.currentThread())
+            null
+        }
+
+        val callerThread = AtomicReference<Thread>()
+        runBlocking(Dispatchers.Main) {
+            callerThread.set(Thread.currentThread())
+            withContext(Dispatchers.IO) { resolveTrackDurations(publication, listOf(link)) }
+        }
+
+        assertNotNull(probeThread.get(), "the probe never ran")
+        assertNotSame(callerThread.get(), probeThread.get(), "the probe ran on the calling thread")
+    }
+
+    @Test
+    fun initNavigatorResolvesDurationsBeforeTheMainThreadHop() {
+        val body = initNavigatorBody()
+
+        val ioHop = body.indexOfFirst { "withContext(Dispatchers.IO)" in it }
+        val resolution = body.indexOfFirst { "resolveTrackDurations(" in it }
+        val mainHop = body.indexOfFirst { "mainScope.async {" in it }
+
+        assertTrue(ioHop >= 0, "initNavigator never switches to Dispatchers.IO")
+        assertTrue(resolution >= 0, "initNavigator never calls resolveTrackDurations")
+        assertTrue(mainHop >= 0, "initNavigator no longer hops to mainScope")
+        assertTrue(ioHop < mainHop, "the IO hop must come before the main-thread hop")
+        assertTrue(resolution < mainHop, "durations must be resolved before the main-thread hop")
+    }
+
+    @Test
+    fun createNavigatorReceivesResolvedReadingOrder() {
+        val body = initNavigatorBody()
+
+        val call = body.indexOfFirst { "createNavigator(" in it }
+        assertTrue(call >= 0, "initNavigator no longer calls createNavigator")
+        val closerOffset = body.subList(call, body.size).indexOfFirst { ").getOrElse" in it }
+        assertTrue(closerOffset > 0, "cannot find the end of the createNavigator call")
+
+        assertTrue(
+            body.subList(call, call + closerOffset).any { "resolvedReadingOrder" in it },
+            "createNavigator is not given the resolved reading order",
+        )
+    }
+
+    /** `initNavigator`'s source lines, from its signature to its closing brace. */
+    private fun initNavigatorBody(): List<String> {
+        val lines = File(mainSourceRoot(), NAVIGATOR_PATH).readLines()
+        val start = lines.indexOfFirst { "override suspend fun initNavigator()" in it }
+        assertTrue(start >= 0, "cannot find initNavigator in $NAVIGATOR_PATH")
+        val closerOffset = lines.subList(start + 1, lines.size).indexOfFirst { it == "    }" }
+        assertTrue(closerOffset >= 0, "cannot find the end of initNavigator")
+        return lines.subList(start, start + closerOffset + 2)
+    }
+
+    /**
+     * The same walk-up `CoroutineScopeHandlerConventionTest` uses. Duplicated on purpose:
+     * a shared test-helper file for two unrelated convention tests would be the
+     * catch-all-helpers anti-pattern, and widening that test's private is worse.
+     */
+    private fun mainSourceRoot(): File {
+        val start = File("").absoluteFile
+        return generateSequence(start) { it.parentFile }
+            .map { File(it, "src/main/kotlin") }
+            .firstOrNull { it.isDirectory }
+            ?: error("cannot locate src/main/kotlin from $start")
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbeTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbeTest.kt
@@ -1,0 +1,279 @@
+package dev.mulev.flureadium.navigators
+
+import android.media.MediaMetadataRetriever
+import android.os.Build
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Href
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.data.ReadError
+import org.readium.r2.shared.util.mediatype.MediaType
+import org.readium.r2.shared.util.resource.FailureResource
+import org.readium.r2.shared.util.resource.Resource
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowMediaMetadataRetriever
+import org.robolectric.shadows.util.DataSource
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Behaviour of [resolveTrackDurations] and the [ResourceMediaDataSource] bridge it
+ * probes through. No test here builds a navigator, and none touches a network: the
+ * resource is a hand-written fake and the retriever is Robolectric's shadow.
+ *
+ * The load-bearing assertion is that a failed probe leaves the duration `null` and
+ * never `0.0` — Readium reads `0.0` as "missing" and refuses to open a publication
+ * whose reading order declares it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+@OptIn(ExperimentalReadiumApi::class, ExperimentalCoroutinesApi::class)
+internal class TrackDurationProbeTest {
+
+    @AfterTest
+    fun tearDown() {
+        // The shadow's metadata and exception maps are static.
+        ShadowMediaMetadataRetriever.reset()
+    }
+
+    @Test
+    fun declaredDurationPassesThroughWithoutProbe() = runBlocking {
+        val publication = mock(Publication::class.java)
+        val link = trackLink("t1.mp3", duration = 300.0)
+
+        val result = resolveTrackDurations(publication, listOf(link))
+
+        assertSame(link, result[0])
+        assertEquals(300.0, result[0].duration)
+        verifyNoInteractions(publication)
+    }
+
+    @Test
+    fun missingDurationIsProbedAndFilled() = runBlocking {
+        stubDuration("90000")
+        val publication = mock(Publication::class.java)
+        val link = trackLink("t1.mp3")
+        `when`(publication.get(link)).thenReturn(FakeResource())
+
+        val result = resolveTrackDurations(publication, listOf(link))
+
+        assertEquals(90.0, result[0].duration)
+    }
+
+    @Test
+    fun zeroDeclaredDurationIsTreatedAsMissing() = runBlocking {
+        stubDuration("90000")
+        val publication = mock(Publication::class.java)
+        val link = trackLink("t1.mp3", duration = 0.0)
+        `when`(publication.get(link)).thenReturn(FakeResource())
+
+        val result = resolveTrackDurations(publication, listOf(link))
+
+        verify(publication).get(link)
+        assertEquals(90.0, result[0].duration)
+    }
+
+    @Test
+    fun failedProbeLeavesDurationNull() = runBlocking {
+        stubDuration("90000")
+        armProbeFailure()
+        val publication = mock(Publication::class.java)
+        val link = trackLink("t1.mp3")
+        `when`(publication.get(link)).thenReturn(FakeResource())
+
+        val result = resolveTrackDurations(publication, listOf(link))
+
+        assertNull(result[0].duration)
+        assertNotEquals(0.0, result[0].duration)
+    }
+
+    @Test
+    fun unreadableDurationLeavesDurationNull() = runBlocking {
+        val publication = mock(Publication::class.java)
+        val link = trackLink("t1.mp3")
+        `when`(publication.get(link)).thenReturn(FakeResource())
+
+        val noMetadata = resolveTrackDurations(publication, listOf(link))
+        assertNull(noMetadata[0].duration)
+
+        stubDuration("0")
+        val zeroMetadata = resolveTrackDurations(publication, listOf(link))
+        assertNull(zeroMetadata[0].duration)
+        assertNotEquals(0.0, zeroMetadata[0].duration)
+    }
+
+    @Test
+    fun missingResourceLeavesDurationNull() = runBlocking {
+        stubDuration("90000")
+        val publication = mock(Publication::class.java)
+        val link = trackLink("t1.mp3")
+        `when`(publication.get(link)).thenReturn(null)
+
+        val result = resolveTrackDurations(publication, listOf(link))
+
+        assertNull(result[0].duration)
+    }
+
+    @Test
+    fun inputOrderIsPreserved() = runBlocking {
+        stubDuration("90000")
+        val publication = mock(Publication::class.java)
+        val links = (1..5).map { trackLink("t$it.mp3", duration = if (it % 2 == 1) 120.0 else null) }
+        links.forEach { `when`(publication.get(it)).thenReturn(FakeResource()) }
+
+        val result = resolveTrackDurations(publication, links)
+
+        assertEquals(links.map { it.href.toString() }, result.map { it.href.toString() })
+        assertEquals(listOf(120.0, 90.0, 120.0, 90.0, 120.0), result.map { it.duration })
+    }
+
+    @Test
+    fun concurrencyIsBounded() = runBlocking(Dispatchers.IO) {
+        stubDuration("90000")
+        val publication = mock(Publication::class.java)
+        val links = (1..10).map { trackLink("t$it.mp3") }
+        val inFlight = AtomicInteger()
+        val peak = AtomicInteger()
+        val threeInFlight = CountDownLatch(3)
+        val release = CountDownLatch(1)
+        links.forEach { link ->
+            `when`(publication.get(link)).thenAnswer {
+                val live = inFlight.incrementAndGet()
+                peak.updateAndGet { maxOf(it, live) }
+                threeInFlight.countDown()
+                release.await(5, TimeUnit.SECONDS)
+                inFlight.decrementAndGet()
+                FakeResource()
+            }
+        }
+
+        val resolution = async { resolveTrackDurations(publication, links, concurrency = 3) }
+
+        assertTrue(threeInFlight.await(5, TimeUnit.SECONDS), "three probes never overlapped")
+        assertEquals(3, peak.get(), "a fourth probe got past the semaphore")
+        release.countDown()
+
+        assertEquals(10, resolution.await().size)
+        assertEquals(3, peak.get(), "more than three probes overlapped while draining")
+    }
+
+    @Test
+    fun resourceIsClosedForEveryProbe() = runBlocking {
+        stubDuration("90000")
+        val publication = mock(Publication::class.java)
+        val links = (1..3).map { trackLink("t$it.mp3") }
+
+        val onSuccess = stubResourcesFor(publication, links)
+        resolveTrackDurations(publication, links)
+        assertTrue(onSuccess.all { it.closed }, "a successful probe leaked its resource")
+
+        armProbeFailure()
+        val onFailure = stubResourcesFor(publication, links)
+        val result = resolveTrackDurations(publication, links)
+
+        assertTrue(onFailure.all { it.closed }, "a failed probe leaked its resource")
+        assertTrue(result.all { it.duration == null })
+    }
+
+    @Test
+    fun resourceMediaDataSourceBridgesReadsToTheResource() {
+        val resource = FakeResource("abcdefgh".toByteArray())
+        val source = ResourceMediaDataSource(resource)
+        val buffer = ByteArray(8)
+
+        assertEquals(8L, source.getSize())
+        assertEquals(3, source.readAt(2, buffer, 0, 3))
+        assertEquals("cde", String(buffer, 0, 3))
+        assertEquals(0, source.readAt(0, buffer, 0, 0))
+        assertEquals(1, resource.reads, "a zero-size read must not touch the resource")
+        assertEquals(-1, source.readAt(8, buffer, 0, 3))
+
+        source.close()
+        assertFalse(resource.closed, "the bridge must not own the resource's lifetime")
+
+        val failing = ResourceMediaDataSource(FailureResource(ReadError.Decoding("boom")))
+        assertFailsWith<IOException> { failing.getSize() }
+        assertFailsWith<IOException> { failing.readAt(0, buffer, 0, 3) }
+    }
+
+    private fun trackLink(name: String, duration: Double? = null) =
+        Link(href = Href(Url(name)!!), mediaType = MediaType.MP3, duration = duration)
+
+    private fun stubResourcesFor(publication: Publication, links: List<Link>): List<FakeResource> =
+        links.map { link ->
+            FakeResource().also { `when`(publication.get(link)).thenReturn(it) }
+        }
+
+    /**
+     * Robolectric collapses every [android.media.MediaDataSource] to the constant key
+     * `"MediaDataSource"` (`shadows/util/DataSource.java`), so one registration arms
+     * every probe in a test.
+     */
+    private fun probeDataSource(): DataSource =
+        DataSource.toDataSource(ResourceMediaDataSource(FakeResource()))
+
+    private fun stubDuration(millis: String) =
+        ShadowMediaMetadataRetriever.addMetadata(
+            probeDataSource(),
+            MediaMetadataRetriever.METADATA_KEY_DURATION,
+            millis,
+        )
+
+    private fun armProbeFailure() =
+        ShadowMediaMetadataRetriever.addException(
+            probeDataSource(),
+            IllegalStateException("setDataSource failed"),
+        )
+
+    /** A [Resource] over in-memory bytes that records its reads and its close. */
+    private class FakeResource(private val bytes: ByteArray = ByteArray(0)) : Resource {
+        var closed = false
+            private set
+
+        var reads = 0
+            private set
+
+        override val sourceUrl: AbsoluteUrl? = null
+
+        override suspend fun properties(): Try<Resource.Properties, ReadError> =
+            Try.success(Resource.Properties())
+
+        override suspend fun length(): Try<Long, ReadError> = Try.success(bytes.size.toLong())
+
+        override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> {
+            reads++
+            if (range == null) return Try.success(bytes)
+            val from = range.first.toInt().coerceIn(0, bytes.size)
+            val until = (range.last.toInt() + 1).coerceIn(from, bytes.size)
+            return Try.success(bytes.copyOfRange(from, until))
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbeTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbeTest.kt
@@ -2,6 +2,7 @@ package dev.mulev.flureadium.navigators
 
 import android.media.MediaMetadataRetriever
 import android.os.Build
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -179,6 +180,37 @@ internal class TrackDurationProbeTest {
 
         assertEquals(10, resolution.await().size)
         assertEquals(3, peak.get(), "more than three probes overlapped while draining")
+    }
+
+    @Test
+    fun cancellingTheCallerCancelsTheResolution() = runBlocking(Dispatchers.IO) {
+        stubDuration("90000")
+        val publication = mock(Publication::class.java)
+        val links = (1..3).map { trackLink("t$it.mp3") }
+        val firstProbeStarted = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        links.forEach { link ->
+            `when`(publication.get(link)).thenAnswer {
+                firstProbeStarted.countDown()
+                release.await(5, TimeUnit.SECONDS)
+                FakeResource()
+            }
+        }
+
+        // concurrency = 1, so probes two and three park on the semaphore. That is a real
+        // suspension point for the cancellation to land on, rather than a race against
+        // start-up that would pass even if the resolution ignored cancellation entirely.
+        val resolution = async { resolveTrackDurations(publication, links, concurrency = 1) }
+
+        assertTrue(
+            firstProbeStarted.await(5, TimeUnit.SECONDS),
+            "no probe ever started, so cancelling below would prove nothing",
+        )
+        resolution.cancel()
+        release.countDown()
+
+        assertFailsWith<CancellationException> { resolution.await() }
+        assertTrue(resolution.isCancelled, "resolveTrackDurations must honour cancellation")
     }
 
     @Test

--- a/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbeTest.kt
+++ b/flureadium/android/src/test/kotlin/dev/mulev/flureadium/navigators/TrackDurationProbeTest.kt
@@ -183,23 +183,24 @@ internal class TrackDurationProbeTest {
     }
 
     @Test
-    fun cancellingTheCallerCancelsTheResolution() = runBlocking(Dispatchers.IO) {
+    fun cancellingTheCallerStopsTheRemainingProbes() = runBlocking(Dispatchers.IO) {
         stubDuration("90000")
         val publication = mock(Publication::class.java)
         val links = (1..3).map { trackLink("t$it.mp3") }
+        val probes = AtomicInteger()
         val firstProbeStarted = CountDownLatch(1)
         val release = CountDownLatch(1)
         links.forEach { link ->
             `when`(publication.get(link)).thenAnswer {
+                probes.incrementAndGet()
                 firstProbeStarted.countDown()
                 release.await(5, TimeUnit.SECONDS)
                 FakeResource()
             }
         }
 
-        // concurrency = 1, so probes two and three park on the semaphore. That is a real
-        // suspension point for the cancellation to land on, rather than a race against
-        // start-up that would pass even if the resolution ignored cancellation entirely.
+        // concurrency = 1, so probes two and three park on the semaphore's withPermit —
+        // a real suspension for the cancellation to land on.
         val resolution = async { resolveTrackDurations(publication, links, concurrency = 1) }
 
         assertTrue(
@@ -208,9 +209,14 @@ internal class TrackDurationProbeTest {
         )
         resolution.cancel()
         release.countDown()
+        resolution.join()
 
+        // The count is the assertion that matters. `isCancelled` and a throwing `await()`
+        // are true of any cancelled Deferred whether or not its body cooperated, so they
+        // would pass over a resolution wrapped in NonCancellable; this would not.
+        assertEquals(1, probes.get(), "cancellation did not stop the queued probes")
         assertFailsWith<CancellationException> { resolution.await() }
-        assertTrue(resolution.isCancelled, "resolveTrackDurations must honour cancellation")
+        assertTrue(resolution.isCancelled)
     }
 
     @Test

--- a/flureadium/docs/getting-started/installation.md
+++ b/flureadium/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ Add Flureadium to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flureadium: ^0.19.0
+  flureadium: ^0.19.1
 ```
 
 Run:

--- a/flureadium/docs/guides/audiobook-playback.md
+++ b/flureadium/docs/guides/audiobook-playback.md
@@ -67,6 +67,14 @@ If your manifest declares a duration for every track, none of this runs: the
 declared values are used as they are and no extra request is made. Publishing
 durations in the manifest is the fastest way to open a streamed audiobook.
 
+A read can fail — a track the manifest points at may be gone, or the server may
+refuse a range request. That track then keeps no duration at all rather than a
+zero one, because a zero length makes Readium reject the whole publication, and
+a book that opens with one unknown track length beats a book that will not open.
+Readium retries that track itself while it builds the navigator, on the UI
+thread, so a run of failed reads still costs a pause even though the successful
+ones no longer do.
+
 ## Playback Controls
 
 ### Basic Controls

--- a/flureadium/docs/guides/audiobook-playback.md
+++ b/flureadium/docs/guides/audiobook-playback.md
@@ -51,6 +51,22 @@ await flureadium.audioEnable(
 );
 ```
 
+### Track Durations and Streamed Audiobooks
+
+A manifest does not have to state how long each track is. When one is missing,
+flureadium reads it from the audio file itself, and reading it means fetching
+part of that file. For a streamed audiobook that is one network request per
+track.
+
+Those reads now happen on a background dispatcher, in parallel, before the
+navigator is built. Earlier versions did them one at a time on the Android UI
+thread while opening the book, which froze the app for as long as the requests
+took.
+
+If your manifest declares a duration for every track, none of this runs: the
+declared values are used as they are and no extra request is made. Publishing
+durations in the manifest is the fastest way to open a streamed audiobook.
+
 ## Playback Controls
 
 ### Basic Controls

--- a/flureadium/example/pubspec.lock
+++ b/flureadium/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.19.0"
+    version: "0.19.1"
   flureadium_platform_interface:
     dependency: "direct overridden"
     description:

--- a/flureadium/pubspec.yaml
+++ b/flureadium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flureadium
 description: "Flutter plugin for reading EPUB ebooks, audiobooks, and comics using the Readium toolkits. Supports EPUB 2/3, PDF, TTS, audiobook playback, highlights, and reading preferences."
-version: 0.19.0
+version: 0.19.1
 homepage: https://github.com/mulev/flureadium
 repository: https://github.com/mulev/flureadium
 issue_tracker: https://github.com/mulev/flureadium/issues


### PR DESCRIPTION
## What

Opening a streamed audiobook blocked the Android main thread for 10 to 13 seconds and tripped Android's not-responding dialog. This moves that work off the main thread.

Readium works out a reading-order item's missing duration by reading the audio file itself, and those reads sit inside `runBlocking` in a `MediaDataSource`. This package built the audiobook navigator on `Dispatchers.Main.immediate`, so the read happened on the thread Android watches. Against a local file that is a disk seek nobody notices. Against a streamed book it is an HTTPS round trip per track, in sequence.

`TrackDurationProbe` now resolves missing durations on `Dispatchers.IO` with bounded concurrency, before the navigator is built. `initNavigator` hands the resolved reading order to Readium's `createNavigator`, so Readium's own blocking fallback never fires.

Two details worth knowing if you review this:

- A failed probe leaves the duration `null`, never `0.0`. Readium refuses a publication outright when a reading-order entry declares a zero duration, so writing zero would convert a missing track length into a book that will not open at all. A duration the manifest declares as `0.0` is treated as missing for the same reason.
- ExoPlayer construction stays on the main thread deliberately. media3 enforces single-thread affinity and this package already drives the player from `mainScope` at six call sites. Only the probing moved.

## Evidence

Measured on a Xiaomi 25028RN03Y opening a 246-track streamed Gutenberg audiobook: 412 ms from tap to `ExoPlayerImpl: Init`, against 10.4 to 12.8 seconds before the change. No ANR, no `APP_SCOUT_HANG`, no dropped-frame warnings in the capture.

One caveat on that measurement. The book's manifest declared its per-track durations, so the run exercised the pass-through branch rather than the probe, and the pre-change code would not have probed that book either. It shows the pass-through costs nothing and that nothing regressed. The probing branch is covered by 13 JVM tests: the dispatcher assertion, order preservation under bounded concurrency, a declared zero treated as missing, a failed probe yielding null rather than zero, and the `ResourceMediaDataSource` bridge.

`./validate run finalize` is green at `8721439` — every suite, including integration.

## Also in this branch

Release prep for 0.19.1. The version moved in all six places that state it: `pubspec.yaml`, the changelog, the package README that pub.dev renders as the package page, the repo-root README, the installation guide, and the example app's lockfile. The podspecs stay at `0.0.1`, which is the plugin convention, and the "since 0.19.0" notes elsewhere describe when an older behaviour changed and are left alone.

Not published to pub.dev yet.
